### PR TITLE
Small log typo fix

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -569,7 +569,7 @@ func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 			}
 		}
 	} else {
-		log.Printf("[DEBUG] <<<<<<<<<< no privacy update required. private: %v", d.Get("private"))
+		log.Printf("[DEBUG] No privacy update required. private: %v", d.Get("private"))
 	}
 
 	return resourceGithubRepositoryRead(d, meta)


### PR DESCRIPTION
I left these arrows in back when I was looking to make some messy log output easier to `grep` for while developing. I should've taken it out then but forgot :grimacing: Better late than never, I suppose? 