### PR TITLE
fix assets_url attribute typo

### DIFF
--- a/github/data_source_github_release.go
+++ b/github/data_source_github_release.go
@@ -82,6 +82,10 @@ func dataSourceGithubRelease() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"assets_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"upload_url": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -147,7 +151,8 @@ func dataSourceGithubReleaseRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("published_at", release.GetPublishedAt())
 	d.Set("url", release.GetURL())
 	d.Set("html_url", release.GetHTMLURL())
-	d.Set("asserts_url", release.GetAssetsURL())
+	d.Set("asserts_url", release.GetAssertsURL())
+	d.Set("assets_url", release.GetAssetsURL())
 	d.Set("upload_url", release.GetUploadURL())
 	d.Set("zipball_url", release.GetZipballURL())
 	d.Set("tarball_url", release.GetTarballURL())

--- a/vendor/github.com/google/go-github/v32/github/github-accessors.go
+++ b/vendor/github.com/google/go-github/v32/github/github-accessors.go
@@ -11980,16 +11980,6 @@ func (r *RepositoryPermissionLevel) GetUser() *User {
 	return r.User
 }
 
-// GetAssertsURL returns the AssetsURL field if it's non-nil, zero value otherwise. Created to generate a deprecation warning
-func (r *RepositoryRelease) GetAssertsURL() string {
-	// TODO: Add deprecation message
-	
-	if r == nil || r.AssetsURL == nil {
-		return ""
-	}
-	return *r.AssetsURL
-}
-
 // GetAssetsURL returns the AssetsURL field if it's non-nil, zero value otherwise.
 func (r *RepositoryRelease) GetAssetsURL() string {
 	if r == nil || r.AssetsURL == nil {

--- a/vendor/github.com/google/go-github/v32/github/github-accessors.go
+++ b/vendor/github.com/google/go-github/v32/github/github-accessors.go
@@ -11980,6 +11980,18 @@ func (r *RepositoryPermissionLevel) GetUser() *User {
 	return r.User
 }
 
+// GetAssertsURL returns the AssetsURL field if it's non-nil, zero value otherwise. Created to generate a deprecation warning
+func (r *RepositoryRelease) GetAssertsURL() string {
+	dataSource.DeprecationMessage = fmt.Sprintf(
+		"asserts_url is deprecated due to a typo in the name. Consider using assets_url instead",
+	)
+	
+	if r == nil || r.AssetsURL == nil {
+		return ""
+	}
+	return *r.AssetsURL
+}
+
 // GetAssetsURL returns the AssetsURL field if it's non-nil, zero value otherwise.
 func (r *RepositoryRelease) GetAssetsURL() string {
 	if r == nil || r.AssetsURL == nil {

--- a/vendor/github.com/google/go-github/v32/github/github-accessors.go
+++ b/vendor/github.com/google/go-github/v32/github/github-accessors.go
@@ -9,7 +9,6 @@ package github
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 )
 
@@ -11983,9 +11982,7 @@ func (r *RepositoryPermissionLevel) GetUser() *User {
 
 // GetAssertsURL returns the AssetsURL field if it's non-nil, zero value otherwise. Created to generate a deprecation warning
 func (r *RepositoryRelease) GetAssertsURL() string {
-	dataSource.DeprecationMessage = fmt.Sprintf(
-		"asserts_url is deprecated due to a typo in the name. Consider using assets_url instead",
-	)
+	// TODO: Add deprecation message
 	
 	if r == nil || r.AssetsURL == nil {
 		return ""

--- a/vendor/github.com/google/go-github/v32/github/github-accessors.go
+++ b/vendor/github.com/google/go-github/v32/github/github-accessors.go
@@ -9,6 +9,7 @@ package github
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 )
 

--- a/website/docs/d/release.html.markdown
+++ b/website/docs/d/release.html.markdown
@@ -68,7 +68,8 @@ data "github_release" "example" {
  * `published_at` - Date of release publishing
  * `url` - Base URL of the release
  * `html_url` - URL directing to detailed information on the release
- * `asserts_url` - URL of any associated assets with the release
+ * `asserts_url` - (deprecated) URL of any associated assets with the release
+ * `assets_url` - URL of any associated assets with the release
  * `upload_url` - URL that can be used to upload Assets to the release
  * `zipball_url` - Download URL of a specific release in `zip` format
  * `tarball_url` - Download URL of a specific release in `tar.gz` format


### PR DESCRIPTION
I noticed that the attribute `assets_url` was typod to be `asserts_url`. This PR is my attempt to fix that mistake without breaking anyone's existing Terraform code.

~~I'm not sure I've handled the deprecation message properly, but I'm happy to make any adjustments needed.~~

I definitely didn't do the deprecation message right and have removed it to allow the tests to pass. Any guidance on how to implement the deprecation message would be appreciated.