### PR TITLE
docs: typo in argument reference for repository

### DIFF
--- a/website/docs/r/repository_file.html.markdown
+++ b/website/docs/r/repository_file.html.markdown
@@ -26,7 +26,7 @@ resource "github_repository_file" "gitignore" {
 
 The following arguments are supported:
 
-* `repo` - (Required) The repository to create the file in.
+* `repository` - (Required) The repository to create the file in.
 
 * `file` - (Required) The path of the file to manage.
 


### PR DESCRIPTION
Documentation for the arguments does not match what is actually required, thus I am updating the `repo` argument to its correct form, `repository`.