### PR TITLE
Enhancement: Add Github actions and dependabot in Github IP Ranges DS

### DIFF
--- a/github/data_source_github_ip_ranges.go
+++ b/github/data_source_github_ip_ranges.go
@@ -29,6 +29,16 @@ func dataSourceGithubIpRanges() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"actions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"dependabot": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -55,6 +65,12 @@ func dataSourceGithubIpRangesRead(d *schema.ResourceData, meta interface{}) erro
 	}
 	if len(api.Importer) > 0 {
 		d.Set("importer", api.Importer)
+	}
+	if len(api.Actions) > 0 {
+		d.Set("actions", api.Actions)
+	}
+	if len(api.Dependabot) > 0 {
+		d.Set("dependabot", api.Dependabot)
 	}
 
 	return nil

--- a/github/data_source_github_ip_ranges_test.go
+++ b/github/data_source_github_ip_ranges_test.go
@@ -17,6 +17,8 @@ func TestAccGithubIpRangesDataSource(t *testing.T) {
 			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "git.#"),
 			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "pages.#"),
 			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "importer.#"),
+			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "actions.#"),
+			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "dependabot.#"),
 		)
 
 		testCase := func(t *testing.T, mode string) {


### PR DESCRIPTION
It's useful to have the IP range of Github actions to restrict traffics
of exposed resources. For example, testing the connectivity of a test
database from a Github action without opening the instance to 0.0.0.0/0.