### PR TITLE
Explore setting vulnerability alerts correctly

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -369,24 +369,6 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
-	var alerts bool
-	if a, ok := d.GetOk("vulnerability_alerts"); ok {
-		alerts = a.(bool)
-	}
-
-	var createVulnerabilityAlerts func(context.Context, string, string) (*github.Response, error)
-	if isPrivate && alerts {
-		createVulnerabilityAlerts = client.Repositories.EnableVulnerabilityAlerts
-	} else if !isPrivate && !alerts {
-		createVulnerabilityAlerts = client.Repositories.DisableVulnerabilityAlerts
-	}
-	if createVulnerabilityAlerts != nil {
-		_, err := createVulnerabilityAlerts(ctx, owner, repoName)
-		if err != nil {
-			return err
-		}
-	}
-
 	pages := expandPages(d.Get("pages").([]interface{}))
 	if pages != nil {
 		_, _, err := client.Repositories.EnablePages(ctx, owner, repoName, pages)

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -549,7 +549,7 @@ func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
-	if !d.IsNewResource() && d.HasChange("vulnerability_alerts") {
+	if d.HasChange("vulnerability_alerts") {
 		updateVulnerabilityAlerts := client.Repositories.DisableVulnerabilityAlerts
 		if vulnerabilityAlerts, ok := d.GetOk("vulnerability_alerts"); ok && vulnerabilityAlerts.(bool) {
 			updateVulnerabilityAlerts = client.Repositories.EnableVulnerabilityAlerts
@@ -564,7 +564,7 @@ func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 	if d.HasChange("visibility") {
 		o, n := d.GetChange("visibility")
 		repoReq.Visibility = github.String(n.(string))
-		log.Printf("[DEBUG] <<<<<<<<<<<<< Updating repository visibility from %s to %s", o, n)
+		log.Printf("[DEBUG] Updating repository visibility from %s to %s", o, n)
 		_, _, err = client.Repositories.Edit(ctx, owner, repoName, repoReq)
 		if err != nil {
 			if !strings.Contains(err.Error(), "422 Visibility is already private") {
@@ -572,13 +572,13 @@ func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 			}
 		}
 	} else {
-		log.Printf("[DEBUG] <<<<<<<<<< no visibility update required. visibility: %s", d.Get("visibility"))
+		log.Printf("[DEBUG] No visibility update required. visibility: %s", d.Get("visibility"))
 	}
 
 	if d.HasChange("private") {
 		o, n := d.GetChange("private")
 		repoReq.Private = github.Bool(n.(bool))
-		log.Printf("[DEBUG] <<<<<<<<<<<<< Updating repository privacy from %v to %v", o, n)
+		log.Printf("[DEBUG] Updating repository privacy from %v to %v", o, n)
 		_, _, err = client.Repositories.Edit(ctx, owner, repoName, repoReq)
 		if err != nil {
 			if !strings.Contains(err.Error(), "422 Privacy is already set") {

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -99,7 +99,7 @@ initial repository creation and create the target branch inside of the repositor
 
 * `template` - (Optional) Use a template repository to create this resource. See [Template Repositories](#template-repositories) below for details.
 
-* `vulnerability_alerts` (Optional) - Set to `true` to enable security alerts for vulnerable dependencies. Enabling requires alerts to be enabled on the owner level. (Note for importing: GitHub enables the alerts on public repos but disables them on private repos by default.) See [GitHub Documentation](https://help.github.com/en/github/managing-security-vulnerabilities/about-security-alerts-for-vulnerable-dependencies) for details.
+* `vulnerability_alerts` (Optional) - Set to `true` to enable security alerts for vulnerable dependencies. Enabling requires alerts to be enabled on the owner level. (Note for importing: GitHub enables the alerts on public repos but disables them on private repos by default.) See [GitHub Documentation](https://help.github.com/en/github/managing-security-vulnerabilities/about-security-alerts-for-vulnerable-dependencies) for details. Note that vulnerability alerts have not been successfully tested on any GitHub Enterprise instance and may be unavailable in those settings.
 
 ### GitHub Pages Configuration
 


### PR DESCRIPTION
Removing the `!d.isNewResource()` check seems to fix vulnerability alerts setting for me (as mentioned in [issue 754](https://github.com/integrations/terraform-provider-github/issues/754)). I'm making this PR in hopes that it doesn't mess up the existing tests...I'm wondering why that behavior was there in the first place. Perhaps it's something to do with the create/immediate update flow we use. 

I'm a little hesitant to remove that check due to [Chesterton's fence](https://en.wikipedia.org/wiki/G._K._Chesterton#Chesterton's_fence), but perhaps someone else knows more than I do about it, and the testing coverage should help us as well.

TODO:
- [x] validate tests still pass
- [x] provide validation instructions for manual testing