### PR TITLE
Include repositories Info associated to the Teams

### DIFF
--- a/github/data_source_github_organization_teams.go
+++ b/github/data_source_github_organization_teams.go
@@ -50,6 +50,11 @@ func dataSourceGithubOrganizationTeams() *schema.Resource {
 							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						"repositories": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
 					},
 				},
 			},
@@ -126,6 +131,16 @@ func flattenGitHubTeams(tq TeamsQuery) []interface{} {
 		}
 
 		t["members"] = flatMembers
+
+		repositories := team.Repositories.Nodes
+
+		flatRepositories := make([]string, len(repositories))
+
+		for i, repository := range repositories {
+			flatRepositories[i] = string(repository.Name)
+		}
+
+		t["repositories"] = flatRepositories
 
 		flatTeams[i] = t
 	}

--- a/github/data_source_github_team_repository_test.go
+++ b/github/data_source_github_team_repository_test.go
@@ -1,0 +1,77 @@
+package github
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccGithubTeamRepositorty(t *testing.T) {
+
+	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+	t.Run("Get Repositories By Teams", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "repo-test" {
+				name = "tf-acc-repo-%s"
+				auto_init = true
+			
+		  	}
+
+			resource "github_team" "team-test" {
+				name = "tf-acc-test-team01"
+			}
+
+			resource "github_team_repository" "team-repo-test" {
+				repository = "${github_repository.repo-test.id}"
+				team_id = "${github_team.team-test.id}"
+			}
+
+			data "github_team" "example" {
+				slug = "team-test-01"
+			}
+
+   		    output "team_repository_name" {
+				value = data.github_team.example.repositories.0
+			}
+			
+			output "team_repository_numbers" {
+				value = data.github_team.example.repositories.#
+			}
+		`, randomID)
+
+		check := resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttrSet("data.github_team.example", "name"),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			t.Skip("individual account not supported for this operation")
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
+
+}

--- a/github/util_v4_teams.go
+++ b/github/util_v4_teams.go
@@ -18,6 +18,11 @@ type TeamsQuery struct {
 						Login githubv4.String
 					}
 				}
+				Repositories struct {
+					Nodes []struct {
+						Name githubv4.String
+					}
+				}
 			}
 			PageInfo PageInfo
 		} `graphql:"teams(first:$first, after:$cursor, rootTeamsOnly:$rootTeamsOnly)"`

--- a/website/docs/d/organization_teams.html.markdown
+++ b/website/docs/d/organization_teams.html.markdown
@@ -40,3 +40,4 @@ The `team` block consists of:
  * `description` - the team's description.
  * `privacy` - the team's privacy type.
  * `members` - List of team members.
+ * `repositories` - List of team repositories.

--- a/website/docs/d/team.html.markdown
+++ b/website/docs/d/team.html.markdown
@@ -30,3 +30,5 @@ data "github_team" "example" {
  * `privacy` - the team's privacy type.
  * `permission` - the team's permission level.
  * `members` - List of team members
+ * `repositories` - List of team repositories
+ 


### PR DESCRIPTION
When I get a github_team I need that the repositories that it has associated are informed. I think that It's very usual that the behaviour of the organization can be replaced with the use of the teams for some enterprise accounts, it's for that reason that I need a get the repositories information associated with the Teams.

- github/data_source_github_organization_teams.go
- github/data_source_github_team.go
- github/util_v4_teams.go
`````
   .....
    "repositories": {
         Type:     schema.TypeList,
         Computed: true,
         Elem:     &amp;schema.Schema{Type: schema.TypeString
    },
    ....
`````

