### PR TITLE
Correct a couple of erroneous master --> main uses

### DIFF
--- a/website/docs/r/branch.html.markdown
+++ b/website/docs/r/branch.html.markdown
@@ -50,11 +50,11 @@ The following additional attributes are exported:
 GitHub Branch can be imported using an ID made up of `repository:branch`, e.g.
 
 ```
-$ terraform import github_branch.terraform terraform:master
+$ terraform import github_branch.terraform terraform:main
 ```
 
 Optionally, a source branch may be specified using an ID of `repository:branch:source_branch`.
-This is useful for importing branches that do not branch directly off master.
+This is useful for importing branches that do not branch directly off main.
 
 ```
 $ terraform import github_branch.terraform terraform:feature-branch:dev

--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -14,7 +14,7 @@ This resource allows you to configure branch protection for repositories in your
 ## Example Usage
 
 ```hcl
-# Protect the master branch of the foo repository. Additionally, require that
+# Protect the main branch of the foo repository. Additionally, require that
 # the "ci/travis" context to be passing and only allow the engineers team merge
 # to the branch.
 


### PR DESCRIPTION
These docs are incorrect since we use `main` in the code rather than `master` as the default branch in both cases. Let's update the docs to fix that.