### PR TITLE
New Resource: github_actions_runner_group

### DIFF
--- a/github/provider.go
+++ b/github/provider.go
@@ -78,6 +78,7 @@ func Provider() terraform.ResourceProvider {
 			"github_actions_environment_secret":               resourceGithubActionsEnvironmentSecret(),
 			"github_actions_organization_secret":              resourceGithubActionsOrganizationSecret(),
 			"github_actions_organization_secret_repositories": resourceGithubActionsOrganizationSecretRepositories(),
+			"github_actions_runner_group":                     resourceGithubActionsRunnerGroup(),
 			"github_actions_secret":                           resourceGithubActionsSecret(),
 			"github_app_installation_repository":              resourceGithubAppInstallationRepository(),
 			"github_branch":                                   resourceGithubBranch(),

--- a/github/resource_github_actions_runner_group.go
+++ b/github/resource_github_actions_runner_group.go
@@ -1,0 +1,225 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/google/go-github/v35/github"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceGithubActionsRunnerGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGithubActionsRunnerGroupCreate,
+		Read:   resourceGithubActionsRunnerGroupRead,
+		Update: resourceGithubActionsRunnerGroupUpdate,
+		Delete: resourceGithubActionsRunnerGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"allows_public_repositories": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"default": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"etag": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"inherited": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"runners_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"selected_repository_ids": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeInt,
+				},
+				Set:      schema.HashInt,
+				Optional: true,
+			},
+			"selected_repositories_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"visibility": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"all", "selected", "private"}, false),
+			},
+		},
+	}
+}
+
+func resourceGithubActionsRunnerGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	err := checkOrganization(meta)
+	if err != nil {
+		return err
+	}
+
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
+	name := d.Get("name").(string)
+	visibility := d.Get("visibility").(string)
+	selectedRepositories, hasSelectedRepositories := d.GetOk("selected_repository_ids")
+
+	if visibility != "selected" && hasSelectedRepositories {
+		return fmt.Errorf("Cannot use selected_repository_ids without visibility being set to selected")
+	}
+
+	selectedRepositoryIDs := []int64{}
+
+	if hasSelectedRepositories {
+		ids := selectedRepositories.(*schema.Set).List()
+
+		for _, id := range ids {
+			selectedRepositoryIDs = append(selectedRepositoryIDs, int64(id.(int)))
+		}
+	}
+
+	// TODO: also get runners
+	// runners := d.Get("runners").([]int64)
+	ctx := context.Background()
+
+	log.Printf("[DEBUG] Creating organization runner group: %s (%s)", name, orgName)
+	runnerGroup, resp, err := client.Actions.CreateOrganizationRunnerGroup(ctx,
+		orgName,
+		github.CreateRunnerGroupRequest{
+			Name:                  &name,
+			Visibility:            &visibility,
+			SelectedRepositoryIDs: selectedRepositoryIDs,
+			// TODO
+			// Runners:               runners,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	d.SetId(strconv.FormatInt(runnerGroup.GetID(), 10))
+	d.Set("etag", resp.Header.Get("ETag"))
+	d.Set("allows_public_repositories", runnerGroup.GetAllowsPublicRepositories())
+	d.Set("default", runnerGroup.GetDefault())
+	d.Set("id", runnerGroup.GetID())
+	d.Set("inherited", runnerGroup.GetInherited())
+	d.Set("name", runnerGroup.GetName())
+	d.Set("runners_url", runnerGroup.GetRunnersURL())
+	d.Set("selected_repositories_url", runnerGroup.GetSelectedRepositoriesURL())
+	d.Set("visibility", runnerGroup.GetVisibility())
+
+	return resourceGithubActionsRunnerGroupRead(d, meta)
+}
+
+func resourceGithubActionsRunnerGroupRead(d *schema.ResourceData, meta interface{}) error {
+	err := checkOrganization(meta)
+	if err != nil {
+		return err
+	}
+
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
+
+	runnerGroupID, err := strconv.ParseInt(d.Id(), 10, 64)
+	if err != nil {
+		return err
+	}
+	ctx := context.WithValue(context.Background(), ctxId, d.Id())
+	if !d.IsNewResource() {
+		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
+	}
+
+	log.Printf("[DEBUG] Reading organization runner group: %s (%s)", d.Id(), orgName)
+	runnerGroup, resp, err := client.Actions.GetOrganizationRunnerGroup(ctx, orgName, runnerGroupID)
+	if err != nil {
+		if ghErr, ok := err.(*github.ErrorResponse); ok {
+			if ghErr.Response.StatusCode == http.StatusNotModified {
+				return nil
+			}
+			if ghErr.Response.StatusCode == http.StatusNotFound {
+				log.Printf("[WARN] Removing organization runner group %s/%s from state because it no longer exists in GitHub",
+					orgName, d.Id())
+				d.SetId("")
+				return nil
+			}
+		}
+		return err
+	}
+
+	d.Set("etag", resp.Header.Get("ETag"))
+	d.Set("allows_public_repositories", runnerGroup.GetAllowsPublicRepositories())
+	d.Set("default", runnerGroup.GetDefault())
+	d.Set("id", runnerGroup.GetID())
+	d.Set("inherited", runnerGroup.GetInherited())
+	d.Set("name", runnerGroup.GetName())
+	d.Set("runners_url", runnerGroup.GetRunnersURL())
+	d.Set("selected_repositories_url", runnerGroup.GetSelectedRepositoriesURL())
+	d.Set("visibility", runnerGroup.GetVisibility())
+
+	return nil
+}
+
+func resourceGithubActionsRunnerGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	err := checkOrganization(meta)
+	if err != nil {
+		return err
+	}
+
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
+
+	name := d.Get("name").(string)
+	visibility := d.Get("visibility").(string)
+
+	options := github.UpdateRunnerGroupRequest{
+		Name:       &name,
+		Visibility: &visibility,
+	}
+
+	runnerGroupID, err := strconv.ParseInt(d.Id(), 10, 64)
+	if err != nil {
+		return err
+	}
+	ctx := context.WithValue(context.Background(), ctxId, d.Id())
+
+	log.Printf("[DEBUG] Updating organization runner group: %s (%s)", d.Id(), orgName)
+	if _, _, err := client.Actions.UpdateOrganizationRunnerGroup(ctx, orgName, runnerGroupID, options); err != nil {
+		return err
+	}
+
+	return resourceGithubActionsRunnerGroupRead(d, meta)
+}
+
+func resourceGithubActionsRunnerGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	err := checkOrganization(meta)
+	if err != nil {
+		return err
+	}
+
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
+	runnerGroupID, err := strconv.ParseInt(d.Id(), 10, 64)
+	if err != nil {
+		return err
+	}
+	ctx := context.WithValue(context.Background(), ctxId, d.Id())
+
+	log.Printf("[DEBUG] Deleting organization runner group: %s (%s)", d.Id(), orgName)
+	_, err = client.Actions.DeleteOrganizationRunnerGroup(ctx, orgName, runnerGroupID)
+	return err
+}

--- a/github/resource_github_actions_runner_group.go
+++ b/github/resource_github_actions_runner_group.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/google/go-github/v36/github"
+	"github.com/google/go-github/v38/github"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )

--- a/github/resource_github_actions_runner_group.go
+++ b/github/resource_github_actions_runner_group.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/google/go-github/v35/github"
+	"github.com/google/go-github/v36/github"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )

--- a/github/resource_github_actions_runner_group.go
+++ b/github/resource_github_actions_runner_group.go
@@ -169,7 +169,7 @@ func resourceGithubActionsRunnerGroupRead(d *schema.ResourceData, meta interface
 	d.Set("visibility", runnerGroup.GetVisibility())
 
 	log.Printf("[DEBUG] Reading organization runner group repositories: %s (%s)", d.Id(), orgName)
-	runnerGroupRepositories, resp, err := client.Actions.ListRepositoryAccessRunnerGroup(ctx, orgName, runnerGroupID)
+	runnerGroupRepositories, _, err := client.Actions.ListRepositoryAccessRunnerGroup(ctx, orgName, runnerGroupID)
 	if err != nil {
 		return err
 	}

--- a/github/resource_github_actions_runner_group.go
+++ b/github/resource_github_actions_runner_group.go
@@ -170,6 +170,9 @@ func resourceGithubActionsRunnerGroupRead(d *schema.ResourceData, meta interface
 
 	log.Printf("[DEBUG] Reading organization runner group repositories: %s (%s)", d.Id(), orgName)
 	runnerGroupRepositories, resp, err := client.Actions.ListRepositoryAccessRunnerGroup(ctx, orgName, runnerGroupID)
+	if err != nil {
+		return err
+	}
 
 	selectedRepositoryIDs := []int64{}
 	for _, repo := range runnerGroupRepositories.Repositories {

--- a/github/resource_github_actions_runner_group_test.go
+++ b/github/resource_github_actions_runner_group_test.go
@@ -1,0 +1,249 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v35/github"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccGithubActionsRunnerGroup_all(t *testing.T) {
+	// ???
+	// resource_github_actions_runner_group_test.go:19: Skipping because GITHUB_OWNER is a user, not an organization.
+	// if err := testAccCheckOrganization(); err != nil {
+	// t.Skipf("Skipping because %s.", err.Error())
+	// }
+
+	var runnerGroup github.RunnerGroup
+
+	var testAccGithubActionsRunnerGroupConfigAll = `
+resource "github_actions_runner_group" "test_all" {
+  name = "test-runner-group-all"
+  visibility = "all"
+}
+`
+	rn := "github_actions_runner_group.test_all"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGithubActionsRunnerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGithubActionsRunnerGroupConfigAll,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGithubActionsRunnerGroupExists(rn, &runnerGroup),
+					testAccCheckGithubActionsRunnerGroupAttributes(&runnerGroup, &testAccGithubActionsRunnerGroupExpectedAttributes{
+						Name:                     "test-runner-group-all",
+						Visibility:               "all",
+						Default:                  false,
+						AllowsPublicRepositories: false,
+						RunnersURL:               fmt.Sprintf(`https://api.github.com/orgs/octo-org/actions/runner_groups/%d/runners`, runnerGroup.ID),
+						SelectedRepositoriesURL:  fmt.Sprintf(`https://api.github.com/orgs/octo-org/actions/runner_groups/%d/repositories`, runnerGroup.ID),
+					}),
+				),
+			},
+			{
+				ResourceName:      rn,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccGithubActionsRunnerGroup_private(t *testing.T) {
+	// ???
+	// resource_github_actions_runner_group_test.go:19: Skipping because GITHUB_OWNER is a user, not an organization.
+	// if err := testAccCheckOrganization(); err != nil {
+	// t.Skipf("Skipping because %s.", err.Error())
+	// }
+
+	var runnerGroup github.RunnerGroup
+
+	rn := "github_actions_runner_group.test_private"
+	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+	var testAccGithubActionsRunnerGroupConfigPrivate = fmt.Sprintf(`
+resource "github_repository" "test" {
+  name = "tf-acc-test-%s"
+  visibility = "private"
+}
+resource "github_actions_runner_group" "test_private" {
+  name = "test-runner-group-private"
+  visibility = "private"
+}
+`, randomID)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGithubActionsRunnerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGithubActionsRunnerGroupConfigPrivate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGithubActionsRunnerGroupExists(rn, &runnerGroup),
+					testAccCheckGithubActionsRunnerGroupAttributes(&runnerGroup, &testAccGithubActionsRunnerGroupExpectedAttributes{
+						Name:                     "test-runner-group-private",
+						Visibility:               "private",
+						Default:                  false,
+						AllowsPublicRepositories: false,
+						RunnersURL:               fmt.Sprintf(`https://api.github.com/orgs/octo-org/actions/runner_groups/%d/runners`, runnerGroup.ID),
+						SelectedRepositoriesURL:  fmt.Sprintf(`https://api.github.com/orgs/octo-org/actions/runner_groups/%d/repositories`, runnerGroup.ID),
+					}),
+				),
+			},
+			{
+				ResourceName:      rn,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccGithubActionsRunnerGroup_selected(t *testing.T) {
+	// ???
+	// resource_github_actions_runner_group_test.go:19: Skipping because GITHUB_OWNER is a user, not an organization.
+	// if err := testAccCheckOrganization(); err != nil {
+	// t.Skipf("Skipping because %s.", err.Error())
+	// }
+
+	var runnerGroup github.RunnerGroup
+
+	rn := "github_actions_runner_group.test_selected"
+	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+	var testAccGithubActionsRunnerGroupConfigSelected = fmt.Sprintf(`
+resource "github_repository" "test" {
+  name = "tf-acc-test-%s"
+  auto_init = true
+}
+
+resource "github_actions_runner_group" "test_selected" {
+  name = "test-runner-group-selected"
+  visibility = "selected"
+  selected_repository_ids = [github_repository.test.repo_id]
+}
+`, randomID)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGithubActionsRunnerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGithubActionsRunnerGroupConfigSelected,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGithubActionsRunnerGroupExists(rn, &runnerGroup),
+					testAccCheckGithubActionsRunnerGroupAttributes(&runnerGroup, &testAccGithubActionsRunnerGroupExpectedAttributes{
+						Name:                     "test-runner-group-selected",
+						Visibility:               "selected",
+						Default:                  false,
+						AllowsPublicRepositories: false,
+						RunnersURL:               fmt.Sprintf(`https://api.github.com/orgs/octo-org/actions/runner_groups/%d/runners`, runnerGroup.ID),
+						SelectedRepositoriesURL:  fmt.Sprintf(`https://api.github.com/orgs/octo-org/actions/runner_groups/%d/repositories`, runnerGroup.ID),
+					}),
+				),
+			},
+			{
+				ResourceName:      rn,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccGithubActionsRunnerGroupDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*Owner).v3client
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "github_actions_runner_group" {
+			continue
+		}
+
+		runnerGroupID, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
+		if err != nil {
+			return err
+		}
+
+		orgName := testAccProvider.Meta().(*Owner).name
+		runnerGroup, res, err := conn.Actions.GetOrganizationRunnerGroup(context.TODO(), orgName, runnerGroupID)
+		if err == nil {
+			if runnerGroup != nil &&
+				runnerGroup.GetID() == runnerGroupID {
+				return fmt.Errorf("Organization runner group still exists")
+			}
+		}
+		if res.StatusCode != 404 {
+			return err
+		}
+		return nil
+	}
+	return nil
+}
+
+func testAccCheckGithubActionsRunnerGroupExists(n string, runnerGroup *github.RunnerGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not Found: %s", n)
+		}
+
+		runnerGroupID, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
+		if err != nil {
+			return err
+		}
+
+		conn := testAccProvider.Meta().(*Owner).v3client
+		orgName := testAccProvider.Meta().(*Owner).name
+		gotRunnerGroup, _, err := conn.Actions.GetOrganizationRunnerGroup(context.TODO(), orgName, runnerGroupID)
+		if err != nil {
+			return err
+		}
+		*runnerGroup = *gotRunnerGroup
+		return nil
+	}
+}
+
+type testAccGithubActionsRunnerGroupExpectedAttributes struct {
+	AllowsPublicRepositories bool
+	Default                  bool
+	ID                       int64
+	Inherited                bool
+	Name                     string
+	Runners                  []int64
+	RunnersURL               string
+	SelectedRepositoriesURL  string
+	SelectedRepositoryIDs    []int64
+	Visibility               string
+}
+
+func testAccCheckGithubActionsRunnerGroupAttributes(runnerGroup *github.RunnerGroup, want *testAccGithubActionsRunnerGroupExpectedAttributes) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if name := runnerGroup.GetName(); name != want.Name {
+			return fmt.Errorf("got runnerGroup name %q; want %q", name, want.Name)
+		}
+		if visibility := runnerGroup.GetVisibility(); visibility != want.Visibility {
+			return fmt.Errorf("got runnerGroup visibility %q; want %q", visibility, want.Visibility)
+		}
+		if inherited := runnerGroup.GetInherited(); inherited != want.Inherited {
+			return fmt.Errorf("got runnerGroup inherited %t; want %t", inherited, want.Inherited)
+		}
+		if URL := runnerGroup.GetRunnersURL(); !strings.HasPrefix(URL, "https://") {
+			return fmt.Errorf("got runners URL %q; want to start with 'https://'", URL)
+		}
+		if isDefault := runnerGroup.GetDefault(); isDefault != want.Default {
+			return fmt.Errorf("got runnerGroup default %t; want %t", isDefault, want.Default)
+		}
+
+		return nil
+	}
+}

--- a/github/resource_github_actions_runner_group_test.go
+++ b/github/resource_github_actions_runner_group_test.go
@@ -243,6 +243,10 @@ func TestAccGithubActionsRunnerGroup(t *testing.T) {
 		check := resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttrSet("github_actions_runner_group.test", "name"),
 			resource.TestCheckResourceAttrSet("github_actions_runner_group.test", "visibility"),
+			resource.TestCheckResourceAttr(
+				"github_actions_runner_group.test", "selected_repository_ids.#",
+				"1",
+			),
 		)
 
 		testCase := func(t *testing.T, mode string) {

--- a/github/resource_github_actions_runner_group_test.go
+++ b/github/resource_github_actions_runner_group_test.go
@@ -34,6 +34,10 @@ func TestAccGithubActionsRunnerGroup(t *testing.T) {
 				"github_actions_runner_group.test", "name",
 			),
 			resource.TestCheckResourceAttr(
+				"github_actions_runner_group.test", "name",
+				fmt.Sprintf(`tf-acc-test-%s`, randomID),
+			),
+			resource.TestCheckResourceAttr(
 				"github_actions_runner_group.test", "visibility",
 				"all",
 			),
@@ -84,6 +88,10 @@ func TestAccGithubActionsRunnerGroup(t *testing.T) {
 		check := resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttrSet(
 				"github_actions_runner_group.test", "name",
+			),
+			resource.TestCheckResourceAttr(
+				"github_actions_runner_group.test", "name",
+				fmt.Sprintf(`tf-acc-test-%s`, randomID),
 			),
 			resource.TestCheckResourceAttr(
 				"github_actions_runner_group.test", "visibility",
@@ -140,6 +148,7 @@ func TestAccGithubActionsRunnerGroup(t *testing.T) {
 			resource.TestCheckResourceAttrSet("github_actions_runner_group.test", "name"),
 			resource.TestCheckResourceAttrSet("github_actions_runner_group.test", "visibility"),
 			resource.TestCheckResourceAttr("github_actions_runner_group.test", "visibility", "all"),
+			resource.TestCheckResourceAttr("github_actions_runner_group.test", "name", fmt.Sprintf(`tf-acc-test-%s`, randomID)),
 		)
 
 		testCase := func(t *testing.T, mode string) {
@@ -173,7 +182,6 @@ func TestAccGithubActionsRunnerGroup(t *testing.T) {
 		})
 	})
 
-	// This test is currently skipped due to the perpetual diff in runner group visibility when creating a private runner group.
 	t.Run("imports a private runner group without error", func(t *testing.T) {
 		config := fmt.Sprintf(`
 					resource "github_repository" "test" {
@@ -188,6 +196,7 @@ func TestAccGithubActionsRunnerGroup(t *testing.T) {
 
 		check := resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttrSet("github_actions_runner_group.test", "name"),
+			resource.TestCheckResourceAttr("github_actions_runner_group.test", "name", fmt.Sprintf(`tf-acc-test-%s`, randomID)),
 			resource.TestCheckResourceAttrSet("github_actions_runner_group.test", "visibility"),
 		)
 
@@ -230,19 +239,21 @@ func TestAccGithubActionsRunnerGroup(t *testing.T) {
 
 		config := fmt.Sprintf(`
 			resource "github_repository" "test" {
-			  name = "tf-acc-test-%s"
+				name = "tf-acc-test-%s"
 			}
 
 			resource "github_actions_runner_group" "test" {
-			  name       = github_repository.test.name
-			  visibility = "selected"
-			  selected_repository_ids = [github_repository.test.repo_id]
+				name       = github_repository.test.name
+				visibility = "selected"
+				selected_repository_ids = [github_repository.test.repo_id]
 			}
     `, randomID)
 
 		check := resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttrSet("github_actions_runner_group.test", "name"),
+			resource.TestCheckResourceAttr("github_actions_runner_group.test", "name", fmt.Sprintf(`tf-acc-test-%s`, randomID)),
 			resource.TestCheckResourceAttrSet("github_actions_runner_group.test", "visibility"),
+			resource.TestCheckResourceAttr("github_actions_runner_group.test", "visibility", "selected"),
 			resource.TestCheckResourceAttr(
 				"github_actions_runner_group.test", "selected_repository_ids.#",
 				"1",

--- a/github/resource_github_actions_runner_group_test.go
+++ b/github/resource_github_actions_runner_group_test.go
@@ -1,249 +1,124 @@
 package github
 
 import (
-	"context"
 	"fmt"
-	"strconv"
-	"strings"
 	"testing"
 
-	"github.com/google/go-github/v35/github"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccGithubActionsRunnerGroup_all(t *testing.T) {
-	// ???
-	// resource_github_actions_runner_group_test.go:19: Skipping because GITHUB_OWNER is a user, not an organization.
-	// if err := testAccCheckOrganization(); err != nil {
-	// t.Skipf("Skipping because %s.", err.Error())
-	// }
+func TestAccGithubActionsRunnerGroup(t *testing.T) {
 
-	var runnerGroup github.RunnerGroup
-
-	var testAccGithubActionsRunnerGroupConfigAll = `
-resource "github_actions_runner_group" "test_all" {
-  name = "test-runner-group-all"
-  visibility = "all"
-}
-`
-	rn := "github_actions_runner_group.test_all"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccGithubActionsRunnerGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccGithubActionsRunnerGroupConfigAll,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGithubActionsRunnerGroupExists(rn, &runnerGroup),
-					testAccCheckGithubActionsRunnerGroupAttributes(&runnerGroup, &testAccGithubActionsRunnerGroupExpectedAttributes{
-						Name:                     "test-runner-group-all",
-						Visibility:               "all",
-						Default:                  false,
-						AllowsPublicRepositories: false,
-						RunnersURL:               fmt.Sprintf(`https://api.github.com/orgs/octo-org/actions/runner_groups/%d/runners`, runnerGroup.ID),
-						SelectedRepositoriesURL:  fmt.Sprintf(`https://api.github.com/orgs/octo-org/actions/runner_groups/%d/repositories`, runnerGroup.ID),
-					}),
-				),
-			},
-			{
-				ResourceName:      rn,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccGithubActionsRunnerGroup_private(t *testing.T) {
-	// ???
-	// resource_github_actions_runner_group_test.go:19: Skipping because GITHUB_OWNER is a user, not an organization.
-	// if err := testAccCheckOrganization(); err != nil {
-	// t.Skipf("Skipping because %s.", err.Error())
-	// }
-
-	var runnerGroup github.RunnerGroup
-
-	rn := "github_actions_runner_group.test_private"
 	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-	var testAccGithubActionsRunnerGroupConfigPrivate = fmt.Sprintf(`
-resource "github_repository" "test" {
-  name = "tf-acc-test-%s"
-  visibility = "private"
-}
-resource "github_actions_runner_group" "test_private" {
-  name = "test-runner-group-private"
-  visibility = "private"
-}
-`, randomID)
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccGithubActionsRunnerGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccGithubActionsRunnerGroupConfigPrivate,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGithubActionsRunnerGroupExists(rn, &runnerGroup),
-					testAccCheckGithubActionsRunnerGroupAttributes(&runnerGroup, &testAccGithubActionsRunnerGroupExpectedAttributes{
-						Name:                     "test-runner-group-private",
-						Visibility:               "private",
-						Default:                  false,
-						AllowsPublicRepositories: false,
-						RunnersURL:               fmt.Sprintf(`https://api.github.com/orgs/octo-org/actions/runner_groups/%d/runners`, runnerGroup.ID),
-						SelectedRepositoriesURL:  fmt.Sprintf(`https://api.github.com/orgs/octo-org/actions/runner_groups/%d/repositories`, runnerGroup.ID),
-					}),
-				),
-			},
-			{
-				ResourceName:      rn,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
+	t.Run("creates runner groups without error", func(t *testing.T) {
 
-func TestAccGithubActionsRunnerGroup_selected(t *testing.T) {
-	// ???
-	// resource_github_actions_runner_group_test.go:19: Skipping because GITHUB_OWNER is a user, not an organization.
-	// if err := testAccCheckOrganization(); err != nil {
-	// t.Skipf("Skipping because %s.", err.Error())
-	// }
+		t.Skip("requires an enterprise cloud account")
 
-	var runnerGroup github.RunnerGroup
-
-	rn := "github_actions_runner_group.test_selected"
-	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-	var testAccGithubActionsRunnerGroupConfigSelected = fmt.Sprintf(`
-resource "github_repository" "test" {
-  name = "tf-acc-test-%s"
-  auto_init = true
-}
-
-resource "github_actions_runner_group" "test_selected" {
-  name = "test-runner-group-selected"
-  visibility = "selected"
-  selected_repository_ids = [github_repository.test.repo_id]
-}
-`, randomID)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccGithubActionsRunnerGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccGithubActionsRunnerGroupConfigSelected,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGithubActionsRunnerGroupExists(rn, &runnerGroup),
-					testAccCheckGithubActionsRunnerGroupAttributes(&runnerGroup, &testAccGithubActionsRunnerGroupExpectedAttributes{
-						Name:                     "test-runner-group-selected",
-						Visibility:               "selected",
-						Default:                  false,
-						AllowsPublicRepositories: false,
-						RunnersURL:               fmt.Sprintf(`https://api.github.com/orgs/octo-org/actions/runner_groups/%d/runners`, runnerGroup.ID),
-						SelectedRepositoriesURL:  fmt.Sprintf(`https://api.github.com/orgs/octo-org/actions/runner_groups/%d/repositories`, runnerGroup.ID),
-					}),
-				),
-			},
-			{
-				ResourceName:      rn,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func testAccGithubActionsRunnerGroupDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Owner).v3client
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "github_actions_runner_group" {
-			continue
-		}
-
-		runnerGroupID, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
-		if err != nil {
-			return err
-		}
-
-		orgName := testAccProvider.Meta().(*Owner).name
-		runnerGroup, res, err := conn.Actions.GetOrganizationRunnerGroup(context.TODO(), orgName, runnerGroupID)
-		if err == nil {
-			if runnerGroup != nil &&
-				runnerGroup.GetID() == runnerGroupID {
-				return fmt.Errorf("Organization runner group still exists")
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+			  name = "tf-acc-test-%s"
+			  vulnerability_alerts = false
 			}
-		}
-		if res.StatusCode != 404 {
-			return err
-		}
-		return nil
-	}
-	return nil
-}
 
-func testAccCheckGithubActionsRunnerGroupExists(n string, runnerGroup *github.RunnerGroup) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not Found: %s", n)
-		}
+			resource "github_actions_runner_group" "test" {
+			  name       = github_repository.test.name
+			  visibility = "all"
+			}
+		`, randomID)
 
-		runnerGroupID, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
-		if err != nil {
-			return err
-		}
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttrSet(
+				"github_actions_runner_group.test", "name",
+			),
+			resource.TestCheckResourceAttr(
+				"github_actions_runner_group.test", "visibility",
+				"all",
+			),
+		)
 
-		conn := testAccProvider.Meta().(*Owner).v3client
-		orgName := testAccProvider.Meta().(*Owner).name
-		gotRunnerGroup, _, err := conn.Actions.GetOrganizationRunnerGroup(context.TODO(), orgName, runnerGroupID)
-		if err != nil {
-			return err
-		}
-		*runnerGroup = *gotRunnerGroup
-		return nil
-	}
-}
-
-type testAccGithubActionsRunnerGroupExpectedAttributes struct {
-	AllowsPublicRepositories bool
-	Default                  bool
-	ID                       int64
-	Inherited                bool
-	Name                     string
-	Runners                  []int64
-	RunnersURL               string
-	SelectedRepositoriesURL  string
-	SelectedRepositoryIDs    []int64
-	Visibility               string
-}
-
-func testAccCheckGithubActionsRunnerGroupAttributes(runnerGroup *github.RunnerGroup, want *testAccGithubActionsRunnerGroupExpectedAttributes) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-
-		if name := runnerGroup.GetName(); name != want.Name {
-			return fmt.Errorf("got runnerGroup name %q; want %q", name, want.Name)
-		}
-		if visibility := runnerGroup.GetVisibility(); visibility != want.Visibility {
-			return fmt.Errorf("got runnerGroup visibility %q; want %q", visibility, want.Visibility)
-		}
-		if inherited := runnerGroup.GetInherited(); inherited != want.Inherited {
-			return fmt.Errorf("got runnerGroup inherited %t; want %t", inherited, want.Inherited)
-		}
-		if URL := runnerGroup.GetRunnersURL(); !strings.HasPrefix(URL, "https://") {
-			return fmt.Errorf("got runners URL %q; want to start with 'https://'", URL)
-		}
-		if isDefault := runnerGroup.GetDefault(); isDefault != want.Default {
-			return fmt.Errorf("got runnerGroup default %t; want %t", isDefault, want.Default)
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
 		}
 
-		return nil
-	}
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			t.Skip("individual account not supported for this operation")
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+
+	t.Run("manages runner visibility", func(t *testing.T) {
+
+		t.Skip("requires an enterprise cloud account")
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+			  name = "tf-acc-test-%s"
+			}
+
+			resource "github_actions_runner_group" "test" {
+			  name       = github_repository.test.name
+			  visibility = "selected"
+			  selected_repository_ids = [github_repository.test.repo_id]
+			}
+		`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttrSet(
+				"github_actions_runner_group.test", "name",
+			),
+			resource.TestCheckResourceAttr(
+				"github_actions_runner_group.test", "visibility",
+				"selected",
+			),
+			resource.TestCheckResourceAttr(
+				"github_actions_runner_group.test", "selected_repository_ids.#",
+				"1",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			t.Skip("individual account not supported for this operation")
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+
 }

--- a/website/docs/r/actions_runner_group.html.markdown
+++ b/website/docs/r/actions_runner_group.html.markdown
@@ -1,0 +1,52 @@
+---
+layout: "github"
+page_title: "GitHub: github_actions_runner_group"
+description: |-
+  Creates and manages an Actions Runner Group within a GitHub organization
+---
+
+# github_actions_runner_group
+
+This resource allows you to create and manage GitHub Actions runner groups within your GitHub enterprise organizations.
+You must have admin access to an organization to use this resource.
+
+## Example Usage
+
+```hcl
+resource "github_repository" "example" {
+  name = "my-repository"
+}
+
+resource "github_actions_runner_group" "example" {
+  name                    = github_repository.example.name
+  visibility              = "selected"
+  selected_repository_ids = [github_repository.example.repo_id]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name`                    - (Required) Name of the runner group
+* `selected_repository_ids` - (Optional) IDs of the repositories which should be added to the runner group
+* `visibility`              - (Optional) Visibility of a runner group. Whether the runner group can include `all`, `selected`, or `private` repositories
+
+## Attributes Reference
+
+* `allows_public_repositories` - Whether public repositories can be added to the runner group
+* `default`                    - Whether this is the default runner group
+* `etag`                       - An etag representing the runner group object
+* `inherited`                  - Whether the runner group is inherited from the enterprise level
+* `runners_url`                - The GitHub API URL for the runner group's runners
+* `selected_repository_ids`    - List of repository IDs that can access the runner group
+* `selected_repositories_url`  - Github API URL for the runner group's repositories
+* `visibility`                 - The visibility of the runner group
+
+## Import
+
+This resource can be imported using the ID of the runner group:
+
+```
+$ terraform import github_actions_runner_group.test 7
+```

--- a/website/docs/r/actions_runner_group.html.markdown
+++ b/website/docs/r/actions_runner_group.html.markdown
@@ -30,7 +30,7 @@ The following arguments are supported:
 
 * `name`                    - (Required) Name of the runner group
 * `selected_repository_ids` - (Optional) IDs of the repositories which should be added to the runner group
-* `visibility`              - (Optional) Visibility of a runner group. Whether the runner group can include `all`, `selected`, or `private` repositories
+* `visibility`              - (Optional) Visibility of a runner group. Whether the runner group can include `all`, `selected`, or `private` repositories. A value of `private` is not currently supported due to limitations in the GitHub API.
 
 ## Attributes Reference
 

--- a/website/github.erb
+++ b/website/github.erb
@@ -68,6 +68,9 @@
               <a href="/docs/providers/github/r/actions_organization_secret_repositories.html">github_actions_organization_secret_repositories</a>
             </li>
             <li>
+              <a href="/docs/providers/github/r/actions_runner_group.html">github_actions_runner_group</a>
+            </li>
+            <li>
               <a href="/docs/providers/github/r/actions_secret.html">github_actions_secret</a>
             </li>
             <li>


### PR DESCRIPTION
(Disclaimer: this is my first time working on a Terraform provider, and this PR is still a work in progress)

This PR is intended to add support for self-hosted runner groups in GitHub Actions as described in https://docs.github.com/en/rest/reference/actions#self-hosted-runner-groups.



### My questions

1. The [docs][1] have a documented parameter `visibility` which should accept `private` as an option. But I can't get a runner group with `visibility = private` through any combination of `POST` or `PATCH` calls I've tried (details below). Should I still attempt to add support for this?
2. The docs do _not_ have a documented `allows_public_repositories` parameter, but providing this parameter seems to have an effect. Should I add support for this?

#### 1. visibility = private?

I added tests, but the one that tests `visibility = true` is failing.

<details>
<summary>
Output of failing test for a runner group with `visibility = private`
</summary>

```
$ TF_LOG= TF_ACC=1  go test -v   ./... -run ^TestAccGithubActionsRunnerGroup
?   	github.com/terraform-providers/terraform-provider-github	[no test files]
=== RUN   TestAccGithubActionsRunnerGroup_all
=== PAUSE TestAccGithubActionsRunnerGroup_all
=== RUN   TestAccGithubActionsRunnerGroup_private
=== PAUSE TestAccGithubActionsRunnerGroup_private
=== RUN   TestAccGithubActionsRunnerGroup_selected
=== PAUSE TestAccGithubActionsRunnerGroup_selected
=== CONT  TestAccGithubActionsRunnerGroup_all
=== CONT  TestAccGithubActionsRunnerGroup_selected
=== CONT  TestAccGithubActionsRunnerGroup_private
--- PASS: TestAccGithubActionsRunnerGroup_all (10.01s)
=== CONT  TestAccGithubActionsRunnerGroup_private
    testing.go:654: Step 0 error: Check failed: Check 2/2 error: got runnerGroup visibility "all"; want "private"
--- FAIL: TestAccGithubActionsRunnerGroup_private (17.92s)
=== CONT  TestAccGithubActionsRunnerGroup_selected
    testing.go:654: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
        
        (map[string]string) {
        }
        
        
        (map[string]string) (len=2) {
         (string) (len=25) "selected_repository_ids.#": (string) (len=1) "1",
         (string) (len=34) "selected_repository_ids.3743502971": (string) (len=9) "376594724"
        }
        
--- FAIL: TestAccGithubActionsRunnerGroup_selected (22.24s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-github/github	22.249s
FAIL
```

</details>

After testing manually with `curl` to debug this failing test, I'm confused about the expected behavior of the [`POST /orgs/{org}/actions/runner-groups`][1] method. The API returns a runner group with visibility `all`, despite specifying `"visibility": "private"` in the request:

```
curl -X POST -d '{"visibility": "private", "org": "human-berries", "name": "should be private"}' \
  -H "Authorization: token $GITHUB_TEST_USER_TOKEN"  -H "Accept: application/vnd.github.v3+json" \
  "https://api.github.com/orgs/human-berries/actions/runner-groups"
{
  "id": 124,
  "name": "should be private",
  "visibility": "all",
  "allows_public_repositories": false,
  "default": false,
  "runners_url": "https://api.github.com/orgs/human-berries/actions/runner-groups/124/runners",
  "inherited": false
}
```

It may be worth mentioning that the dropdown on the web UI only has options for "Selected" and "All" (whether updating a runner group or creating a new runner group):

![image](https://user-images.githubusercontent.com/1585815/122359497-37abba80-cf1b-11eb-95ed-9944f7de19b4.png)

(There is also a checkmark--hidden by the dropdown in the screenshot above--for "Allow public repositories" that is checkable whether "selected" or "all" is chosen from the dropdown.)


Am I missing something?


#### 2. `allows_public_repositories` parameter?

There is no documented `allows_public_repositories` parameter ([ref][1]), but specifying it seems to be the only way to get a value of `allows_public_repositories": true` in the `create` response:

```
curl -X POST -d '{"visibility": "selected", "allows_public_repositories": true, "name": "allows public repos true", "selected_repository_ids": [376523398, 377751328]}' -H "Authorization: token $GITHUB_TEST_USER_TOKEN"  -H "Accept: application/vnd.github.v3+json"   "https://api.github.com/orgs/human-berries/actions/runner-groups"
{
  "id": 134,
  "name": "allows public repos true",
  "visibility": "selected",
  "allows_public_repositories": true,
  "default": false,
  "selected_repositories_url": "https://api.github.com/orgs/human-berries/actions/runner-groups/134/repositories",
  "runners_url": "https://api.github.com/orgs/human-berries/actions/runner-groups/134/runners",
  "inherited": false
}

curl -X POST -d '{"visibility": "selected", "allows_public_repositories": false, "name": "allows public repos false", "selected_repository_ids": [376523398, 377751328]}' -H "Authorization: token $GITHUB_TEST_USER_TOKEN"  -H "Accept: application/vnd.github.v3+json"   "https://api.github.com/orgs/human-berries/actions/runner-groups"
{
  "id": 135,
  "name": "allows public repos false",
  "visibility": "selected",
  "allows_public_repositories": false,
  "default": false,
  "selected_repositories_url": "https://api.github.com/orgs/human-berries/actions/runner-groups/135/repositories",
  "runners_url": "https://api.github.com/orgs/human-berries/actions/runner-groups/135/runners",
  "inherited": false
}
```



Related: https://github.com/integrations/terraform-provider-github/issues/542

[1]: https://docs.github.com/en/rest/reference/actions#create-a-self-hosted-runner-group-for-an-organization