### PR TITLE
validate actions secret names

### DIFF
--- a/github/resource_github_actions_organization_secret.go
+++ b/github/resource_github_actions_organization_secret.go
@@ -20,9 +20,10 @@ func resourceGithubActionsOrganizationSecret() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"secret_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateSecretNameFunc,
 			},
 			"plaintext_value": {
 				Type:      schema.TypeString,

--- a/github/resource_github_actions_secret.go
+++ b/github/resource_github_actions_secret.go
@@ -25,9 +25,10 @@ func resourceGithubActionsSecret() *schema.Resource {
 				Required: true,
 			},
 			"secret_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateSecretNameFunc,
 			},
 			"plaintext_value": {
 				Type:      schema.TypeString,

--- a/github/util_test.go
+++ b/github/util_test.go
@@ -106,3 +106,56 @@ func flipUsernameCase(username string) string {
 	}
 	return string(oc)
 }
+
+func TestAccGithubUtilValidateSecretName(t *testing.T) {
+	cases := []struct {
+		Name  string
+		Error bool
+	}{
+		{
+			Name: "valid",
+		},
+		{
+			Name: "v",
+		},
+		{
+			Name: "_valid_underscore_",
+		},
+		{
+			Name: "valid_digit_1",
+		},
+		{
+			Name:  "invalid-dashed",
+			Error: true,
+		},
+		{
+			Name:  "1_invalid_leading_digit",
+			Error: true,
+		},
+		{
+			Name:  "1_invalid_leading_digit",
+			Error: true,
+		},
+		{
+			Name:  "GITHUB_PREFIX",
+			Error: true,
+		},
+		{
+			Name:  "github_prefix",
+			Error: true,
+		},
+	}
+
+	for _, tc := range cases {
+		var name interface{} = tc.Name
+		_, errors := validateSecretNameFunc(name, "")
+
+		if tc.Error != (len(errors) != 0) {
+			if tc.Error {
+				t.Fatalf("expected error, got none (%s)", tc.Name)
+			} else {
+				t.Fatalf("unexpected error(s): %s (%s)", errors, tc.Name)
+			}
+		}
+	}
+}

--- a/github/util_test.go
+++ b/github/util_test.go
@@ -133,10 +133,6 @@ func TestAccGithubUtilValidateSecretName(t *testing.T) {
 			Error: true,
 		},
 		{
-			Name:  "1_invalid_leading_digit",
-			Error: true,
-		},
-		{
 			Name:  "GITHUB_PREFIX",
 			Error: true,
 		},


### PR DESCRIPTION
This PR implements the secret naming rules described in the GitHub docs:

https://docs.github.com/en/actions/reference/encrypted-secrets#naming-your-secrets

Currently, if a user supplies an invalid secret name, it will be rejected at apply time:

```
422 Failed to add secret. Name is invalid []
```

Instead, this makes naming violations raise a clear error at validate/plan time. I've added unit tests against the validation function, similar to how other shared validation functions are handled. Happy to add a full acceptance test for an invalid case if that's of interest.