### PR TITLE
website/docs: Correctly capitalize GitHub

### DIFF
--- a/website/docs/d/repository.html.markdown
+++ b/website/docs/d/repository.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 
 * `archived` - Whether the repository is archived.
 
-* `pages` - The repository's GitHub Pages configuration. 
+* `pages` - The repository's GitHub Pages configuration.
 
 * `topics` - The list of topics of the repository.
 
@@ -71,4 +71,4 @@ The following arguments are supported:
 
 * `node_id` - GraphQL global node id for use with v4 API
 
-* `repo_id` - Github ID for the repository
+* `repo_id` - GitHub ID for the repository

--- a/website/docs/r/actions_organization_secret.html.markdown
+++ b/website/docs/r/actions_organization_secret.html.markdown
@@ -11,7 +11,7 @@ This resource allows you to create and manage GitHub Actions secrets within your
 You must have write access to a repository to use this resource.
 
 Secret values are encrypted using the [Go '/crypto/box' module](https://godoc.org/golang.org/x/crypto/nacl/box) which is
-interoperable with [libsodium](https://libsodium.gitbook.io/doc/). Libsodium is used by Github to decrypt secret values. 
+interoperable with [libsodium](https://libsodium.gitbook.io/doc/). Libsodium is used by GitHub to decrypt secret values.
 
 For the purposes of security, the contents of the `plaintext_value` field have been marked as `sensitive` to Terraform,
 but it is important to note that **this does not hide it from state files**. You should treat state as sensitive always.

--- a/website/docs/r/actions_secret.html.markdown
+++ b/website/docs/r/actions_secret.html.markdown
@@ -11,7 +11,7 @@ This resource allows you to create and manage GitHub Actions secrets within your
 You must have write access to a repository to use this resource.
 
 Secret values are encrypted using the [Go '/crypto/box' module](https://godoc.org/golang.org/x/crypto/nacl/box) which is
-interoperable with [libsodium](https://libsodium.gitbook.io/doc/). Libsodium is used by Github to decrypt secret values. 
+interoperable with [libsodium](https://libsodium.gitbook.io/doc/). Libsodium is used by GitHub to decrypt secret values.
 
 For the purposes of security, the contents of the `plaintext_value` field have been marked as `sensitive` to Terraform,
 but it is important to note that **this does not hide it from state files**. You should treat state as sensitive always.

--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -92,7 +92,7 @@ The following arguments are supported:
 * `dismiss_stale_reviews`: (Optional) Dismiss approved reviews automatically when a new commit is pushed. Defaults to `false`.
 * `dismissal_restrictions`: (Optional) The list of actor IDs with dismissal access.
 * `require_code_owner_reviews`: (Optional) Require an approved review in pull requests including files with a designated code owner. Defaults to `false`.
-* `required_approving_review_count`: (Optional) Require x number of approvals to satisfy branch protection requirements. If this is specified it must be a number between 1-6. This requirement matches Github's API, see the upstream [documentation](https://developer.github.com/v3/repos/branches/#parameters-1) for more information.
+* `required_approving_review_count`: (Optional) Require x number of approvals to satisfy branch protection requirements. If this is specified it must be a number between 1-6. This requirement matches GitHub's API, see the upstream [documentation](https://developer.github.com/v3/repos/branches/#parameters-1) for more information.
 
 
 ## Import

--- a/website/docs/r/branch_protection_v3.html.markdown
+++ b/website/docs/r/branch_protection_v3.html.markdown
@@ -7,7 +7,7 @@ description: |-
 
 # github\_branch\_protection
 
-Protects a GitHub branch. 
+Protects a GitHub branch.
 
 The `github_branch_protection` resource has moved to the GraphQL API, while this resource will continue to leverage the REST API.
 
@@ -93,7 +93,7 @@ The following arguments are supported:
 * `dismissal_teams`: (Optional) The list of team slugs with dismissal access.
   Always use `slug` of the team, **not** its name. Each team already **has** to have access to the repository.
 * `require_code_owner_reviews`: (Optional) Require an approved review in pull requests including files with a designated code owner. Defaults to `false`.
-* `required_approving_review_count`: (Optional) Require x number of approvals to satisfy branch protection requirements. If this is specified it must be a number between 1-6. This requirement matches Github's API, see the upstream [documentation](https://developer.github.com/v3/repos/branches/#parameters-1) for more information.
+* `required_approving_review_count`: (Optional) Require x number of approvals to satisfy branch protection requirements. If this is specified it must be a number between 1-6. This requirement matches GitHub's API, see the upstream [documentation](https://developer.github.com/v3/repos/branches/#parameters-1) for more information.
 
 ### Restrictions
 

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -26,7 +26,7 @@ resource "github_repository" "example" {
 }
 ```
 
-## Example Usage with Github Pages Enabled
+## Example Usage with GitHub Pages Enabled
 
 ```hcl
 resource "github_repository" "example" {
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 * `private` - (Optional) Set to `true` to create a private repository.
   Repositories are created as public (e.g. open source) by default.
-  
+
 * `visibility` - (Optional) Can be `public` or `private`. If your organization is associated with an enterprise account using GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+, visibility can also be `internal`. The `visibility` parameter overrides the `private` parameter.
 
 * `has_issues` - (Optional) Set to `true` to enable the GitHub Issues features
@@ -66,7 +66,7 @@ The following arguments are supported:
 
 * `has_wiki` - (Optional) Set to `true` to enable the GitHub Wiki features on
   the repository.
-  
+
 * `is_template` - (Optional) Set to `true` to tell GitHub that this is a template repository.
 
 * `allow_merge_commit` - (Optional) Set to `false` to disable merge commits on the repository.
@@ -93,23 +93,23 @@ initial repository creation and create the target branch inside of the repositor
 
 * `archive_on_destroy` - (Optional) Set to `true` to archive the repository instead of deleting on destroy.
 
-* `pages` - (Optional) The repository's Github Pages configuration. See [Github Pages Configuration](#github-pages-configuration) below for details.
+* `pages` - (Optional) The repository's GitHub Pages configuration. See [GitHub Pages Configuration](#github-pages-configuration) below for details.
 
 * `topics` - (Optional) The list of topics of the repository.
 
 * `template` - (Optional) Use a template repository to create this resource. See [Template Repositories](#template-repositories) below for details.
 
-* `vulnerability_alerts` (Optional) - Set to `true` to enable security alerts for vulnerable dependencies. Enabling requires alerts to be enabled on the owner level. (Note for importing: GitHub enables the alerts on public repos but disables them on private repos by default.) See [GitHub Documentation](https://help.github.com/en/github/managing-security-vulnerabilities/about-security-alerts-for-vulnerable-dependencies) for details. 
+* `vulnerability_alerts` (Optional) - Set to `true` to enable security alerts for vulnerable dependencies. Enabling requires alerts to be enabled on the owner level. (Note for importing: GitHub enables the alerts on public repos but disables them on private repos by default.) See [GitHub Documentation](https://help.github.com/en/github/managing-security-vulnerabilities/about-security-alerts-for-vulnerable-dependencies) for details.
 
-### Github Pages Configuration 
+### GitHub Pages Configuration
 
 The `pages` block supports the following:
 
-* `source` - (Required) The source branch and directory for the rendered Pages site. See [Github Pages Source](#github-pages-source) below for details.
+* `source` - (Required) The source branch and directory for the rendered Pages site. See [GitHub Pages Source](#github-pages-source) below for details.
 
 * `cname` - (Optional) The custom domain for the repository. This can only be set after the repository has been created.
 
-#### Github Pages Source ####
+#### GitHub Pages Source ####
 
 The `source` block supports the following:
 
@@ -144,12 +144,12 @@ The following additional attributes are exported:
 
 * `node_id` - GraphQL global node id for use with v4 API
 
-* `repo_id` - Github ID for the repository
+* `repo_id` - GitHub ID for the repository
 
-* `pages` - The block consisting of the repository's Github Pages configuration with the following additional attributes:
- * `custom_404` - Whether the rendered Github Pages site has a custom 404 page.
- * `html_url` - The absolute URL (including scheme) of the rendered Github Pages site e.g. `https://username.github.io`.
- * `status` - The Github Pages site's build status e.g. `building` or `built`.
+* `pages` - The block consisting of the repository's GitHub Pages configuration with the following additional attributes:
+ * `custom_404` - Whether the rendered GitHub Pages site has a custom 404 page.
+ * `html_url` - The absolute URL (including scheme) of the rendered GitHub Pages site e.g. `https://username.github.io`.
+ * `status` - The GitHub Pages site's build status e.g. `building` or `built`.
 
 ## Import
 

--- a/website/docs/r/repository_milestone.html.markdown
+++ b/website/docs/r/repository_milestone.html.markdown
@@ -9,7 +9,7 @@ description: |-
 
 Provides a GitHub repository milestone resource.
 
-This resource allows you to create and manage milestones for a Github Repository within an organization or user account.
+This resource allows you to create and manage milestones for a GitHub Repository within an organization or user account.
 
 ## Example Usage
 
@@ -26,9 +26,9 @@ resource "github_repository_milestone" "example" {
 
 The following arguments are supported:
 
-* `owner` - (Required) The owner of the Github Repository.
+* `owner` - (Required) The owner of the GitHub Repository.
 
-* `repository` - (Required) The name of the Github Repository.
+* `repository` - (Required) The name of the GitHub Repository.
 
 * `title` - (Required) The title of the milestone.
 

--- a/website/docs/r/team_sync_group_mapping.html.markdown
+++ b/website/docs/r/team_sync_group_mapping.html.markdown
@@ -10,7 +10,7 @@ description: |-
 This resource allows you to create and manage Identity Provider (IdP) group connections within your GitHub teams.
 You must have team synchronization enabled for organizations owned by enterprise accounts.
 
-To learn more about team synchronization between IdPs and Github, please refer to:
+To learn more about team synchronization between IdPs and GitHub, please refer to:
 https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/synchronizing-teams-between-your-identity-provider-and-github
 
 ## Example Usage
@@ -21,7 +21,7 @@ data "github_organization_team_sync_groups" "example_groups" {}
 
 resource "github_team_sync_group_mapping" "example_group_mapping" {
   team_slug        = "example"
-  
+
   dynamic "group" {
     for_each = [for g in data.github_organization_team_sync_groups.example_groups.groups : g if g.group_name == "some_team_group"]
     content {
@@ -29,7 +29,7 @@ resource "github_team_sync_group_mapping" "example_group_mapping" {
       group_name        = group.value.group_name
       group_description = group.value.group_description
     }
-  } 
+  }
 }
 ```
 
@@ -45,7 +45,7 @@ The `group` block consists of:
 
 * `group_id` - The ID of the IdP group.
 
-* `group_name` - The name of the IdP group. 
+* `group_name` - The name of the IdP group.
 
 * `group_description` - The description of the IdP group.
 


### PR DESCRIPTION
- My editor also fixed some trailing whitespace.
