### PR TITLE
Document newly added data attributes

### DIFF
--- a/website/docs/d/ip_ranges.html.markdown
+++ b/website/docs/d/ip_ranges.html.markdown
@@ -17,6 +17,8 @@ data "github_ip_ranges" "test" {}
 
 ## Attributes Reference
 
+ * `actions` - An array of IP addresses in CIDR format specifying the addresses that incoming requests from GitHub actions will originate from.
+ * `dependabot` - An array of IP addresses in CIDR format specifying the A records for dependabot.
  * `hooks` - An Array of IP addresses in CIDR format specifying the addresses that incoming service hooks will originate from.
  * `git` - An Array of IP addresses in CIDR format specifying the Git servers.
  * `pages` - An Array of IP addresses in CIDR format specifying the A records for GitHub Pages.


### PR DESCRIPTION
As of https://github.com/integrations/terraform-provider-github/commit/3e539bef1e62af8207142592a187cc98071d1343 the `github_ip_ranges` data resource supports `actions` and `dependabot`, but the documentation does not include this, this PR adds them to the docs.