### PR TITLE
Fix a possible typo on setDismissalActorIDs

### DIFF
--- a/github/util_v4_branch_protection.go
+++ b/github/util_v4_branch_protection.go
@@ -190,7 +190,7 @@ func setDismissalActorIDs(actors []DismissalActorTypes) []string {
 			pushActors = append(pushActors, a.Actor.Team.ID.(string))
 		}
 		if a.Actor.User != (Actor{}) {
-			pushActors = append(pushActors, a.Actor.Team.ID.(string))
+			pushActors = append(pushActors, a.Actor.User.ID.(string))
 		}
 	}
 


### PR DESCRIPTION
## Description
A simple PR for a typo.

There seems to be a typo in the setDismissalActorIDs func, this PR is to simply fix that if it was really unintended.

## Reason
While using the provider, my team and I have realized that `github_branch_protection:push_restrictions` does not change on the first terraform application and somehow only gets queued for change on the second time. It was a really weird bug, and it might be due to this.

If this PR is a non-issue, I will open an issue with more descriptions regarding it.