### PR TITLE
resource/github_team: Add default team maintainer

### DIFF
--- a/github/resource_github_team.go
+++ b/github/resource_github_team.go
@@ -43,6 +43,11 @@ func resourceGithubTeam() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"create_default_maintainer": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"slug": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/github/resource_github_team.go
+++ b/github/resource_github_team.go
@@ -137,6 +137,7 @@ func resourceGithubTeamRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("ldap_dn", team.GetLDAPDN())
 	d.Set("slug", team.GetSlug())
+	d.Set("create_default_maintainer", d.Get("create_default_maintainer").(bool))
 
 	return nil
 }

--- a/github/resource_github_team_test.go
+++ b/github/resource_github_team_test.go
@@ -36,6 +36,7 @@ func TestAccGithubTeam_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr("github_team.foo", "parent_team_id"),
 					resource.TestCheckResourceAttr("github_team.foo", "ldap_dn", ""),
 					resource.TestCheckResourceAttr("github_team.foo", "slug", name),
+					resource.TestCheckResourceAttr("github_team.foo", "create_default_maintainer", "false"),
 				),
 			},
 			{
@@ -49,6 +50,7 @@ func TestAccGithubTeam_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr("github_team.foo", "parent_team_id"),
 					resource.TestCheckResourceAttr("github_team.foo", "ldap_dn", ""),
 					resource.TestCheckResourceAttr("github_team.foo", "slug", updatedName),
+					resource.TestCheckResourceAttr("github_team.foo", "create_default_maintainer", "false"),
 				),
 			},
 		},
@@ -211,6 +213,7 @@ resource "github_team" "foo" {
 	name = "%s"
 	description = "Terraform acc test group"
 	privacy = "secret"
+	create_default_maintainer = false
 }
 `, teamName)
 }


### PR DESCRIPTION
Fixes #130 

Still needs:
- Acceptance tests :heavy_check_mark: 
- Further testing of the provider plugin against more configs 
- Testing with org admins and org member tokens
  Org member token deletes team when removing github_team_membership. Org admin does not :x: 
- Check of github_team_membership resource