### PR TITLE
Allow dependabot to check go dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This change allows dependabot to check any go dependencies which this project uses and submit PRs with version bumps in order to keep packages up-to-date on a weekly basis.

https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates

I believe this would be in lieu of renovate. It seems like the renovate configs already handle go package upgrades.