### PR TITLE
Add `restrict_dismissals` on `github_branch_protection` resource

### DIFF
--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -68,6 +68,10 @@ func resourceGithubBranchProtection() *schema.Resource {
 							Optional: true,
 						},
 						PROTECTION_RESTRICTS_REVIEW_DISMISSALS: {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						PROTECTION_RESTRICTS_REVIEW_DISMISSERS: {
 							Type:     schema.TypeSet,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},

--- a/github/util_v4_branch_protection.go
+++ b/github/util_v4_branch_protection.go
@@ -132,6 +132,9 @@ func branchProtectionResourceData(d *schema.ResourceData, meta interface{}) (Bra
 				data.RequiresCodeOwnerReviews = v.(bool)
 			}
 			if v, ok := m[PROTECTION_RESTRICTS_REVIEW_DISMISSALS]; ok {
+				data.RestrictsReviewDismissals = v.(bool)
+			}
+			if v, ok := m[PROTECTION_RESTRICTS_REVIEW_DISMISSERS]; ok {
 				reviewDismissalActorIDs := make([]string, 0)
 				vL := v.(*schema.Set).List()
 				for _, v := range vL {
@@ -226,7 +229,8 @@ func setApprovingReviews(protection BranchProtectionRule) interface{} {
 			PROTECTION_REQUIRED_APPROVING_REVIEW_COUNT: protection.RequiredApprovingReviewCount,
 			PROTECTION_REQUIRES_CODE_OWNER_REVIEWS:     protection.RequiresCodeOwnerReviews,
 			PROTECTION_DISMISSES_STALE_REVIEWS:         protection.DismissesStaleReviews,
-			PROTECTION_RESTRICTS_REVIEW_DISMISSALS:     dismissalActors,
+			PROTECTION_RESTRICTS_REVIEW_DISMISSALS:     protection.RestrictsReviewDismissals,
+			PROTECTION_RESTRICTS_REVIEW_DISMISSERS:     dismissalActors,
 		},
 	}
 

--- a/github/util_v4_consts.go
+++ b/github/util_v4_consts.go
@@ -14,7 +14,8 @@ const (
 	PROTECTION_REQUIRES_STATUS_CHECKS          = "required_status_checks"
 	PROTECTION_REQUIRES_STRICT_STATUS_CHECKS   = "strict"
 	PROTECTION_RESTRICTS_PUSHES                = "push_restrictions"
-	PROTECTION_RESTRICTS_REVIEW_DISMISSALS     = "dismissal_restrictions"
+	PROTECTION_RESTRICTS_REVIEW_DISMISSALS     = "restrict_dismissals"
+	PROTECTION_RESTRICTS_REVIEW_DISMISSERS     = "dismissal_restrictions"
 
 	REPOSITORY_ID = "repository_id"
 )

--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -33,7 +33,8 @@ resource "github_branch_protection" "example" {
   }
 
   required_pull_request_reviews {
-    dismiss_stale_reviews = true
+    dismiss_stale_reviews  = true
+    restrict_dismissals    = true
     dismissal_restrictions = [
       data.github_user.example.node_id,
       github_team.example.node_id,
@@ -93,7 +94,8 @@ The following arguments are supported:
 `required_pull_request_reviews` supports the following arguments:
 
 * `dismiss_stale_reviews`: (Optional) Dismiss approved reviews automatically when a new commit is pushed. Defaults to `false`.
-* `dismissal_restrictions`: (Optional) The list of actor IDs with dismissal access.
+* `restrict_dismissals`: (Optional) Restrict pull request review dismissals.
+* `dismissal_restrictions`: (Optional) The list of actor IDs with dismissal access. If not empty, `restrict_dismissals` is ignored.
 * `require_code_owner_reviews`: (Optional) Require an approved review in pull requests including files with a designated code owner. Defaults to `false`.
 * `required_approving_review_count`: (Optional) Require x number of approvals to satisfy branch protection requirements. If this is specified it must be a number between 1-6. This requirement matches GitHub's API, see the upstream [documentation](https://developer.github.com/v3/repos/branches/#parameters-1) for more information.
 


### PR DESCRIPTION
# Related Issue
Fixes #838

## Approach
Added a new argument `restrict_dismissals` to `github_branch_protection` resource to allow `Restrict who can dismiss pull request reviews` to be checked by Terraform even when `dismissal_restrictions` is empty.

`restrict_dismissals` is ignored when `dismissal_restrictions` is not empty, similar to `source_branch` and `source_sha` from https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch and `private` and `visibility` from https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository.

I have tested this functionality locally on a private registry.