### PR TITLE
Add "web" and "api" IP blocks published by GitHub

### DIFF
--- a/github/data_source_github_ip_ranges.go
+++ b/github/data_source_github_ip_ranges.go
@@ -14,6 +14,16 @@ func dataSourceGithubIpRanges() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"web": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"api": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"git": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -41,11 +51,17 @@ func dataSourceGithubIpRangesRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	if len(api.Hooks)+len(api.Git)+len(api.Pages)+len(api.Importer) > 0 {
+	if len(api.Hooks)+len(api.Web)+len(api.Api)+len(api.Git)+len(api.Pages)+len(api.Importer) > 0 {
 		d.SetId("github-ip-ranges")
 	}
 	if len(api.Hooks) > 0 {
 		d.Set("hooks", api.Hooks)
+	}
+	if len(api.Web) > 0 {
+		d.Set("web", api.Web)
+	}
+	if len(api.Api) > 0 {
+		d.Set("api", api.Api)
 	}
 	if len(api.Git) > 0 {
 		d.Set("git", api.Git)

--- a/github/data_source_github_ip_ranges_test.go
+++ b/github/data_source_github_ip_ranges_test.go
@@ -19,6 +19,8 @@ func TestAccGithubIpRangesDataSource_existing(t *testing.T) {
 				`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "hooks.#"),
+					resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "web.#"),
+					resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "api.#"),
 					resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "git.#"),
 					resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "pages.#"),
 					resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "importer.#"),

--- a/vendor/github.com/google/go-github/v31/github/misc.go
+++ b/vendor/github.com/google/go-github/v31/github/misc.go
@@ -144,6 +144,14 @@ type APIMeta struct {
 	// that incoming service hooks will originate from on GitHub.com.
 	Hooks []string `json:"hooks,omitempty"`
 
+	// An Array of IP addresses in CIDR format specifying the addresses
+	// of GitHub.com web servers.
+	Web []string `json:"web,omitempty"`
+
+	// An Array of IP addresses in CIDR format specifying the addresses
+	// of GitHub.com API servers.
+	Api []string `json:"api,omitempty"`
+
 	// An Array of IP addresses in CIDR format specifying the Git servers
 	// for GitHub.com.
 	Git []string `json:"git,omitempty"`

--- a/website/docs/d/ip_ranges.html.markdown
+++ b/website/docs/d/ip_ranges.html.markdown
@@ -18,6 +18,8 @@ data "github_ip_ranges" "test" {}
 ## Attributes Reference
 
  * `hooks` - An Array of IP addresses in CIDR format specifying the addresses that incoming service hooks will originate from.
+ * `web` - An Array of IP addresses in CIDR format specifying the Web servers.
+ * `api` - An Array of IP addresses in CIDR format specifying the API servers.
  * `git` - An Array of IP addresses in CIDR format specifying the Git servers.
  * `pages` - An Array of IP addresses in CIDR format specifying the A records for GitHub Pages.
  * `importer` - An Array of IP addresses in CIDR format specifying the A records for GitHub Importer.


### PR DESCRIPTION
For some reason the "web" and "api" blocks published at https://api.github.com/meta are missing from the github_ip_ranges data source, this intends to remedy that. I'm not sure why they aren't included in the first place.

Also... I don't code in GoLang and lack the tooling as well as the ability to test this locally, but it seemed easy enough to add the bits of code needed for this PR. Which is to say, I hope this looks OK and I didn't miss anything.