### PR TITLE
fix issue that prevents 'internal' repositories being created in an Enterprise Managed User organisation

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -303,7 +303,7 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 
 	visibility, ok := d.Get("visibility").(string)
 	if ok {
-		if visibility == "private" {
+		if visibility == "private" || visibility == "internal" {
 			isPrivate = true
 		}
 	}


### PR DESCRIPTION
When an `internal` repository is built first time round it defaults to `public`. Public repositories cannot be created in an `Enterprise Managed User` organisation on GitHub.com. This PR allows Terraform to first create `internal` repos as `private` and then change to `internal`.

```
Error: POST https://api.github.com/orgs/ORG1/repos: 422 Public repositories are not permitted for Enterprise Managed Organizations. []
```