### PR TITLE
Modify github_team to accept slug as a valid parent_team_id

### DIFF
--- a/github/resource_github_team.go
+++ b/github/resource_github_team.go
@@ -46,7 +46,7 @@ func resourceGithubTeam() *schema.Resource {
 			"parent_team_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "ID or slug of team",
+				Description: "ID or slug of parent team",
 			},
 			"ldap_dn": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Inspired by #693, This PR add support for declaring `parent_team_id` as a string on `github_team`.

This is especially useful when declaring teams in a loop and so cannot reference the other team object .
