### PR TITLE
Keep visibility setting on repository creation

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -223,11 +223,6 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 	repoReq := resourceGithubRepositoryObject(d)
 	owner := meta.(*Owner).name
 
-	// Auth issues (403 You need admin access to the organization before adding a repository to it.)
-	// are encountered when the resources is created with the visibility parameter. As
-	// resourceGithubRepositoryUpdate is called immediately after, this is subsequently corrected.
-	repoReq.Visibility = nil
-
 	repoName := repoReq.GetName()
 	ctx := context.Background()
 


### PR DESCRIPTION
This fixes #580 

As stated in the issue the statement in the comment is incorrect as you do not need to be an owner to create a repository in an organization but you need to be an owner to change the visibility of an already existing repository. Hence the update is failing.

Happy to get any feedback on this.