### PR TITLE
Add error message for importing branch protection

### DIFF
--- a/github/resource_github_branch_protection_test.go
+++ b/github/resource_github_branch_protection_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -66,6 +67,16 @@ func TestAccGithubBranchProtection(t *testing.T) {
 							fmt.Sprintf("tf-acc-test-%s", randomID), "main",
 						),
 					},
+					{
+						ResourceName: "github_branch_protection.test",
+						ImportState:  true,
+						ExpectError: regexp.MustCompile(
+							`Could not find a branch protection rule with the pattern 'no-such-pattern'\.`,
+						),
+						ImportStateIdFunc: importBranchProtectionByRepoName(
+							fmt.Sprintf("tf-acc-test-%s", randomID), "no-such-pattern",
+						),
+					},
 				},
 			})
 		}
@@ -128,6 +139,15 @@ func TestAccGithubBranchProtection(t *testing.T) {
 						ImportStateVerify: true,
 						ImportStateIdFunc: importBranchProtectionByRepoID(
 							"github_repository.test", "main"),
+					},
+					{
+						ResourceName: "github_branch_protection.test",
+						ImportState:  true,
+						ExpectError: regexp.MustCompile(
+							`Could not find a branch protection rule with the pattern 'no-such-pattern'\.`,
+						),
+						ImportStateIdFunc: importBranchProtectionByRepoID(
+							"github_repository.test", "no-such-pattern"),
 					},
 				},
 			})

--- a/github/util_v4_branch_protection.go
+++ b/github/util_v4_branch_protection.go
@@ -297,11 +297,9 @@ func getBranchProtectionID(repoID githubv4.ID, pattern string, meta interface{})
 		variables["cursor"] = githubv4.NewString(query.Node.Repository.BranchProtectionRules.PageInfo.EndCursor)
 	}
 
-	var id string
 	for i := range allRules {
 		if allRules[i].Pattern == pattern {
-			id = allRules[i].ID
-			return id, nil
+			return allRules[i].ID, nil
 		}
 	}
 

--- a/github/util_v4_branch_protection.go
+++ b/github/util_v4_branch_protection.go
@@ -301,11 +301,11 @@ func getBranchProtectionID(repoID githubv4.ID, pattern string, meta interface{})
 	for i := range allRules {
 		if allRules[i].Pattern == pattern {
 			id = allRules[i].ID
-			break
+			return id, nil
 		}
 	}
 
-	return id, nil
+	return nil, fmt.Errorf("Could not find a branch protection rule with the pattern '%s'.", pattern)
 }
 
 func statusChecksDiffSuppression(k, old, new string, d *schema.ResourceData) bool {


### PR DESCRIPTION
@bateller reported (as a follow-up on #671) that the import function for `github_branch_protection` doesn't give a nice error message if the resource doesn't exist on GitHub.

```
Error: nil entry in ImportState results. This is always a bug with
the resource that is being imported. Please report this as
a bug to Terraform.
```

This pull request changes the message to:
```
Error: Could not find a branch protection rule with the pattern 'master'.
```

The trouble is, I don't know how to add an idiomatic test for this change. Any advice would be much appreciated.