### PR TITLE
Fix error handling

### DIFF
--- a/github/config.go
+++ b/github/config.go
@@ -115,6 +115,8 @@ func (c *Config) ConfigureOwner(owner *Owner) (*Owner, error) {
 				owner.id = remoteOrg.GetID()
 				owner.IsOrganization = true
 			}
+		} else {
+			return nil, err
 		}
 	}
 
@@ -210,6 +212,8 @@ func (c *Config) Clients() (interface{}, error) {
 				owner.id = remoteOrg.GetID()
 				owner.IsOrganization = true
 			}
+		} else {
+			return nil, err
 		}
 	}
 	return &owner, nil


### PR DESCRIPTION
Do not silently proceed further on receiving an error response.

I had a typo in my GHE url, and it would always show me:
```
Error: This resource can only be used in the context of an organization, "my-org-name" is a user.
```
instead of the actual error that it could not resolve the host (because of my typo).