### PR TITLE
Fix branch protection import by repository node ID and pattern

### DIFF
--- a/github/migrate_github_branch_protection.go
+++ b/github/migrate_github_branch_protection.go
@@ -27,7 +27,7 @@ func resourceGithubBranchProtectionUpgradeV0(rawState map[string]interface{}, me
 	}
 
 	branch := rawState["branch"].(string)
-	protectionRuleID, err := getBranchProtectionID(repoName, branch, meta)
+	protectionRuleID, err := getBranchProtectionID(repoID, branch, meta)
 	if err != nil {
 		return nil, err
 	}

--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -307,7 +307,7 @@ func resourceGithubBranchProtectionImport(d *schema.ResourceData, meta interface
 	}
 	d.Set("repository_id", repoID)
 
-	id, err := getBranchProtectionID(repoName, pattern, meta)
+	id, err := getBranchProtectionID(repoID, pattern, meta)
 	if err != nil {
 		return nil, err
 	}

--- a/github/util_v4_branch_protection.go
+++ b/github/util_v4_branch_protection.go
@@ -255,7 +255,7 @@ func setPushes(protection BranchProtectionRule) []string {
 	return pushActors
 }
 
-func getBranchProtectionID(name string, pattern string, meta interface{}) (githubv4.ID, error) {
+func getBranchProtectionID(repoID githubv4.ID, pattern string, meta interface{}) (githubv4.ID, error) {
 	var query struct {
 		Node struct {
 			Repository struct {
@@ -268,11 +268,10 @@ func getBranchProtectionID(name string, pattern string, meta interface{}) (githu
 				} `graphql:"branchProtectionRules(first: $first, after: $cursor)"`
 				ID string
 			} `graphql:"... on Repository"`
-		} `graphql:"repository(owner: $owner, name: $name)"`
+		} `graphql:"node(id: $id)"`
 	}
 	variables := map[string]interface{}{
-		"owner":  githubv4.String(meta.(*Owner).name),
-		"name":   githubv4.String(name),
+		"id":     repoID,
 		"first":  githubv4.Int(100),
 		"cursor": (*githubv4.String)(nil),
 	}


### PR DESCRIPTION
Importing github_branch_protection using an ID of the form `<repo-node-id>:<pattern>` was broken, because the repository node ID was used as a repository name in the GraphQL query to fetch the branch protection rule.

I've updated the tests so that there is now an import test for both both ways of importing branch protection rules (`<repo-name>:<pattern>` and `<repo-node-id>:<pattern>`).

Closes: #671 