### PR TITLE
fix based on linter

### DIFF
--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -173,7 +173,7 @@ func resourceGithubBranchProtectionRead(d *schema.ResourceData, meta interface{}
 		"id": d.Id(),
 	}
 
-	ctx := context.WithValue(context.Background(), "id", d.Id())
+	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 	client := meta.(*Owner).v4client
 	err := client.Query(ctx, &query, variables)
 	if err != nil {
@@ -266,7 +266,7 @@ func resourceGithubBranchProtectionUpdate(d *schema.ResourceData, meta interface
 		ReviewDismissalActorIDs:      githubv4NewIDSlice(githubv4IDSlice(data.ReviewDismissalActorIDs)),
 	}
 
-	ctx := context.WithValue(context.Background(), "id", d.Id())
+	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 	client := meta.(*Owner).v4client
 	err = client.Mutate(ctx, &mutate, input, nil)
 	if err != nil {
@@ -288,7 +288,7 @@ func resourceGithubBranchProtectionDelete(d *schema.ResourceData, meta interface
 		BranchProtectionRuleID: d.Id(),
 	}
 
-	ctx := context.WithValue(context.Background(), "id", d.Id())
+	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 	client := meta.(*Owner).v4client
 	err := client.Mutate(ctx, &mutate, input, nil)
 


### PR DESCRIPTION
Errors are occurred by executing `make lint`.

```
$ make lint
==> Checking source code against linters...
golangci-lint run ./...
github/resource_github_branch_protection.go:176:49: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
        ctx := context.WithValue(context.Background(), "id", d.Id())
                                                       ^
github/resource_github_branch_protection.go:269:49: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
        ctx := context.WithValue(context.Background(), "id", d.Id())
                                                       ^
github/resource_github_branch_protection.go:291:49: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
        ctx := context.WithValue(context.Background(), "id", d.Id())
                                                       ^
make: *** [lint] Error 1
```

It seems that CI is failing due to these errors.