### PR TITLE
Do not destroy the repository when you change the repository name

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -30,7 +30,6 @@ func resourceGithubRepository() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -68,6 +68,69 @@ func TestAccGithubRepositories(t *testing.T) {
 
 	})
 
+
+	t.Run("updates a repositories name without error", func(t *testing.T) {
+
+		oldName := fmt.Sprintf(`tf-acc-test-rename-%[1]s`, randomID)
+		newName := fmt.Sprintf(`%[1]s-renamed`, oldName)
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+			  name         = "%[1]s"
+			  description  = "Terraform acceptance tests %[2]s"
+			}
+		`, oldName, randomID)
+
+		checks := map[string]resource.TestCheckFunc{
+			"before": resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"github_repository.test", "name",
+					oldName,
+				),
+			),
+			"after": resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"github_repository.test", "name",
+					newName,
+				),
+			),
+		}
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  checks["before"],
+					},
+					{
+						// Rename the repo to something else
+						Config: strings.Replace(
+							config,
+							oldName,
+							newName, 1),
+						Check: checks["after"],
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
+
 	t.Run("imports repositories without error", func(t *testing.T) {
 
 		config := fmt.Sprintf(`

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -68,7 +68,6 @@ func TestAccGithubRepositories(t *testing.T) {
 
 	})
 
-
 	t.Run("updates a repositories name without error", func(t *testing.T) {
 
 		oldName := fmt.Sprintf(`tf-acc-test-rename-%[1]s`, randomID)


### PR DESCRIPTION
Inspired by the discussion in here: https://github.com/integrations/terraform-provider-github/issues/616, the change for this was easier than I expected. I just made it so that changing the `name` field wouldn't force a new resource.

I tested this change locally using the following terraform config:
```
resource "github_repository" "test" {
  name        = "renamerepo"
  description = "testing renaming a repo"
  auto_init   = true
}
```

After planning and applying the config above, I went ahead and changed the config to:
```
resource "github_repository" "test" {
  name        = "renamerepo2"
  description = "testing renaming a repo"
  auto_init   = true
}
```
The following [gist](https://gist.github.com/k24dizzle/5734e616c8131cdd43fa424a1b53672e) contains the resulting plan and apply of the provider `before` and `after` my changes.

I also went ahead and added a unit test for this:
```
    --- PASS: TestAccGithubRepositories/updates_a_repositories_name_without_error (10.03s)
        --- SKIP: TestAccGithubRepositories/updates_a_repositories_name_without_error/with_an_anonymous_account (0.00s)
        --- SKIP: TestAccGithubRepositories/updates_a_repositories_name_without_error/with_an_individual_account (0.00s)
        --- PASS: TestAccGithubRepositories/updates_a_repositories_name_without_error/with_an_organization_account (10.03s)
```