### PR TITLE
Log choices for organization/owner

### DIFF
--- a/github/config.go
+++ b/github/config.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"log"
 	"net/http"
 	"net/url"
 	"path"
@@ -148,9 +149,14 @@ func (c *Config) Meta() (interface{}, error) {
 	owner.v3client = v3client
 
 	if c.Anonymous() {
+		log.Printf("[DEBUG] No token present; configuring anonymous owner.")
 		return &owner, nil
 	} else {
-		return c.ConfigureOwner(&owner)
+		_, err = c.ConfigureOwner(&owner)
+		if err != nil {
+			return &owner, err
+		}
+		log.Printf("[DEBUG] Token present; configuring authenticated owner: %s", owner.name)
+		return &owner, nil
 	}
-
 }

--- a/github/provider.go
+++ b/github/provider.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -182,6 +183,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 
 		org := d.Get("organization").(string)
 		if org != "" {
+			log.Printf("[DEBUG] Selecting organization attribute as owner: %s", org)
 			owner = org
 		}
 

--- a/github/provider_utils.go
+++ b/github/provider_utils.go
@@ -98,11 +98,11 @@ func testAccCheckOrganization() error {
 
 func OwnerOrOrgEnvDefaultFunc() (interface{}, error) {
 	if organization := os.Getenv("GITHUB_ORGANIZATION"); organization != "" {
-		log.Printf("[DEBUG] Selecting owner %q from GITHUB_ORGANIZATION environment variable", organization)
+		log.Printf("[DEBUG] Selecting owner %s from GITHUB_ORGANIZATION environment variable", organization)
 		return organization, nil
 	}
 	owner := os.Getenv("GITHUB_OWNER")
-	log.Printf("[DEBUG] Selecting owner %q from GITHUB_OWNER environment variable", owner)
+	log.Printf("[DEBUG] Selecting owner %s from GITHUB_OWNER environment variable", owner)
 	return owner, nil
 }
 

--- a/github/provider_utils.go
+++ b/github/provider_utils.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"testing"
 )
@@ -97,9 +98,12 @@ func testAccCheckOrganization() error {
 
 func OwnerOrOrgEnvDefaultFunc() (interface{}, error) {
 	if organization := os.Getenv("GITHUB_ORGANIZATION"); organization != "" {
+		log.Printf("[DEBUG] Selecting owner %q from GITHUB_ORGANIZATION environment variable", organization)
 		return organization, nil
 	}
-	return os.Getenv("GITHUB_OWNER"), nil
+	owner := os.Getenv("GITHUB_OWNER")
+	log.Printf("[DEBUG] Selecting owner %q from GITHUB_OWNER environment variable", owner)
+	return owner, nil
 }
 
 func testOrganizationFunc() string {


### PR DESCRIPTION
Recently there's been [some confusion](https://github.com/integrations/terraform-provider-github/issues/647) as to which owner/organization are being selected as the owner for Terraform operations. I'm offering this PR as a way to start discussion about how to better handle this situation. Perhaps it's worth starting with a documentation improvement before making a breaking change to backwards compatibility as [the original comment mentions](https://github.com/integrations/terraform-provider-github/blob/main/github/provider.go#L167).