### PR TITLE
docs(resources/actions_environment_secret): fix example usage

### DIFF
--- a/website/docs/r/actions_environment_secret.html.markdown
+++ b/website/docs/r/actions_environment_secret.html.markdown
@@ -41,12 +41,12 @@ data "github_repository" "repo" {
 }
 
 resource "github_repository_environment" "repo_environment" {
-  repository       = data.github_repository.repo
+  repository       = data.github_repository.repo.full_name
   environment      = "example_environment"
 }
 
 resource "github_actions_environment_secret" "test_secret" {
-  repository       = data.github_repository.repo
+  repository       = data.github_repository.repo.full_name
   environment      = github_repository_environment.repo_environment.environment
   secret_name      = "test_secret_name"
   plaintext_value  = "%s"


### PR DESCRIPTION
github_actions_environment_secret and github_repository_environment expect a string as the repository parameter.