### PR TITLE
Allow empty array for org secret selected repos

### DIFF
--- a/github/resource_github_actions_organization_secret.go
+++ b/github/resource_github_actions_organization_secret.go
@@ -85,9 +85,7 @@ func resourceGithubActionsOrganizationSecretCreateOrUpdate(d *schema.ResourceDat
 	visibility := d.Get("visibility").(string)
 	selectedRepositories, hasSelectedRepositories := d.GetOk("selected_repository_ids")
 
-	if visibility == "selected" && !hasSelectedRepositories {
-		return fmt.Errorf("Cannot use visbility set to selected without selected_repository_ids")
-	} else if visibility != "selected" && hasSelectedRepositories {
+	if visibility != "selected" && hasSelectedRepositories {
 		return fmt.Errorf("Cannot use selected_repository_ids without visibility being set to selected")
 	}
 


### PR DESCRIPTION
Fixes #842 

Github API will accept empty/null value for selected_repository_ids when visibility is set to selected.

An empty/null value will set selected repositories list to empty, which should be considered as a valid use case.