### PR TITLE
Documentation fix on github_repository_environment

### DIFF
--- a/website/docs/r/repository_environment.html.markdown
+++ b/website/docs/r/repository_environment.html.markdown
@@ -17,7 +17,7 @@ data "github_user" "current" {
 }
 
 resource "github_repository" "example" {
-  name         = "example"
+  environment  = "example"
   description  = "My awesome codebase"
 }
 
@@ -38,7 +38,7 @@ resource "github_repository_environment" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the environment.
+* `environment` - (Required) The name of the environment.
 
 * `repository` - (Required) The repository of the environment.
 


### PR DESCRIPTION
This PR will fix the documentation about the `github_repository_environment` resource, where one of the parameters where named wrong.