### PR TITLE
create repository with internal visibility initially instead of changing it later

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -309,11 +309,6 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	repoReq.Private = github.Bool(isPrivate)
-	if isPrivate {
-		repoReq.Visibility = github.String("private")
-	} else {
-		repoReq.Visibility = github.String("public")
-	}
 
 	if template, ok := d.GetOk("template"); ok {
 		templateConfigBlocks := template.([]interface{})
@@ -567,7 +562,7 @@ func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 		log.Printf("[DEBUG] <<<<<<<<<<<<< Updating repository visibility from %s to %s", o, n)
 		_, _, err = client.Repositories.Edit(ctx, owner, repoName, repoReq)
 		if err != nil {
-			if !strings.Contains(err.Error(), "422 Visibility is already private") {
+			if !strings.Contains(err.Error(), fmt.Sprintf("422 Visibility is already %s", n.(string))) {
 				return err
 			}
 		}

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -802,47 +802,49 @@ func TestAccGithubRepositoryVisibility(t *testing.T) {
 
 	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
-	t.Run("creates repos with private visibility", func(t *testing.T) {
+	for _, visibility := range []string{"private", "internal"} {
+		t.Run(fmt.Sprintf("creates repos with %s visibility", visibility), func(t *testing.T) {
 
-		config := fmt.Sprintf(`
-			resource "github_repository" "private" {
-				name       = "tf-acc-test-visibility-private-%s"
-				visibility = "private"
-			}
-		`, randomID)
+			config := fmt.Sprintf(`
+				resource "github_repository" "%[1]s" {
+					name       = "tf-acc-test-visibility-%[1]s-%[2]s"
+					visibility = "%[1]s"
+				}
+			`, visibility, randomID)
 
-		check := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(
-				"github_repository.private", "visibility",
-				"private",
-			),
-		)
+			check := resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					fmt.Sprintf("github_repository.%s", visibility), "visibility",
+					visibility,
+				),
+			)
 
-		testCase := func(t *testing.T, mode string) {
-			resource.Test(t, resource.TestCase{
-				PreCheck:  func() { skipUnlessMode(t, mode) },
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: config,
-						Check:  check,
+			testCase := func(t *testing.T, mode string) {
+				resource.Test(t, resource.TestCase{
+					PreCheck:  func() { skipUnlessMode(t, mode) },
+					Providers: testAccProviders,
+					Steps: []resource.TestStep{
+						{
+							Config: config,
+							Check:  check,
+						},
 					},
-				},
+				})
+			}
+
+			t.Run("with an anonymous account", func(t *testing.T) {
+				t.Skip("anonymous account not supported for this operation")
 			})
-		}
 
-		t.Run("with an anonymous account", func(t *testing.T) {
-			t.Skip("anonymous account not supported for this operation")
-		})
+			t.Run("with an individual account", func(t *testing.T) {
+				testCase(t, individual)
+			})
 
-		t.Run("with an individual account", func(t *testing.T) {
-			testCase(t, individual)
+			t.Run("with an organization account", func(t *testing.T) {
+				testCase(t, organization)
+			})
 		})
-
-		t.Run("with an organization account", func(t *testing.T) {
-			testCase(t, organization)
-		})
-	})
+	}
 
 	t.Run("updates repos to private visibility", func(t *testing.T) {
 

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -844,6 +844,49 @@ func TestAccGithubRepositoryVisibility(t *testing.T) {
 		})
 	})
 
+	t.Run("creates repos with internal visibility", func(t *testing.T) {
+		t.Skip("organization used in automated tests does not support internal repositories")
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "internal" {
+				name       = "tf-acc-test-visibility-internal-%s"
+				visibility = "internal"
+			}
+		`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_repository.internal", "visibility",
+				"internal",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+
 	t.Run("updates repos to private visibility", func(t *testing.T) {
 
 		config := fmt.Sprintf(`

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -802,49 +802,47 @@ func TestAccGithubRepositoryVisibility(t *testing.T) {
 
 	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
-	for _, visibility := range []string{"private", "internal"} {
-		t.Run(fmt.Sprintf("creates repos with %s visibility", visibility), func(t *testing.T) {
+	t.Run("creates repos with private visibility", func(t *testing.T) {
 
-			config := fmt.Sprintf(`
-				resource "github_repository" "%[1]s" {
-					name       = "tf-acc-test-visibility-%[1]s-%[2]s"
-					visibility = "%[1]s"
-				}
-			`, visibility, randomID)
-
-			check := resource.ComposeTestCheckFunc(
-				resource.TestCheckResourceAttr(
-					fmt.Sprintf("github_repository.%s", visibility), "visibility",
-					visibility,
-				),
-			)
-
-			testCase := func(t *testing.T, mode string) {
-				resource.Test(t, resource.TestCase{
-					PreCheck:  func() { skipUnlessMode(t, mode) },
-					Providers: testAccProviders,
-					Steps: []resource.TestStep{
-						{
-							Config: config,
-							Check:  check,
-						},
-					},
-				})
+		config := fmt.Sprintf(`
+			resource "github_repository" "private" {
+				name       = "tf-acc-test-visibility-private-%s"
+				visibility = "private"
 			}
+		`, randomID)
 
-			t.Run("with an anonymous account", func(t *testing.T) {
-				t.Skip("anonymous account not supported for this operation")
-			})
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_repository.private", "visibility",
+				"private",
+			),
+		)
 
-			t.Run("with an individual account", func(t *testing.T) {
-				testCase(t, individual)
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
 			})
+		}
 
-			t.Run("with an organization account", func(t *testing.T) {
-				testCase(t, organization)
-			})
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
 		})
-	}
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
 
 	t.Run("updates repos to private visibility", func(t *testing.T) {
 


### PR DESCRIPTION
Addresses https://github.com/integrations/terraform-provider-github/issues/788

Tested by:
* running the tests in `github/resource_github_repository_test.go` and 
* manually testing by creating an `internal` repository with member credentials in an organization that does not allow members to change repository visibility