### PR TITLE
Allow renaming a GitHub repository by removing ForceNew on name

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -30,7 +30,6 @@ func resourceGithubRepository() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"description": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
This PR removes the `ForceNew` field for the `name` attribute in `resource/github_repository`, which enables renaming repositories via Terraform.

I have tested this change and it behaved as expected.