### PR TITLE
visibility should be set on create and removed on update

### DIFF
--- a/examples/repo_org_internal/README.md
+++ b/examples/repo_org_internal/README.md
@@ -1,0 +1,18 @@
+# Repository Visibility with Org, type internal
+
+This demos various repository [visibility settings](https://help.github.com/en/github/administering-a-repository/setting-repository-visibility) for repositories.
+
+This example will create a repositories in the specified `owner` organization. See https://www.terraform.io/docs/providers/github/index.html for details on configuring [`providers.tf`](./providers.tf) accordingly.
+
+Alternatively, you may use variables passed via command line:
+
+```console
+export GITHUB_OWNER=
+export GITHUB_TOKEN=
+```
+
+```console
+terraform apply \
+  -var "owner=${GITHUB_OWNER}" \
+  -var "github_token=${GITHUB_TOKEN}"
+```

--- a/examples/repo_org_internal/cli.cfg
+++ b/examples/repo_org_internal/cli.cfg
@@ -1,0 +1,10 @@
+provider_installation {
+  filesystem_mirror {
+    path    = "/Users/jurgen.weber/checkouts/terraform/terraform-provider-github/examples/repo_org_internal/terraform.d/plugins"
+    include = ["*/*/*"]
+  }
+  direct {
+    exclude = ["*/*/*"]
+  }
+}
+

--- a/examples/repo_org_internal/main.tf
+++ b/examples/repo_org_internal/main.tf
@@ -1,0 +1,5 @@
+resource github_repository internal {
+  name        = "mtribes-jurgen"
+  description = "A internal-visible repository created by Terraform"
+  visibility  = "internal"
+}

--- a/examples/repo_org_internal/outputs.tf
+++ b/examples/repo_org_internal/outputs.tf
@@ -1,0 +1,4 @@
+output internal_repository {
+  description = "Example repository JSON blob"
+  value       = github_repository.internal
+}

--- a/examples/repo_org_internal/providers.tf
+++ b/examples/repo_org_internal/providers.tf
@@ -1,0 +1,4 @@
+provider github {
+  owner = var.owner
+  token = var.github_token
+}

--- a/examples/repo_org_internal/variables.tf
+++ b/examples/repo_org_internal/variables.tf
@@ -1,0 +1,9 @@
+variable owner {
+  description = "GitHub owner used to configure the provider"
+  type        = string
+}
+
+variable github_token {
+  description = "GitHub access token used to configure the provider"
+  type        = string
+}

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -271,11 +271,6 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 	repoReq := resourceGithubRepositoryObject(d)
 	owner := meta.(*Owner).name
 
-	// Auth issues (403 You need admin access to the organization before adding a repository to it.)
-	// are encountered when the resources is created with the visibility parameter. As
-	// resourceGithubRepositoryUpdate is called immediately after, this is subsequently corrected.
-	repoReq.Visibility = nil
-
 	repoName := repoReq.GetName()
 	ctx := context.Background()
 
@@ -462,10 +457,9 @@ func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 
 	repoReq := resourceGithubRepositoryObject(d)
 
+	// The visibility of a repo can not be changed once created
 	// The endpoint will throw an error if trying to PATCH with a visibility value that is the same
-	if !d.HasChange("visibility") {
-		repoReq.Visibility = nil
-	}
+	repoReq.Visibility = nil
 
 	// Can only set `default_branch` on an already created repository with the target branches ref already in-place
 	if v, ok := d.GetOk("default_branch"); ok {

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -457,9 +457,17 @@ func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 
 	repoReq := resourceGithubRepositoryObject(d)
 
-	// The visibility of a repo can not be changed once created
-	// The endpoint will throw an error if trying to PATCH with a visibility value that is the same
-	repoReq.Visibility = nil
+	if d.HasChange("visibility") {
+		// The endpoint will throw an error if this repo is being created and the old value is ""
+		o, n := d.GetChange("visibility")
+		log.Printf("[DEBUG] Old Value %v New Value %v", o, n)
+		if o.(string) == "" {
+			repoReq.Visibility = nil
+		}
+	} else {
+		// The endpoint will throw an error if trying to PATCH with a visibility value that is the same
+		repoReq.Visibility = nil
+	}
 
 	// Can only set `default_branch` on an already created repository with the target branches ref already in-place
 	if v, ok := d.GetOk("default_branch"); ok {


### PR DESCRIPTION
https://github.com/integrations/terraform-provider-github/issues/662

You can find a lot of my journey in the above ticket and with the help of some at [google/go-github](https://github.com/google/go-github/pull/1786) and github support I have found my problem.

Having the visibility removed on create, meant I could not create internal repos (when I do not have permissions to create public repos in my org) and the comment I removed 

```
        // Auth issues (403 You need admin access to the organization before adding a repository to it.)
        // are encountered when the resources is created with the visibility parameter. As
        // resourceGithubRepositoryUpdate is called immediately after, this is subsequently corrected.
```

is the exact issue and problem I was facing, but this is suggesting that it should solve it. Since you can not update the visibility of a repo (edit: I later learned that this is not true, you can edit the visibility of repos), leaving it to update will always error also, as per the other comment:

```
// The endpoint will throw an error if trying to PATCH with a visibility value that is the same
```

this patch will always fail, so it should never run.

this PR solves this repo create problem, by ensuring that Visibility is set on create and never updates.

I also added in the example/demo I was using to test my provider locally.

Thanks

Note; If there are circumstances in which a repo can change its visibility do we know what they all are and we can update this accordingly.