### PR TITLE
Manage organizations by Enterprise Account

### DIFF
--- a/github/data_source_github_organization.go
+++ b/github/data_source_github_organization.go
@@ -66,7 +66,7 @@ func dataSourceGithubOrganizationRead(d *schema.ResourceData, meta interface{}) 
 	plan := organization.GetPlan()
 
 	opts := &github.RepositoryListByOrgOptions{
-		ListOptions: github.ListOptions{PerPage: 10, Page: 1},
+		ListOptions: github.ListOptions{PerPage: 100, Page: 1},
 	}
 
 	var repoList []string
@@ -90,7 +90,7 @@ func dataSourceGithubOrganizationRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	membershipOpts := &github.ListMembersOptions{
-		ListOptions: github.ListOptions{PerPage: 10, Page: 1},
+		ListOptions: github.ListOptions{PerPage: 100, Page: 1},
 	}
 
 	var memberList []string

--- a/github/provider.go
+++ b/github/provider.go
@@ -83,6 +83,7 @@ func Provider() terraform.ResourceProvider {
 			"github_branch_protection_v3":        resourceGithubBranchProtectionV3(),
 			"github_issue_label":                 resourceGithubIssueLabel(),
 			"github_membership":                  resourceGithubMembership(),
+			"github_organization":                resourceGithubOrganization(),
 			"github_organization_block":          resourceOrganizationBlock(),
 			"github_organization_project":        resourceGithubOrganizationProject(),
 			"github_organization_webhook":        resourceGithubOrganizationWebhook(),

--- a/github/provider_utils.go
+++ b/github/provider_utils.go
@@ -60,6 +60,12 @@ func skipUnlessMode(t *testing.T, providerMode string) {
 		} else {
 			t.Log("GITHUB_TOKEN and GITHUB_ORGANIZATION environment variables should be set")
 		}
+	case enterprise:
+		if os.Getenv("GITHUB_TOKEN") != "" && os.Getenv("ENTERPRISE_ACCOUNT") != "" {
+			return
+		} else {
+			t.Log("GITHUB_TOKEN and ENTERPRISE_ACCOUNT environment variables should be set")
+		}
 	}
 
 	t.Skipf("Skipping %s which requires %s mode", t.Name(), providerMode)
@@ -121,3 +127,4 @@ func testOwnerFunc() string {
 const anonymous = "anonymous"
 const individual = "individual"
 const organization = "organization"
+const enterprise = "enterprise"

--- a/github/resource_github_organization.go
+++ b/github/resource_github_organization.go
@@ -86,7 +86,7 @@ func resourceGithubOrganizationUpdate(d *schema.ResourceData, meta interface{}) 
 	newName := github.String(d.Get("login").(string))
 	newOrganization := github.Organization{
 		Login: &orgName,
-		// Name: github.String(d.Get("profile_name").(string)),
+		Name:  github.String(d.Get("profile_name").(string)),
 	}
 
 	log.Printf("[DEBUG] Updating organization: %s", orgName)
@@ -95,6 +95,12 @@ func resourceGithubOrganizationUpdate(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
+	org, _, err := client.Organizations.Edit(ctx, orgName, &newOrganization)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(strconv.FormatInt(org.GetID(), 10))
 	return resourceGithubOrganizationRead(d, meta)
 }
 

--- a/github/resource_github_organization.go
+++ b/github/resource_github_organization.go
@@ -38,8 +38,8 @@ func resourceGithubOrganization() *schema.Resource {
 
 func resourceGithubOrganizationCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Owner).v3client
+	authenticatedUser := meta.(*Owner).name
 
-	ownerName := meta.(*Owner).name
 	organizationName := github.String(d.Get("login").(string))
 	enterpriseAdmin := github.String(d.Get("admin").(string))
 
@@ -49,7 +49,8 @@ func resourceGithubOrganizationCreate(d *schema.ResourceData, meta interface{}) 
 
 	ctx := context.Background()
 
-	log.Printf("[DEBUG] Creating organization: %s (%s)", *organizationName, ownerName)
+	// if enterpriseAdmin != authenticatedUser something is wrong
+	log.Printf("[DEBUG] Creating organization: %s (%s)", *organizationName, authenticatedUser)
 	githubOrganization, _, err := client.Admin.CreateOrg(ctx, &newOrganization, *enterpriseAdmin)
 	if err != nil {
 		return err

--- a/github/resource_github_organization.go
+++ b/github/resource_github_organization.go
@@ -1,0 +1,104 @@
+package github
+
+import (
+	"context"
+	"log"
+	"strconv"
+
+	"github.com/google/go-github/v36/github"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceGithubOrganization() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGithubOrganizationCreate,
+		Read:   resourceGithubOrganizationRead,
+		Update: resourceGithubOrganizationUpdate,
+		Delete: resourceGithubOrganizationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"login": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"admin": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"profile_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceGithubOrganizationCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Owner).v3client
+
+	ownerName := meta.(*Owner).name
+	login := github.String(d.Get("login").(string))
+	admin := github.String(d.Get("admin").(string))
+
+	newOrganization := github.Organization{
+		Login: login,
+	}
+
+	ctx := context.Background()
+
+	log.Printf("[DEBUG] Creating organization: %s (%s)", *login, ownerName)
+	githubOrganization, _, err := client.Admin.CreateOrg(ctx, &newOrganization, *admin)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(strconv.FormatInt(githubOrganization.GetID(), 10))
+	return resourceGithubOrganizationRead(d, meta)
+}
+
+func resourceGithubOrganizationRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
+
+	ctx := context.Background()
+
+	log.Printf("[DEBUG] Reading organization: %s", orgName)
+	org, _, err := client.Organizations.Get(ctx, orgName)
+	if err != nil {
+		return err
+	}
+
+	d.Set("login", org.GetLogin())
+	d.Set("profile_name", org.GetName())
+
+	return nil
+}
+
+func resourceGithubOrganizationUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
+
+	ctx := context.Background()
+
+	newName := github.String(d.Get("login").(string))
+	newOrganization := github.Organization{
+		Login: &orgName,
+		// Name: github.String(d.Get("profile_name").(string)),
+	}
+
+	log.Printf("[DEBUG] Updating organization: %s", orgName)
+	_, _, err := client.Admin.RenameOrg(ctx, &newOrganization, *newName)
+	if err != nil {
+		return err
+	}
+
+	return resourceGithubOrganizationRead(d, meta)
+}
+
+func resourceGithubOrganizationDelete(d *schema.ResourceData, meta interface{}) error {
+	// no github api for that?
+	return nil
+}

--- a/github/resource_github_organization_test.go
+++ b/github/resource_github_organization_test.go
@@ -1,0 +1,57 @@
+package github
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccGithubOrganization(t *testing.T) {
+
+	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+	t.Run("creates an organization configured with defaults", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+			resource "github_organization" "test" {
+				login         = "tf-acc-organization-%s"
+				admin         = "enterprise_admin"
+			}
+		`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttrSet("github_organization.test", "login"),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			t.Skip("individual account not supported for this operation")
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			t.Skip("organization account not supported for this operation")
+		})
+
+		t.Run("with an enterprise account", func(t *testing.T) {
+			testCase(t, enterprise)
+		})
+	})
+}


### PR DESCRIPTION
Hello,
would like to manage GitHub organizations (creating, renaming, deleting) by terraform.
I have not found `resource_github_organization` resource to create/update/delete organization by terraform.

Found that it is possible by GitHub API, but you need `enterprise account` (in oposit of `organization account` used for most cases) to do so: 
https://docs.github.com/en/enterprise-server@3.1/rest/reference/enterprise-admin

This is my very first terraform provider resource/test implementation and after running acceptance tests

`TF_LOG=DEBUG TF_ACC=1 go test -v   ./... -run TestAccGithubOrganization$`

I'm not able to pass this on public github.com. 
> Error: POST https://api.github.com/admin/organizations: 404 Not Found []

Is this a limitation of public GitHub and creating organizations is possible only on Enterprise GitHub? 

There are few more questions, I'm not sure about:
* Do github provider support authentication by Enterprise Account? Where to pass this, if GITHUB_OWNER does not fit to it?
* How to test against GHE, specially where to pass `base_url`
* How to proper test Enterprise Account use cases in acceptance tests

Many thanks for collaborating on this.