### PR TITLE
Give a helpful error message when trying to import a github_branch that does not exist

### DIFF
--- a/github/resource_github_branch.go
+++ b/github/resource_github_branch.go
@@ -183,5 +183,15 @@ func resourceGithubBranchImport(d *schema.ResourceData, meta interface{}) ([]*sc
 
 	d.Set("source_branch", sourceBranch)
 
-	return []*schema.ResourceData{d}, resourceGithubBranchRead(d, meta)
+	err = resourceGithubBranchRead(d, meta)
+	if err != nil {
+		return nil, err
+	}
+
+	// resourceGithubBranchRead calls d.SetId("") if the branch does not exist
+	if d.Id() == "" {
+		return nil, fmt.Errorf("Repository %s does not have a branch named %s.", repoName, branchName)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/github/resource_github_branch_test.go
+++ b/github/resource_github_branch_test.go
@@ -18,18 +18,19 @@ func TestAccGithubBranch(t *testing.T) {
 		config := fmt.Sprintf(`
 			resource "github_repository" "test" {
 			  name = "tf-acc-test-%[1]s"
-				auto_init = true
+			  auto_init = true
 			}
 
 			resource "github_branch" "test" {
 			  repository = github_repository.test.id
-			  branch     = "tf-acc-test-%[1]s"
+			  branch     = "test"
 			}
 		`, randomID)
 
 		check := resource.ComposeTestCheckFunc(
 			resource.TestMatchResourceAttr(
-				"github_branch.test", "id", regexp.MustCompile(randomID),
+				"github_branch.test", "id",
+				regexp.MustCompile(fmt.Sprintf("tf-acc-test-%s:test", randomID)),
 			),
 		)
 
@@ -41,6 +42,21 @@ func TestAccGithubBranch(t *testing.T) {
 					{
 						Config: config,
 						Check:  check,
+					},
+					{
+						ResourceName:            "github_branch.test",
+						ImportState:             true,
+						ImportStateId:           fmt.Sprintf("tf-acc-test-%s:test", randomID),
+						ImportStateVerify:       true,
+						ImportStateVerifyIgnore: []string{"source_sha"},
+					},
+					{
+						ResourceName:  "github_branch.test",
+						ImportState:   true,
+						ImportStateId: fmt.Sprintf("tf-acc-test-%s:nonsense", randomID),
+						ExpectError: regexp.MustCompile(
+							"Repository tf-acc-test-[a-z0-9]* does not have a branch named nonsense.",
+						),
 					},
 				},
 			})
@@ -65,24 +81,25 @@ func TestAccGithubBranch(t *testing.T) {
 		config := fmt.Sprintf(`
 			resource "github_repository" "test" {
 			  name = "tf-acc-test-%[1]s"
-				auto_init = true
+			  auto_init = true
 			}
 
 			resource "github_branch" "source" {
 			  repository = github_repository.test.id
-			  branch     = "tf-acc-test-%[1]s-source"
+			  branch     = "source"
 			}
 
 			resource "github_branch" "test" {
-			  repository 		= github_repository.test.id
+			  repository    = github_repository.test.id
 			  source_branch = github_branch.source.branch
-			  branch        = "tf-acc-test-%[1]s"
+			  branch        = "test"
 			}
 		`, randomID)
 
 		check := resource.ComposeTestCheckFunc(
 			resource.TestMatchResourceAttr(
-				"github_branch.test", "id", regexp.MustCompile(randomID),
+				"github_branch.test", "id",
+				regexp.MustCompile(fmt.Sprintf("tf-acc-test-%s:test", randomID)),
 			),
 		)
 
@@ -94,6 +111,21 @@ func TestAccGithubBranch(t *testing.T) {
 					{
 						Config: config,
 						Check:  check,
+					},
+					{
+						ResourceName:            "github_branch.test",
+						ImportState:             true,
+						ImportStateId:           fmt.Sprintf("tf-acc-test-%s:test:source", randomID),
+						ImportStateVerify:       true,
+						ImportStateVerifyIgnore: []string{"source_sha"},
+					},
+					{
+						ResourceName:  "github_branch.test",
+						ImportState:   true,
+						ImportStateId: fmt.Sprintf("tf-acc-test-%s:nonsense:source", randomID),
+						ExpectError: regexp.MustCompile(
+							"Repository tf-acc-test-[a-z0-9]* does not have a branch named nonsense.",
+						),
 					},
 				},
 			})


### PR DESCRIPTION
I noticed that in issue #636, errors are not reported properly when importing a `github_branch` resource. In particular, the case where the branch does not exist on GitHub is not handled by the provider and the user gets a Terraform error instead:

```
Error: nil entry in ImportState results. This is always a bug with
the resource that is being imported. Please report this as
a bug to Terraform.
```

I've updated this message to:

```
Error: Repository tftest does not have a branch named nosuchbranch.
```