### PR TITLE
Add admin property to organization data source.

### DIFF
--- a/website/docs/d/organization.html.markdown
+++ b/website/docs/d/organization.html.markdown
@@ -15,9 +15,15 @@ Use this data source to retrieve basic information about a GitHub Organization.
 data "github_organization" "test" {
   name = "github"
 }
+
+locals {
+  admins = data.github_organization.test.admins
+}
 ```
 
 ## Attributes Reference
 
  * `plan` - The plan name for the organization account
  * `repositories` - (`list`) A list with the repositories on the organization
+ * `admins` - (`list`) A list with the admins on the organization
+ * `members` - (`list`) A list with the members on the organization


### PR DESCRIPTION
Current implementation place members and admins into members property of data_source_github_organization resource.

There is no way how to determine, if it is a member or admin.

Upon this I have added a new property `admins` with organization admins only.
This PR also fix that there are only members in `members` property.

Doc were updated for these two properties.