### PR TITLE
docs: fix typo in `repository_environment.html.markdown`

### DIFF
--- a/website/docs/r/repository_environment.html.markdown
+++ b/website/docs/r/repository_environment.html.markdown
@@ -17,13 +17,13 @@ data "github_user" "current" {
 }
 
 resource "github_repository" "example" {
-  environment  = "example"
+  name         = "A Repository Project"
   description  = "My awesome codebase"
 }
 
 resource "github_repository_environment" "example" {
-  name          = "A Repository Project"
-  repository    = github_repository.example.name
+  environment  = "example"
+  repository   = github_repository.example.name
   reviewers {
     users = [data.github_user.current.id]
   }


### PR DESCRIPTION
`name` and `environment` field are in the wrong resource on the `repository_environment` documentation