### PR TITLE
resource/repository_file: ignore commit-related fields during acctest import step

### DIFF
--- a/github/resource_github_repository_file_test.go
+++ b/github/resource_github_repository_file_test.go
@@ -143,6 +143,9 @@ func TestAccGithubRepositoryFile_basic(t *testing.T) {
 				ResourceName:      rn,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"commit_author", "commit_email", "commit_message",
+				},
 			},
 		},
 	})
@@ -222,6 +225,9 @@ func TestAccGithubRepositoryFile_branch(t *testing.T) {
 				ImportState:       true,
 				ImportStateId:     fmt.Sprintf("test-repo/%s:test-branch", path),
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"commit_author", "commit_email", "commit_message",
+				},
 			},
 		},
 	})
@@ -292,6 +298,9 @@ func TestAccGithubRepositoryFile_committer(t *testing.T) {
 				ResourceName:      rn,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"commit_author", "commit_email", "commit_message",
+				},
 			},
 		},
 	})


### PR DESCRIPTION
Addresses test failures since commit info is no longer set in `Read` per #466:
```
--- FAIL: TestAccGithubRepositoryFile_basic (15.20s)
    testing.go:654: Step 2 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
        
        (map[string]string) {
        }
        
        
        (map[string]string) (len=3) {
         (string) (len=13) "commit_author": (string) (len=9) "Test User",
         (string) (len=12) "commit_email": (string) (len=60) "60107403+github-terraform-test-user@users.noreply.github.com",
         (string) (len=14) "commit_message": (string) (len=34) "Update tf-acc-test-file-7r6ww6pfrt"
        }
```
```
--- FAIL: TestAccGithubRepositoryFile_branch (12.28s)
    testing.go:654: Step 2 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
        
        (map[string]string) {
        }
        
        
        (map[string]string) (len=3) {
         (string) (len=13) "commit_author": (string) (len=9) "Test User",
         (string) (len=12) "commit_email": (string) (len=60) "60107403+github-terraform-test-user@users.noreply.github.com",
         (string) (len=14) "commit_message": (string) (len=34) "Update tf-acc-test-file-u2iquispnf"
        }
```
```
--- FAIL: TestAccGithubRepositoryFile_committer (15.33s)
    testing.go:654: Step 2 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
        
        (map[string]string) {
        }
        
        
        (map[string]string) (len=3) {
         (string) (len=13) "commit_author": (string) (len=14) "Terraform User",
         (string) (len=12) "commit_email": (string) (len=21) "terraform@example.com",
         (string) (len=14) "commit_message": (string) (len=20) "Managed by Terraform"
        }
```