### PR TITLE
github/config: Fix detection of individual, non-org accounts

### DIFF
--- a/github/config.go
+++ b/github/config.go
@@ -115,8 +115,6 @@ func (c *Config) ConfigureOwner(owner *Owner) (*Owner, error) {
 				owner.id = remoteOrg.GetID()
 				owner.IsOrganization = true
 			}
-		} else {
-			return nil, err
 		}
 	}
 


### PR DESCRIPTION
- Previously, whenever an individual user tried to interact with their repos, the provider would return an error, rendering v4.3.1 unusable:

  ```
  ➜ terraform plan
  Error: GET https://api.github.com/orgs/issyl0: 404 Not Found []
  on /Users/issyl0/repos/terraform/github.tf line 1, in provider "github":
  ```

- Reproduction steps and a log of manual tests I did: https://gist.github.com/issyl0/cd61e4cb59de2c2e1e8f45e3cf7c12f5.

- `ConfigureOwner` works such that if the `owner.name` is not blank (ie, the user had specified `owner = <username>` in their Terraform file), the code progresses to check if the `owner.name` is an org. Importantly, that check (prior to this change) returned an error if `owner.name` was not an org. That final error meant it was impossible to run if not using an organisation account.

----

- This is a partial revert of #668. Interestingly, `github/config_test.go` didn't fail at all before (and I couldn't figure out how to make a better test). Reverting it all also fixed the problem, but the `ConfigureOwner` method appeared to do the right thing for me on its own. **I also don't have an org account to test this against to confirm regression of the issue that PR was fixing.**

- Fixes #678.

----

- As I was preparing to spend part of my Saturday using this provider to configure my personal account repos with consistent settings, I noticed it was broken so I thought I'd have a go at figuring out how! This is only my second Terraform provider change ever, so if things could be better, I'd appreciate some pointers for improvements! As always, thanks for building this provider!