### PR TITLE
fix: Replace `\n` strings with new lines in pem_file

### DIFF
--- a/github/provider.go
+++ b/github/provider.go
@@ -3,8 +3,8 @@ package github
 import (
 	"fmt"
 	"log"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/github/provider.go
+++ b/github/provider.go
@@ -218,6 +218,13 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 			}
 
 			if v, ok := appAuthAttr["pem_file"].(string); ok && v != "" {
+				// The Go encoding/pem package only decodes PEM formatted blocks
+				// that contain new lines. Some platforms, like Terraform Cloud,
+				// do not support new lines within Environment Variables.
+				// Any occurrence of \n in the `pem_file` argument's value 
+				// (explicit value, or default value taken from 
+				// GITHUB_APP_PEM_FILE Environment Variable) is replaced with an
+				// actual new line character before decoding.
 				appPemFile = strings.Replace(v, `\n`, "\n", -1)
 			} else {
 				return nil, fmt.Errorf("app_auth.pem_file must be set and contain a non-empty value")

--- a/github/provider.go
+++ b/github/provider.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"time"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -217,7 +218,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 			}
 
 			if v, ok := appAuthAttr["pem_file"].(string); ok && v != "" {
-				appPemFile = v
+				appPemFile = strings.Replace(v, `\n`, "\n", -1)
 			} else {
 				return nil, fmt.Errorf("app_auth.pem_file must be set and contain a non-empty value")
 			}

--- a/github/provider.go
+++ b/github/provider.go
@@ -221,8 +221,8 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 				// The Go encoding/pem package only decodes PEM formatted blocks
 				// that contain new lines. Some platforms, like Terraform Cloud,
 				// do not support new lines within Environment Variables.
-				// Any occurrence of \n in the `pem_file` argument's value 
-				// (explicit value, or default value taken from 
+				// Any occurrence of \n in the `pem_file` argument's value
+				// (explicit value, or default value taken from
 				// GITHUB_APP_PEM_FILE Environment Variable) is replaced with an
 				// actual new line character before decoding.
 				appPemFile = strings.Replace(v, `\n`, "\n", -1)

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -105,7 +105,7 @@ The following arguments are supported in the `provider` block:
 * `app_auth` - (Optional) Configuration block to use GitHub App installation token. When not provided, the provider can only access resources available anonymously.
   * `id` - (Required) This is the ID of the GitHub App. It can sourced from the `GITHUB_APP_ID` environment variable.
   * `installation_id` - (Required) This is the ID of the GitHub App installation. It can sourced from the `GITHUB_APP_INSTALLATION_ID` environment variable.
-  * `pem_file` - (Required) This is the contents of the GitHub App private key PEM file. It can also be sourced from the `GITHUB_APP_PEM_FILE` environment variable.
+  * `pem_file` - (Required) This is the contents of the GitHub App private key PEM file. It can also be sourced from the `GITHUB_APP_PEM_FILE` environment variable and may use `\n` instead of actual new lines.
 
 * `write_delay_ms` - (Optional) The number of milliseconds to sleep in between write operations in order to satisfy the GitHub API rate limits. Defaults to 1000ms or 1 second if not provided.
 


### PR DESCRIPTION
#804 added environment variable input for `pem_file` but golang's pem decode functionality only works when the string contains _actual_ new lines. Terraform Cloud does not permit new lines in Environment Variables, therefore it is currently not possible to use the `GITHUB_APP_PEM_FILE` Environment Variable on Terraform Cloud.

Unfortunately, there's no test coverage for the functionality in question so while this is, in principle, a very simple change, I'm not entirely sure if there are side effects I have not considered.

https://play.golang.org/p/h3Pn97nqF8j