### PR TITLE
`github_repository_file` - Fix creation crash

### DIFF
--- a/github/resource_github_repository_file.go
+++ b/github/resource_github_repository_file.go
@@ -204,7 +204,7 @@ func resourceGithubRepositoryFileCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", repo, file))
-	d.Set("commit", create.Commit.GetSHA())
+	d.Set("commit_sha", create.Commit.GetSHA())
 
 	return resourceGithubRepositoryFileRead(d, meta)
 }


### PR DESCRIPTION
The `commit` is renamed to `commit_sha`, setting to a un-existed property will cause provider crash.

Fix #733