### PR TITLE
Fix app authentication for enterprise GitHub

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -31,6 +31,10 @@ func GenerateOAuthTokenFromApp(baseURL, appID, appInstallationID, pemData string
 }
 
 func getInstallationAccessToken(baseURL string, jwt string, installationID string) (string, error) {
+	if baseURL != "https://api.github.com/" {
+		baseURL += "api/v3/"
+	}
+
 	url := fmt.Sprintf("%sapp/installations/%s/access_tokens", baseURL, installationID)
 
 	req, err := http.NewRequest(http.MethodPost, url, nil)

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -145,7 +145,7 @@ func TestGetInstallationAccessToken(t *testing.T) {
 
 	ts := githubApiMock([]*mockResponse{
 		{
-			ExpectedUri: fmt.Sprintf("/app/installations/%s/access_tokens", testGitHubAppInstallationID),
+			ExpectedUri: fmt.Sprintf("/api/v3/app/installations/%s/access_tokens", testGitHubAppInstallationID),
 			ExpectedHeaders: map[string]string{
 				"Accept":        "application/vnd.github.v3+json",
 				"Authorization": fmt.Sprintf("Bearer %s", fakeJWT),


### PR DESCRIPTION
Insert api/v3/ if base URL is not github.com for App Authentication.
Similar to https://github.com/integrations/terraform-provider-github/blob/f8eeee871d6e0e08642512bb52e0be5a915f8ac6/github/config.go#L79
which is not useable during app authentication because authentication is done first.
Related to #812.