### PR TITLE
Modify github_team_repository to accept slug as a valid team_id as well

### DIFF
--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -22,10 +22,10 @@ func resourceGithubTeamRepository() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"team_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				Description:  "ID or slug of team",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "ID or slug of team",
 			},
 			"repository": {
 				Type:     schema.TypeString,
@@ -58,6 +58,9 @@ func resourceGithubTeamRepositoryCreate(d *schema.ResourceData, meta interface{}
 	// The given team id could be an id or a slug
 	givenTeamId := d.Get("team_id").(string)
 	teamId, err := getTeamID(givenTeamId, meta)
+	if err != nil {
+		return err
+	}
 
 	orgName := meta.(*Owner).name
 	repoName := d.Get("repository").(string)

--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -126,7 +126,11 @@ func resourceGithubTeamRepositoryRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.Set("etag", resp.Header.Get("ETag"))
-	d.Set("team_id", teamIdString)
+	if d.Get("team_id") == "" {
+		// If team_id is empty, that means we are importing the resource.
+		// Set the team_id to be the id of the team.
+		d.Set("team_id", teamIdString)
+	}
 	d.Set("repository", repo.GetName())
 
 	permName, permErr := getRepoPermission(repo.GetPermissions())

--- a/github/resource_github_team_repository_test.go
+++ b/github/resource_github_team_repository_test.go
@@ -1,227 +1,173 @@
 package github
 
 import (
-	"context"
 	"fmt"
-	"strconv"
+	"strings"
 	"testing"
 
-	"github.com/google/go-github/v32/github"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccGithubTeamRepository_basic(t *testing.T) {
-	if err := testAccCheckOrganization(); err != nil {
-		t.Skipf("Skipping because %s.", err.Error())
-	}
+func TestAccGithubTeamRepository(t *testing.T) {
 
-	var repository github.Repository
+	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
-	rn := "github_team_repository.test_team_test_repo"
-	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	repoName := fmt.Sprintf("tf-acc-test-team-%s", acctest.RandString(5))
+	t.Run("manages team permissions to a repository", func(t *testing.T) {
 
-	testCase := func(t *testing.T, teamIdentifier string) {
-		resource.ParallelTest(t, resource.TestCase{
-			PreCheck:     func() { testAccPreCheck(t) },
-			Providers:    testAccProviders,
-			CheckDestroy: testAccCheckGithubTeamRepositoryDestroy,
-			Steps: []resource.TestStep{
-				{
-					Config: testAccGithubTeamRepositoryConfig(randString, repoName, teamIdentifier),
-					Check: resource.ComposeTestCheckFunc(
-						testAccCheckGithubTeamRepositoryExists(rn, &repository),
-						testAccCheckGithubTeamRepositoryRoleState("pull", &repository),
-					),
-				},
-				{
-					Config: testAccGithubTeamRepositoryUpdateConfig(randString, repoName, teamIdentifier),
-					Check: resource.ComposeTestCheckFunc(
-						testAccCheckGithubTeamRepositoryExists(rn, &repository),
-						testAccCheckGithubTeamRepositoryRoleState("push", &repository),
-					),
-				},
-				{
-					ResourceName:      rn,
-					ImportState:       true,
-					ImportStateVerify: true,
-				},
-			},
-		})
-	}
-
-	t.Run("with a team id identifier", func(t *testing.T) {
-		testCase(t, "id")
-	})
-
-	t.Run("with a team slug identifier", func(t *testing.T) {
-		testCase(t, "slug")
-	})
-}
-
-func TestAccCheckGetPermissions(t *testing.T) {
-	pullMap := map[string]bool{"pull": true, "triage": false, "push": false, "maintain": false, "admin": false}
-	triageMap := map[string]bool{"pull": false, "triage": true, "push": false, "maintain": false, "admin": false}
-	pushMap := map[string]bool{"pull": true, "triage": false, "push": true, "maintain": false, "admin": false}
-	maintainMap := map[string]bool{"pull": false, "triage": false, "push": false, "maintain": true, "admin": false}
-	adminMap := map[string]bool{"pull": true, "triage": false, "push": true, "maintain": false, "admin": true}
-	errorMap := map[string]bool{"pull": false, "triage": false, "push": false, "maintain": false, "admin": false}
-
-	pull, _ := getRepoPermission(pullMap)
-	if pull != "pull" {
-		t.Fatalf("Expected pull permission, actual: %s", pull)
-	}
-
-	triage, _ := getRepoPermission(triageMap)
-	if triage != "triage" {
-		t.Fatalf("Expected triage permission, actual: %s", triage)
-	}
-
-	push, _ := getRepoPermission(pushMap)
-	if push != "push" {
-		t.Fatalf("Expected push permission, actual: %s", push)
-	}
-
-	maintain, _ := getRepoPermission(maintainMap)
-	if maintain != "maintain" {
-		t.Fatalf("Expected maintain permission, actual: %s", maintain)
-	}
-
-	admin, _ := getRepoPermission(adminMap)
-	if admin != "admin" {
-		t.Fatalf("Expected admin permission, actual: %s", admin)
-	}
-
-	errPerm, err := getRepoPermission(errorMap)
-	if err == nil {
-		t.Fatalf("Expected an error getting permissions, actual: %v", errPerm)
-	}
-}
-
-func testAccCheckGithubTeamRepositoryRoleState(role string, repository *github.Repository) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		resourceRole, err := getRepoPermission(repository.GetPermissions())
-		if err != nil {
-			return err
-		}
-
-		if resourceRole != role {
-			return fmt.Errorf("Team repository role %v in resource does match expected state of %v", resourceRole, role)
-		}
-		return nil
-	}
-}
-
-func testAccCheckGithubTeamRepositoryExists(n string, repository *github.Repository) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not Found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No team repository ID is set")
-		}
-
-		conn := testAccProvider.Meta().(*Owner).v3client
-
-		teamIdString, repoName, err := parseTwoPartID(rs.Primary.ID, "team_id", "repository")
-		if err != nil {
-			return err
-		}
-		teamId, err := strconv.ParseInt(teamIdString, 10, 64)
-		if err != nil {
-			return unconvertibleIdErr(teamIdString, err)
-		}
-
-		repo, _, err := conn.Teams.IsTeamRepoByID(context.TODO(),
-			testAccProvider.Meta().(*Owner).id,
-			teamId,
-			testAccProvider.Meta().(*Owner).name,
-			repoName)
-
-		if err != nil {
-			return err
-		}
-		*repository = *repo
-		return nil
-	}
-}
-
-func testAccCheckGithubTeamRepositoryDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Owner).v3client
-	orgId := testAccProvider.Meta().(*Owner).id
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "github_team_repository" {
-			continue
-		}
-
-		teamIdString, repoName, err := parseTwoPartID(rs.Primary.ID, "team_id", "repository")
-		if err != nil {
-			return err
-		}
-		teamId, err := strconv.ParseInt(teamIdString, 10, 64)
-		if err != nil {
-			return unconvertibleIdErr(teamIdString, err)
-		}
-
-		repo, resp, err := conn.Teams.IsTeamRepoByID(context.TODO(),
-			orgId,
-			teamId,
-			testAccProvider.Meta().(*Owner).name,
-			repoName)
-
-		if err == nil {
-			if repo != nil &&
-				buildTwoPartID(teamIdString, repo.GetName()) == rs.Primary.ID {
-				return fmt.Errorf("Team repository still exists")
+		config := fmt.Sprintf(`
+			resource "github_team" "test" {
+				name        = "tf-acc-test-team-repo-%s"
+				description = "test"
 			}
+
+			resource "github_repository" "test" {
+				name = "tf-acc-test-%[1]s"
+			}
+
+			resource "github_team_repository" "test" {
+				team_id    = "${github_team.test.id}"
+				repository = "${github_repository.test.name}"
+				permission = "pull"
+			}
+		`, randomID)
+
+		checks := map[string]resource.TestCheckFunc{
+			"pull": resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"github_team_repository.test", "permission",
+					"pull",
+				),
+			),
+			"triage": resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"github_team_repository.test", "permission",
+					"triage",
+				),
+			),
+			"push": resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"github_team_repository.test", "permission",
+					"push",
+				),
+			),
+			"maintain": resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"github_team_repository.test", "permission",
+					"maintain",
+				),
+			),
+			"admin": resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"github_team_repository.test", "permission",
+					"admin",
+				),
+			),
 		}
-		if resp.StatusCode != 404 {
-			return err
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  checks["pull"],
+					},
+					{
+						Config: strings.Replace(config,
+							`permission = "pull"`,
+							`permission = "triage"`, 1),
+						Check: checks["triage"],
+					},
+					{
+						Config: strings.Replace(config,
+							`permission = "pull"`,
+							`permission = "push"`, 1),
+						Check: checks["push"],
+					},
+					{
+						Config: strings.Replace(config,
+							`permission = "pull"`,
+							`permission = "maintain"`, 1),
+						Check: checks["maintain"],
+					},
+					{
+						Config: strings.Replace(config,
+							`permission = "pull"`,
+							`permission = "admin"`, 1),
+						Check: checks["admin"],
+					},
+				},
+			})
 		}
-		return nil
-	}
-	return nil
-}
 
-func testAccGithubTeamRepositoryConfig(randString, repoName string, teamIdentifier string) string {
-	return fmt.Sprintf(`
-resource "github_team" "test_team" {
-  name        = "tf-acc-test-team-repo-%s"
-  description = "Terraform acc test group"
-}
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
 
-resource "github_repository" "test" {
-  name = "%s"
-}
+		t.Run("with an individual account", func(t *testing.T) {
+			t.Skip("individual account not supported for this operation")
+		})
 
-resource "github_team_repository" "test_team_test_repo" {
-  team_id    = "${github_team.test_team.%s}"
-  repository = "${github_repository.test.name}"
-  permission = "pull"
-}
-`, randString, repoName, teamIdentifier)
-}
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
 
-func testAccGithubTeamRepositoryUpdateConfig(randString, repoName string, teamIdentifier string) string {
-	return fmt.Sprintf(`
-resource "github_team" "test_team" {
-  name        = "tf-acc-test-team-repo-%s"
-  description = "Terraform acc test group"
-}
+	})
 
-resource "github_repository" "test" {
-  name = "%s"
-}
+	t.Run("accepts both team slug and team ID for `team_id`", func(t *testing.T) {
 
-resource "github_team_repository" "test_team_test_repo" {
-  team_id    = "${github_team.test_team.%s}"
-  repository = "${github_repository.test.name}"
-  permission = "push"
-}
-`, randString, repoName, teamIdentifier)
+		config := fmt.Sprintf(`
+			resource "github_team" "test" {
+				name        = "tf-acc-test-team-repo-%s"
+				description = "test"
+			}
+
+			resource "github_repository" "test" {
+				name = "tf-acc-test-%[1]s"
+			}
+
+			resource "github_team_repository" "test" {
+				team_id    = "${github_team.test.slug}"
+				repository = "${github_repository.test.name}"
+				permission = "pull"
+			}
+		`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttrSet("github_team_repository.test", "team_id"),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+					{
+						Config: strings.Replace(config,
+							`github_team.test.id`,
+							`github_team.test.slug`, 1),
+						Check: check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			t.Skip("individual account not supported for this operation")
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
 }

--- a/github/util.go
+++ b/github/util.go
@@ -1,6 +1,8 @@
 package github
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -109,4 +111,33 @@ func validateTeamIDFunc(v interface{}, keyName string) (we []string, errors []er
 func splitRepoFilePath(path string) (string, string) {
 	parts := strings.Split(path, "/")
 	return parts[0], strings.Join(parts[1:], "/")
+}
+
+func getTeamID(teamIDString string, meta interface{}) (int64, error) {
+	ctx := context.Background()
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
+	orgId := meta.(*Owner).id
+
+	teamId, parseIntErr := strconv.ParseInt(teamIDString, 10, 64)
+	if parseIntErr != nil {
+		// The given id not an integer, assume it is a team slug
+		team, _, slugErr := client.Teams.GetTeamBySlug(ctx, orgName, teamIDString)
+		if slugErr != nil {
+			return -1, errors.New(parseIntErr.Error() + slugErr.Error())
+		}
+		return team.GetID(), nil
+	} else {
+		// The given id is an integer, assume it is a team id
+		team, _, teamIdErr := client.Teams.GetTeamByID(ctx, orgId, teamId)
+		if teamIdErr != nil {
+			// There isn't a team with the given ID, assume it is a teamslug
+			team, _, slugErr := client.Teams.GetTeamBySlug(ctx, orgName, teamIDString)
+			if slugErr != nil {
+				return -1, errors.New(teamIdErr.Error() + slugErr.Error())
+			}
+			return team.GetID(), nil
+		}
+		return team.GetID(), nil
+	}
 }

--- a/github/util.go
+++ b/github/util.go
@@ -114,6 +114,8 @@ func splitRepoFilePath(path string) (string, string) {
 }
 
 func getTeamID(teamIDString string, meta interface{}) (int64, error) {
+	// Given a string that is either a team id or team slug, return the
+	// id of the team it is referring to.
 	ctx := context.Background()
 	client := meta.(*Owner).v3client
 	orgName := meta.(*Owner).name

--- a/website/docs/r/team_repository.html.markdown
+++ b/website/docs/r/team_repository.html.markdown
@@ -41,7 +41,7 @@ resource "github_team_repository" "some_team_repo" {
 
 The following arguments are supported:
 
-* `team_id` - (Required) The GitHub team id
+* `team_id` - (Required) The GitHub team id or the GitHub team slug
 * `repository` - (Required) The repository to add to the team.
 * `permission` - (Optional) The permissions of team members regarding the repository.
   Must be one of `pull`, `triage`, `push`, `maintain`, or `admin`. Defaults to `pull`.


### PR DESCRIPTION
Attempt to address: https://github.com/integrations/terraform-provider-github/issues/675

Was tested locally, and I attempted to modify the acceptance tests to test this new behavior.

However, I wasn't able to get the acceptance tests to run locally, even after creating a new org called `kzhaotest` and setting the `GITHUB_TOKEN` and `GITHUB_ORGANIZATION` env variables:
```
kzhao@kzhao-mbp151 ~/go/src/github.com/k24dizzle/terraform-provider-github (teamid) $ TF_LOG=DEBUG TF_ACC=1  go test -v   ./... -run ^TestAccGithubTeamRepository_basic
?   	github.com/terraform-providers/terraform-provider-github	[no test files]
=== RUN   TestAccGithubTeamRepository_basic
2021/02/04 16:18:07 [ERROR] Github API Request error: &http.badStringError{what:"unsupported protocol scheme", str:""}
2021/02/04 16:18:07 [TRACE] Acquiring lock for GitHub API request (%!q(<nil>))
2021/02/04 16:18:07 [TRACE] Releasing lock for GitHub API request (%!q(<nil>))
    TestAccGithubTeamRepository_basic: resource_github_team_repository_test.go:17: Skipping because GITHUB_OWNER "kzhaotest" is a user, not an organization.
--- SKIP: TestAccGithubTeamRepository_basic (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-github/github	(cached)
```

Open to any feedback/comments
