### PR TITLE
Add import function for github_actions_organization_secret resource

### DIFF
--- a/github/resource_github_actions_organization_secret_test.go
+++ b/github/resource_github_actions_organization_secret_test.go
@@ -116,4 +116,54 @@ func TestAccGithubActionsOrganizationSecret(t *testing.T) {
 			testCase(t, organization)
 		})
 	})
+
+	t.Run("imports secrets without error", func(t *testing.T) {
+		secretValue := "super_secret_value"
+
+		config := fmt.Sprintf(`
+			resource "github_actions_organization_secret" "test_secret" {
+				secret_name      = "test_secret_name"
+				plaintext_value  = "%s"
+				visibility       = "private"
+			}
+		`, secretValue)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_actions_organization_secret.test_secret", "plaintext_value",
+				secretValue,
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+					{
+						ResourceName:            "github_actions_organization_secret.test_secret",
+						ImportState:             true,
+						ImportStateVerify:       true,
+						ImportStateVerifyIgnore: []string{"plaintext_value"},
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			t.Skip("individual account not supported for this operation")
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
 }

--- a/website/docs/r/actions_organization_secret.html.markdown
+++ b/website/docs/r/actions_organization_secret.html.markdown
@@ -56,3 +56,15 @@ The following arguments are supported:
 
 * `created_at`      - Date of actions_secret creation.
 * `updated_at`      - Date of actions_secret update.
+
+## Import
+
+This resource can be imported using an ID made up of the secret name:
+
+```
+$ terraform import github_actions_organization_secret.test_secret test_secret_name
+```
+
+NOTE: the implementation is limited in that it won't fetch the value of the
+`plaintext_value` field when importing. You may need to ignore changes for the
+`plaintext_value` as a workaround.


### PR DESCRIPTION
## Use Cases
Importer function will be useful when migrating existing Github organisational secrets to Terraform resources. This will allow importing existing organisation secrets into Terraform state along with it's visibility status and list of repositories when visibility is `selected`.

One defect of this implementation is it won't fetch value for `plaintext_value` for the secret to the state file. So would recommend using this along with resources ignoring changes for `plaintext_value`.

## Changes include:
* Create importer function for resource github_actions_organization_secret
* Import organization secrets along with selected repository IDs list if visibility is `selected`