### PR TITLE
Change default branch name in docs

### DIFF
--- a/website/docs/r/branch.html.markdown
+++ b/website/docs/r/branch.html.markdown
@@ -29,7 +29,7 @@ The following arguments are supported:
 
 * `branch` - (Required) The repository branch to create.
 
-* `source_branch` - (Optional) The branch name to start from. Defaults to `master`.
+* `source_branch` - (Optional) The branch name to start from. Defaults to `main`.
 
 * `source_sha` - (Optional) The commit hash to start from. Defaults to the tip of `source_branch`. If provided, `source_branch` is ignored.
 


### PR DESCRIPTION
Experimentally, github is returning an assumption of "main" now rather than master, which is in accordance with changes in underlying git/github semantics.

Docs should reflect this as mutations in `source_branch` can lead to plans that destroy and recreate these branches, which is likely unintended behaviour.