### PR TITLE
Return nil instead of 404 error if branch does not exist

### DIFF
--- a/github/data_source_github_branch_test.go
+++ b/github/data_source_github_branch_test.go
@@ -59,4 +59,51 @@ func TestAccGithubBranchDataSource(t *testing.T) {
 		})
 
 	})
+
+	t.Run("queries an invalid branch without error", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+			  name = "tf-acc-test-%[1]s"
+				auto_init = true
+			}
+
+			data "github_branch" "test" {
+				repository = github_repository.test.id
+				branch = "xxxxxx"
+			}
+		`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckNoResourceAttr(
+				"data.github_branch.test", "id",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
 }


### PR DESCRIPTION
Fixes #747 - github_branch needs to not fail if branch doesn't exist