### PR TITLE
Skip If-None-Match header if empty

### DIFF
--- a/github/transport.go
+++ b/github/transport.go
@@ -34,7 +34,7 @@ func (ett *etagTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
 
 	etag := ctx.Value(ctxEtag)
-	if v, ok := etag.(string); ok {
+	if v, ok := etag.(string); ok && v != "" {
 		req.Header.Set("If-None-Match", v)
 	}
 


### PR DESCRIPTION
Avoid sending empty If-None-Match header when a resource's ETAG is not defined, which may cause issues with enterprise WAFs.