### PR TITLE
[#803] Allow GitHub App PEM data to be passed directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+BREAKING CHANGES:
+
+- Allow GitHub App PEM data to be passed directly ([#803](https://github.com/integrations/terraform-provider-github/issues/803))
+
 ## 4.10.1 (May 25, 2021)
 
 BUG FIXES:

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -5,33 +5,30 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
 	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
+
+	"gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 const (
 	testGitHubAppID             string = "123456789"
 	testGitHubAppInstallationID string = "987654321"
-	testGitHubAppPrivateKeyFile string = "test-fixtures/github-app-key.pem"
 	testGitHubAppPublicKeyFile  string = "test-fixtures/github-app-key.pub"
+	testGitHubAppPrivateKeyFile string = "test-fixtures/github-app-key.pem"
 )
 
 var (
 	testEpochTime = time.Unix(0, 0)
+
+	testGitHubAppPrivateKeyPemData, _ = ioutil.ReadFile(testGitHubAppPrivateKeyFile)
 )
 
 func TestGenerateAppJWT(t *testing.T) {
-	pemData, err := ioutil.ReadFile(testGitHubAppPrivateKeyFile)
-	if err != nil {
-		t.Logf("Failed to read private key file '%s': %s", testGitHubAppPrivateKeyFile, err)
-		t.FailNow()
-	}
-
-	appJWT, err := generateAppJWT(testGitHubAppID, testEpochTime, pemData)
+	appJWT, err := generateAppJWT(testGitHubAppID, testEpochTime, testGitHubAppPrivateKeyPemData)
 	t.Log(appJWT)
 	if err != nil {
 		t.Logf("Failed to generate GitHub app JWT: %s", err)

--- a/github/provider.go
+++ b/github/provider.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -150,7 +151,7 @@ func init() {
 			"`token`. Anonymous mode is enabled if both `token` and `app_auth` are not set.",
 		"app_auth.id":              "The GitHub App ID.",
 		"app_auth.installation_id": "The GitHub App installation instance ID.",
-		"app_auth.pem_file":        "The GitHub App PEM file path.",
+		"app_auth.pem_file":        "The GitHub App PEM file contents.",
 	}
 }
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -104,7 +104,9 @@ The following arguments are supported in the `provider` block:
 * `app_auth` - (Optional) Configuration block to use GitHub App installation token. When not provided, the provider can only access resources available anonymously.
   * `id` - (Required) This is the ID of the GitHub App. It can sourced from the `GITHUB_APP_ID` environment variable.
   * `installation_id` - (Required) This is the ID of the GitHub App installation. It can sourced from the `GITHUB_APP_INSTALLATION_ID` environment variable.
-  * `pem_file` - (Required) This is the path to the GitHub App private key file. It can sourced from the `GITHUB_APP_PEM_FILE` environment variable.
+  * `pem_file` - (Required) This is the contents of the GitHub App private key PEM file. It can also be sourced from the `GITHUB_APP_PEM_FILE` environment variable.
+
+Note: If you have a PEM file on disk, you can pass it in via `pem_file = file("path/to/file.pem")`.
 
 For backwards compatibility, if more than one of `owner`, `organization`,
 `GITHUB_OWNER` and `GITHUB_ORGANIZATION` are set, the first in this


### PR DESCRIPTION
This is a generic (but breaking) solution to #803 that supports the current functionality via Terraform's `file` function to emulate previous behavior (wherein you provide a path to a PEM file).

This is cleaner and simpler than providing more named options for file contents, and the original behavior has only been around for a few days or weeks, so it's a good time to break it (and it's trivial to emulate with `file()`).

We've tested it with our real workspace in Terraform Cloud. It's also the only way we can use this feature, because that private key cannot be secured any other way and has root access to everything.