### PR TITLE
Fix copy-paste error on push restriction actors

### DIFF
--- a/github/util_v4_branch_protection.go
+++ b/github/util_v4_branch_protection.go
@@ -190,7 +190,7 @@ func setDismissalActorIDs(actors []DismissalActorTypes) []string {
 			pushActors = append(pushActors, a.Actor.Team.ID.(string))
 		}
 		if a.Actor.User != (Actor{}) {
-			pushActors = append(pushActors, a.Actor.Team.ID.(string))
+			pushActors = append(pushActors, a.Actor.User.ID.(string))
 		}
 	}
 
@@ -204,7 +204,10 @@ func setPushActorIDs(actors []PushActorTypes) []string {
 			pushActors = append(pushActors, a.Actor.Team.ID.(string))
 		}
 		if a.Actor.User != (Actor{}) {
-			pushActors = append(pushActors, a.Actor.Team.ID.(string))
+			pushActors = append(pushActors, a.Actor.User.ID.(string))
+		}
+		if a.Actor.App != (Actor{}) {
+			pushActors = append(pushActors, a.Actor.App.ID.(string))
 		}
 	}
 


### PR DESCRIPTION
A duplicated block meant that push restrictions on protected branches
could only be applied to teams. This enables users and apps to also be
taken into account, as was the intention of #615.