### PR TITLE
set license_template field

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -307,6 +307,7 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("has_projects", repo.GetHasProjects())
 	d.Set("has_wiki", repo.GetHasWiki())
 	d.Set("is_template", repo.GetIsTemplate())
+	d.Set("license_template", repo.GetLicense().GetKey())
 	d.Set("allow_merge_commit", repo.GetAllowMergeCommit())
 	d.Set("allow_squash_merge", repo.GetAllowSquashMerge())
 	d.Set("allow_rebase_merge", repo.GetAllowRebaseMerge())

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -353,7 +353,7 @@ func TestAccGithubRepository_templates(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"auto_init", "gitignore_template", "license_template",
+					"auto_init", "gitignore_template",
 				},
 			},
 		},
@@ -486,7 +486,7 @@ func TestAccGithubRepository_autoInitForceNew(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"auto_init", "license_template", "gitignore_template",
+					"auto_init", "gitignore_template",
 				},
 			},
 		},


### PR DESCRIPTION
Changes:
* set `license_template` attribute w/go-github's `GetLicense()` method

Closes #306 

Output of Acceptance tests:
```
--- PASS: TestAccGithubRepository_hasProjects (6.69s)
--- PASS: TestAccGithubRepository_archive (9.07s)
--- PASS: TestAccGithubRepository_templates (10.05s)
--- PASS: TestAccGithubRepository_createFromTemplate (13.06s)
--- PASS: TestAccGithubRepository_defaultBranch (13.14s)
--- PASS: TestAccGithubRepository_archiveUpdate (14.90s)
--- PASS: TestAccGithubRepository_basic (16.28s)
--- PASS: TestAccGithubRepository_autoInitForceNew (19.54s)
--- PASS: TestAccGithubRepository_topics (24.66s)
```