### PR TITLE
fix(data/repository): set name and full_name attributes as computed

### DIFF
--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -17,11 +17,13 @@ func dataSourceGithubRepository() *schema.Resource {
 			"full_name": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				Computed:      true,
 				ConflictsWith: []string{"name"},
 			},
 			"name": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				Computed:      true,
 				ConflictsWith: []string{"full_name"},
 			},
 


### PR DESCRIPTION
This avoids propagating null values when the evaluation of the data source is deferred.

In some rare situations where one is using the repository data source on a not yet existing repository (which will be created during terraform apply), the evaluation of this data source will be deferred. However, a resource using only its full_name attribute (if the name argument was set) or its name attribute (if the full_name argument was set), will immediately get a null value since these attributes are not set as computed. Setting these attributes to computed solves the problem.