### PR TITLE
Add allow_force_pushes, allow_deletions and require_linear_history

### DIFF
--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -354,15 +354,11 @@ func resourceGithubBranchProtectionDelete(d *schema.ResourceData, meta interface
 }
 
 func buildProtectionRequest(d *schema.ResourceData) (*github.ProtectionRequest, error) {
-	requireLinearHistory := d.Get("require_linear_history").(bool)
-	allowForcePushes := d.Get("allow_force_pushes").(bool)
-	allowDeletions := d.Get("allow_deletions").(bool)
-
 	req := &github.ProtectionRequest{
 		EnforceAdmins:        d.Get("enforce_admins").(bool),
-		RequireLinearHistory: &requireLinearHistory,
-		AllowForcePushes:     &allowForcePushes,
-		AllowDeletions:       &allowDeletions,
+		RequireLinearHistory: github.Bool(d.Get("require_linear_history").(bool)),
+		AllowForcePushes:     github.Bool(d.Get("allow_force_pushes").(bool)),
+		AllowDeletions:       github.Bool(d.Get("allow_deletions").(bool)),
 	}
 
 	rsc, err := expandRequiredStatusChecks(d)

--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -145,6 +145,21 @@ func resourceGithubBranchProtection() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"allow_force_pushes": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"allow_deletions": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"require_linear_history": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -238,6 +253,9 @@ func resourceGithubBranchProtectionRead(d *schema.ResourceData, meta interface{}
 	d.Set("repository", repoName)
 	d.Set("branch", branch)
 	d.Set("enforce_admins", githubProtection.GetEnforceAdmins().Enabled)
+	d.Set("require_linear_history", githubProtection.GetRequireLinearHistory().Enabled)
+	d.Set("allow_force_pushes", githubProtection.GetAllowForcePushes().Enabled)
+	d.Set("allow_deletions", githubProtection.GetAllowDeletions().Enabled)
 
 	if err := flattenAndSetRequiredStatusChecks(d, githubProtection); err != nil {
 		return fmt.Errorf("Error setting required_status_checks: %v", err)
@@ -336,8 +354,15 @@ func resourceGithubBranchProtectionDelete(d *schema.ResourceData, meta interface
 }
 
 func buildProtectionRequest(d *schema.ResourceData) (*github.ProtectionRequest, error) {
+	requireLinearHistory := d.Get("require_linear_history").(bool)
+	allowForcePushes := d.Get("allow_force_pushes").(bool)
+	allowDeletions := d.Get("allow_deletions").(bool)
+
 	req := &github.ProtectionRequest{
-		EnforceAdmins: d.Get("enforce_admins").(bool),
+		EnforceAdmins:        d.Get("enforce_admins").(bool),
+		RequireLinearHistory: &requireLinearHistory,
+		AllowForcePushes:     &allowForcePushes,
+		AllowDeletions:       &allowDeletions,
 	}
 
 	rsc, err := expandRequiredStatusChecks(d)

--- a/github/resource_github_branch_protection_test.go
+++ b/github/resource_github_branch_protection_test.go
@@ -54,6 +54,7 @@ func TestAccGithubBranchProtection_basic(t *testing.T) {
 					testAccCheckGithubBranchProtectionNoPullRequestReviewsExist(&protection),
 					resource.TestCheckResourceAttr(rn, "repository", repoName),
 					resource.TestCheckResourceAttr(rn, "branch", "master"),
+					resource.TestCheckResourceAttr(rn, "required_status_checks.0.strict", "false"),
 					resource.TestCheckResourceAttr(rn, "required_status_checks.0.contexts.#", "1"),
 					resource.TestCheckResourceAttr(rn, "required_pull_request_reviews.#", "0"),
 					resource.TestCheckResourceAttr(rn, "restrictions.#", "0"),

--- a/github/resource_github_branch_protection_test.go
+++ b/github/resource_github_branch_protection_test.go
@@ -36,6 +36,9 @@ func TestAccGithubBranchProtection_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rn, "repository", repoName),
 					resource.TestCheckResourceAttr(rn, "branch", "master"),
 					resource.TestCheckResourceAttr(rn, "enforce_admins", "true"),
+					resource.TestCheckResourceAttr(rn, "allow_force_pushes", "true"),
+					resource.TestCheckResourceAttr(rn, "allow_deletions", "true"),
+					resource.TestCheckResourceAttr(rn, "require_linear_history", "true"),
 					resource.TestCheckResourceAttr(rn, "require_signed_commits", "true"),
 					resource.TestCheckResourceAttr(rn, "required_status_checks.0.strict", "true"),
 					resource.TestCheckResourceAttr(rn, "required_status_checks.0.contexts.#", "1"),
@@ -56,6 +59,9 @@ func TestAccGithubBranchProtection_basic(t *testing.T) {
 					testAccCheckGithubBranchProtectionNoPullRequestReviewsExist(&protection),
 					resource.TestCheckResourceAttr(rn, "repository", repoName),
 					resource.TestCheckResourceAttr(rn, "branch", "master"),
+					resource.TestCheckResourceAttr(rn, "allow_force_pushes", "false"),
+					resource.TestCheckResourceAttr(rn, "allow_deletions", "false"),
+					resource.TestCheckResourceAttr(rn, "require_linear_history", "false"),
 					resource.TestCheckResourceAttr(rn, "require_signed_commits", "false"),
 					resource.TestCheckResourceAttr(rn, "required_status_checks.0.strict", "false"),
 					resource.TestCheckResourceAttr(rn, "required_status_checks.0.contexts.#", "1"),
@@ -427,9 +433,12 @@ resource "github_repository" "test" {
 }
 
 resource "github_branch_protection" "master" {
-  repository     = "${github_repository.test.name}"
-  branch         = "master"
-  enforce_admins = true
+  repository             = "${github_repository.test.name}"
+  branch                 = "master"
+  enforce_admins         = true
+  allow_force_pushes     = true
+  allow_deletions        = true
+  require_linear_history = true
   require_signed_commits = true
 
   required_status_checks {

--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -18,9 +18,12 @@ This resource allows you to configure branch protection for repositories in your
 # the "ci/travis" context to be passing and only allow the engineers team merge
 # to the branch.
 resource "github_branch_protection" "example" {
-  repository     = "${github_repository.example.name}"
-  branch         = "master"
-  enforce_admins = true
+  repository             = "${github_repository.example.name}"
+  branch                 = "master"
+  enforce_admins         = true
+  allow_force_pushes     = true
+  allow_deletions        = true
+  require_linear_history = true
 
   required_status_checks {
     strict   = false
@@ -58,6 +61,9 @@ The following arguments are supported:
 * `repository` - (Required) The GitHub repository name.
 * `branch` - (Required) The Git branch to protect.
 * `enforce_admins` - (Optional) Boolean, setting this to `true` enforces status checks for repository administrators.
+* `allow_force_pushes` - (Optional) Boolean, setting this to `true` permits everyone with write access to the protected branch to force pushes. Defaults to `false`.
+* `allow_deletions` - (Optional) Boolean, setting this to `true` permits everyone with write access to the protected branch to delete the branch. Defaults to `false`.
+* `require_linear_history` - (Optional) Boolean, setting this to `true` enforces a linear commit Git history, preventing anyone from pushing merge commits to the branch. Defaults to `false`.
 * `require_signed_commits` - (Optional) Boolean, setting this to `true` requires all commits to be signed with GPG.
 * `required_status_checks` - (Optional) Enforce restrictions for required status checks. See [Required Status Checks](#required-status-checks) below for details.
 * `required_pull_request_reviews` - (Optional) Enforce restrictions for pull request reviews. See [Required Pull Request Reviews](#required-pull-request-reviews) below for details.


### PR DESCRIPTION
Closes #305.

There is an inconsistency in the naming of the `require_linear_history` property. The [documentation](https://developer.github.com/v3/repos/branches/#update-branch-protection) writes it as `required_linear_history` (require**d**). The Go GitHub Client defines it as *require*. I actually think *require* makes more sense as its a boolean value and not a list of required values. I'm also fine with changing it though, so let me know.

Output of acceptance tests:

```
=== RUN   TestAccGithubBranchProtection_basic
=== PAUSE TestAccGithubBranchProtection_basic
=== CONT  TestAccGithubBranchProtection_basic
--- PASS: TestAccGithubBranchProtection_basic (22.06s)
PASS
ok  	github.com/terraform-providers/terraform-provider-github/github	22.083s
```