### PR TITLE
support init repo from fork 

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -438,8 +438,7 @@ func resourceGithubRepositoryDelete(d *schema.ResourceData, meta interface{}) er
 		repoName = parsedID[1]
 	}
 
-	log.Printf(
-		"[DEBUG] Deleting repository: %s/%s", owner, repoName)
+	log.Printf("[DEBUG] Deleting repository: %s/%s", owner, repoName)
 	_, err = client.Repositories.Delete(ctx, owner, repoName)
 
 	return err

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -282,7 +282,7 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 			d.SetId(*repo.Name)
 		}
 	}
-	
+
 	topics := expandStringList(d.Get("topics").(*schema.Set).List())
 	if len(topics) > 0 {
 		_, _, err = client.Repositories.ReplaceAllTopics(ctx, orgName, repoName, topics)

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -1049,12 +1049,12 @@ resource "github_repository" "foo" {
   description  = "Terraform acceptance tests %s"
   homepage_url = "http://example.com/"
 
-	template {
-		owner = "%s"
-		repository = "%s"
-	}
+  template {
+    owner      = "%s"
+    repository = "%s"
+  }
 
-	# So that acceptance tests can be run in a github organization
+  # So that acceptance tests can be run in a github organization
   # with no billing
   private = false
 
@@ -1072,21 +1072,21 @@ resource "github_repository" "foo" {
 func testAccGithubRepositoryCreateFromForkForUser(name, description, homepage string) string {
 	return fmt.Sprintf(`
 resource "github_repository" "test" {
-	name = "tf-acc-test-%s"
-    description = "%s"
-    homepage_url = "%s"
+  name         = "tf-acc-test-%s"
+  description  = "%s"
+  homepage_url = "%s"
 
 
-	private = false
-    has_issues           = true
-    has_wiki             = true
-    is_template          = false
+  private     = false
+  has_issues  = true
+  has_wiki    = true
+  is_template = false
 
-    allow_merge_commit   = true
-    allow_squash_merge   = false
-    allow_rebase_merge   = false
-    has_downloads        = true
-    auto_init            = true
+  allow_merge_commit = true
+  allow_squash_merge = false
+  allow_rebase_merge = false
+  has_downloads      = true
+  auto_init          = true
 
 }
 
@@ -1099,11 +1099,11 @@ resource "github_repository" "foo" {
   has_wiki             = github_repository.test.has_wiki
   is_template          = github_repository.test.is_template
 
-  allow_merge_commit   = github_repository.test.allow_merge_commit
-  allow_squash_merge   = github_repository.test.allow_squash_merge
-  allow_rebase_merge   = github_repository.test.allow_rebase_merge
-  has_downloads        = github_repository.test.has_downloads
-  auto_init            = github_repository.test.auto_init
+  allow_merge_commit = github_repository.test.allow_merge_commit
+  allow_squash_merge = github_repository.test.allow_squash_merge
+  allow_rebase_merge = github_repository.test.allow_rebase_merge
+  has_downloads      = github_repository.test.has_downloads
+  auto_init          = github_repository.test.auto_init
 
 }
 `, name, description, homepage)
@@ -1112,7 +1112,7 @@ resource "github_repository" "foo" {
 func testAccGithubRepositoryCreateFromForkForOrg() string {
 	return fmt.Sprintf(`
 data "github_repositories" "test" {
-	query = "repo:google/go-github"
+  query = "repo:google/go-github"
 }
 
 resource "github_repository" "foo" {
@@ -1126,7 +1126,7 @@ resource "github_repository" "foo" {
 func testAccGithubRepositoryCreateFromForkForOrgUpdate(description, homepage string) string {
 	return fmt.Sprintf(`
 data "github_repositories" "test" {
-	query = "repo:google/go-github"
+  query = "repo:google/go-github"
 }
 
 resource "github_repository" "foo" {

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -78,7 +78,7 @@ initial repository creation and create the target branch inside of the repositor
 
 * `template` - (Optional) Use a template repository to create this resource. See [Template Repositories](#template-repositories) below for details.
 
-* `fork_from_repository` - (Optional) The repository to fork from in the format `OWNER/RESPOSITORY` e.g. "terraform-providers/terraform-provider-github"
+* `fork_from_repository` - (Optional) The repository to fork from in the format `OWNER/REPOSITORY` e.g. "terraform-providers/terraform-provider-github"
 
 * `fork_into_organization` - (Optional) The Github organization to set as the owner if forked from another repository. By default, the repository will live within the authenticated user's account.  
 

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -78,6 +78,10 @@ initial repository creation and create the target branch inside of the repositor
 
 * `template` - (Optional) Use a template repository to create this resource. See [Template Repositories](#template-repositories) below for details.
 
+* `fork_from_repository` - (Optional) The repository to fork from in the format `OWNER/RESPOSITORY` e.g. "terraform-providers/terraform-provider-github"
+
+* `fork_into_organization` - (Optional) The Github organization to set as the owner if forked from another repository. By default, the repository will live within the authenticated user's account.  
+
 ### Template Repositories
 
 `template` supports the following arguments:


### PR DESCRIPTION
Closes #43 

* Changes:
  * support forking as an additional method of creating a new repo with `fork_from_repository` and `fork_into_organization` optional attributes
  * `fork_from_repository`: to be provided in the format `OWNER/REPOSITORY`
  * `fork_into_organization`: to be provided if user wants to override default behavior of creating the new forked repo in the authenticated user's account

Output of acceptance tests:
```
--- PASS: TestAccGithubRepository_createFromForkForOrg (10.23s)
--- PASS: TestAccGithubRepository_createFromForkForUser (18.39s)
```