### PR TITLE
team: mark slug as computed when name changes

### DIFF
--- a/github/resource_github_team.go
+++ b/github/resource_github_team.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/google/go-github/v32/github"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/shurcooL/githubv4"
 )
@@ -20,6 +21,12 @@ func resourceGithubTeam() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+
+		CustomizeDiff: customdiff.Sequence(
+			customdiff.ComputedIf("slug", func(d *schema.ResourceDiff, meta interface{}) bool {
+				return d.HasChange("name")
+			}),
+		),
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/compose.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/compose.go
@@ -1,0 +1,72 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// All returns a CustomizeDiffFunc that runs all of the given
+// CustomizeDiffFuncs and returns all of the errors produced.
+//
+// If one function produces an error, functions after it are still run.
+// If this is not desirable, use function Sequence instead.
+//
+// If multiple functions returns errors, the result is a multierror.
+//
+// For example:
+//
+//     &schema.Resource{
+//         // ...
+//         CustomizeDiff: customdiff.All(
+//             customdiff.ValidateChange("size", func (old, new, meta interface{}) error {
+//                 // If we are increasing "size" then the new value must be
+//                 // a multiple of the old value.
+//                 if new.(int) <= old.(int) {
+//                     return nil
+//                 }
+//                 if (new.(int) % old.(int)) != 0 {
+//                     return fmt.Errorf("new size value must be an integer multiple of old value %d", old.(int))
+//                 }
+//                 return nil
+//             }),
+//             customdiff.ForceNewIfChange("size", func (old, new, meta interface{}) bool {
+//                 // "size" can only increase in-place, so we must create a new resource
+//                 // if it is decreased.
+//                 return new.(int) < old.(int)
+//             }),
+//             customdiff.ComputedIf("version_id", func (d *schema.ResourceDiff, meta interface{}) bool {
+//                 // Any change to "content" causes a new "version_id" to be allocated.
+//                 return d.HasChange("content")
+//             }),
+//         ),
+//     }
+//
+func All(funcs ...schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		var err error
+		for _, f := range funcs {
+			thisErr := f(d, meta)
+			if thisErr != nil {
+				err = multierror.Append(err, thisErr)
+			}
+		}
+		return err
+	}
+}
+
+// Sequence returns a CustomizeDiffFunc that runs all of the given
+// CustomizeDiffFuncs in sequence, stopping at the first one that returns
+// an error and returning that error.
+//
+// If all functions succeed, the combined function also succeeds.
+func Sequence(funcs ...schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		for _, f := range funcs {
+			err := f(d, meta)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/computed.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/computed.go
@@ -1,0 +1,16 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// ComputedIf returns a CustomizeDiffFunc that sets the given key's new value
+// as computed if the given condition function returns true.
+func ComputedIf(key string, f ResourceConditionFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		if f(d, meta) {
+			d.SetNewComputed(key)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/condition.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/condition.go
@@ -1,0 +1,60 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// ResourceConditionFunc is a function type that makes a boolean decision based
+// on an entire resource diff.
+type ResourceConditionFunc func(d *schema.ResourceDiff, meta interface{}) bool
+
+// ValueChangeConditionFunc is a function type that makes a boolean decision
+// by comparing two values.
+type ValueChangeConditionFunc func(old, new, meta interface{}) bool
+
+// ValueConditionFunc is a function type that makes a boolean decision based
+// on a given value.
+type ValueConditionFunc func(value, meta interface{}) bool
+
+// If returns a CustomizeDiffFunc that calls the given condition
+// function and then calls the given CustomizeDiffFunc only if the condition
+// function returns true.
+//
+// This can be used to include conditional customizations when composing
+// customizations using All and Sequence, but should generally be used only in
+// simple scenarios. Prefer directly writing a CustomizeDiffFunc containing
+// a conditional branch if the given CustomizeDiffFunc is already a
+// locally-defined function, since this avoids obscuring the control flow.
+func If(cond ResourceConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		if cond(d, meta) {
+			return f(d, meta)
+		}
+		return nil
+	}
+}
+
+// IfValueChange returns a CustomizeDiffFunc that calls the given condition
+// function with the old and new values of the given key and then calls the
+// given CustomizeDiffFunc only if the condition function returns true.
+func IfValueChange(key string, cond ValueChangeConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		if cond(old, new, meta) {
+			return f(d, meta)
+		}
+		return nil
+	}
+}
+
+// IfValue returns a CustomizeDiffFunc that calls the given condition
+// function with the new values of the given key and then calls the
+// given CustomizeDiffFunc only if the condition function returns true.
+func IfValue(key string, cond ValueConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		if cond(d.Get(key), meta) {
+			return f(d, meta)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/doc.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/doc.go
@@ -1,0 +1,11 @@
+// Package customdiff provides a set of reusable and composable functions
+// to enable more "declarative" use of the CustomizeDiff mechanism available
+// for resources in package helper/schema.
+//
+// The intent of these helpers is to make the intent of a set of diff
+// customizations easier to see, rather than lost in a sea of Go function
+// boilerplate. They should _not_ be used in situations where they _obscure_
+// intent, e.g. by over-using the composition functions where a single
+// function containing normal Go control flow statements would be more
+// straightforward.
+package customdiff

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/force_new.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/force_new.go
@@ -1,0 +1,40 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// ForceNewIf returns a CustomizeDiffFunc that flags the given key as
+// requiring a new resource if the given condition function returns true.
+//
+// The return value of the condition function is ignored if the old and new
+// values of the field compare equal, since no attribute diff is generated in
+// that case.
+func ForceNewIf(key string, f ResourceConditionFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		if f(d, meta) {
+			d.ForceNew(key)
+		}
+		return nil
+	}
+}
+
+// ForceNewIfChange returns a CustomizeDiffFunc that flags the given key as
+// requiring a new resource if the given condition function returns true.
+//
+// The return value of the condition function is ignored if the old and new
+// values compare equal, since no attribute diff is generated in that case.
+//
+// This function is similar to ForceNewIf but provides the condition function
+// only the old and new values of the given key, which leads to more compact
+// and explicit code in the common case where the decision can be made with
+// only the specific field value.
+func ForceNewIfChange(key string, f ValueChangeConditionFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		if f(old, new, meta) {
+			d.ForceNew(key)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/validate.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/validate.go
@@ -1,0 +1,38 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// ValueChangeValidationFunc is a function type that validates the difference
+// (or lack thereof) between two values, returning an error if the change
+// is invalid.
+type ValueChangeValidationFunc func(old, new, meta interface{}) error
+
+// ValueValidationFunc is a function type that validates a particular value,
+// returning an error if the value is invalid.
+type ValueValidationFunc func(value, meta interface{}) error
+
+// ValidateChange returns a CustomizeDiffFunc that applies the given validation
+// function to the change for the given key, returning any error produced.
+func ValidateChange(key string, f ValueChangeValidationFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		return f(old, new, meta)
+	}
+}
+
+// ValidateValue returns a CustomizeDiffFunc that applies the given validation
+// function to value of the given key, returning any error produced.
+//
+// This should generally not be used since it is functionally equivalent to
+// a validation function applied directly to the schema attribute in question,
+// but is provided for situations where composing multiple CustomizeDiffFuncs
+// together makes intent clearer than spreading that validation across the
+// schema.
+func ValidateValue(key string, f ValueValidationFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		val := d.Get(key)
+		return f(val, meta)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -242,6 +242,7 @@ github.com/hashicorp/terraform-json
 # github.com/hashicorp/terraform-plugin-sdk v1.7.0
 github.com/hashicorp/terraform-plugin-sdk/acctest
 github.com/hashicorp/terraform-plugin-sdk/helper/acctest
+github.com/hashicorp/terraform-plugin-sdk/helper/customdiff
 github.com/hashicorp/terraform-plugin-sdk/helper/hashcode
 github.com/hashicorp/terraform-plugin-sdk/helper/logging
 github.com/hashicorp/terraform-plugin-sdk/helper/resource


### PR DESCRIPTION
This configures Terraform to mark `github_team.*.slug` as computed any time `name` changes, ensuring that it shows any resource that is dependent on `slug` as requiring an update.

I spotted this need when using `terraform import` with an existing team that had a different name than what was declared in configuration. Other resources in the same configuration ([`team_sync_group_mapping`](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_sync_group_mapping) in my case) that depended on that slug still showed the current slug in the plan. Without this hint from `CustomizeDiff`, Terraform can't know that the computed value of `slug` will be different after the name is updated and the value in state (from the import) should not be used.

I used `customdiff.Sequence` as a general pattern here so that additional CustomizeDiffFuncs can be added for other fields. However, it could easily be removed too.

A test that has another resource that depends on `slug` provides coverage here. Using another team and sticking a `slug` in the description was convenient. Without the customized diff, the test fails:

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccGithubTeamUpdateName -timeout 120m
?   	github.com/terraform-providers/terraform-provider-github	[no test files]
=== RUN   TestAccGithubTeamUpdateName
=== RUN   TestAccGithubTeamUpdateName/marks_the_slug_as_computed_when_the_name_changes
=== RUN   TestAccGithubTeamUpdateName/marks_the_slug_as_computed_when_the_name_changes/with_an_anonymous_account
    resource_github_team_test.go:199: anonymous account not supported for this operation
=== RUN   TestAccGithubTeamUpdateName/marks_the_slug_as_computed_when_the_name_changes/with_an_individual_account
    resource_github_team_test.go:203: individual account not supported for this operation
=== RUN   TestAccGithubTeamUpdateName/marks_the_slug_as_computed_when_the_name_changes/with_an_organization_account
    testing.go:654: Step 1 error: errors during apply:

        Error: Provider produced inconsistent final plan

        When expanding the plan for github_team.other to include new values learned so
        far during apply, provider "github" produced an invalid new value for
        .description: was cty.StringVal("tf-acc-kpzaa"), but now
        cty.StringVal("tf-acc-updated-kpzaa").

        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.

--- FAIL: TestAccGithubTeamUpdateName (8.71s)
    --- FAIL: TestAccGithubTeamUpdateName/marks_the_slug_as_computed_when_the_name_changes (8.71s)
        --- SKIP: TestAccGithubTeamUpdateName/marks_the_slug_as_computed_when_the_name_changes/with_an_anonymous_account (0.00s)
        --- SKIP: TestAccGithubTeamUpdateName/marks_the_slug_as_computed_when_the_name_changes/with_an_individual_account (0.00s)
        --- FAIL: TestAccGithubTeamUpdateName/marks_the_slug_as_computed_when_the_name_changes/with_an_organization_account (8.71s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-github/github	8.970s
FAIL
make: *** [testacc] Error 1
```

With the custom diff the test passes.