### PR TITLE
docs: Fix reference to repository name in Environment Secret example

### DIFF
--- a/website/docs/r/actions_environment_secret.html.markdown
+++ b/website/docs/r/actions_environment_secret.html.markdown
@@ -41,12 +41,12 @@ data "github_repository" "repo" {
 }
 
 resource "github_repository_environment" "repo_environment" {
-  repository       = data.github_repository.repo.full_name
+  repository       = data.github_repository.repo.name
   environment      = "example_environment"
 }
 
 resource "github_actions_environment_secret" "test_secret" {
-  repository       = data.github_repository.repo.full_name
+  repository       = data.github_repository.repo.name
   environment      = github_repository_environment.repo_environment.environment
   secret_name      = "test_secret_name"
   plaintext_value  = "%s"


### PR DESCRIPTION
The repository attribute accepted by `github_actions_environment_secret` is expected to be a Repository `name` with the owner derived by the provider from the context. The current attribute (`full_name`) is not correct and results in a double-org path (e.g: `org/org/repo`).

https://github.com/integrations/terraform-provider-github/blob/8d1c520ec054baf3f09c322ee13daf2bcfcd9871/github/resource_github_actions_environment_secret.go#L121