### PR TITLE
fix regex for topic validation

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -178,7 +178,7 @@ func resourceGithubRepository() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`), "must include only lowercase alphanumeric characters or hyphens and cannot start with a hyphen"),
+					ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,34}$`), "must include only lowercase alphanumeric characters or hyphens and cannot start with a hyphen and consist of 35 characters or less"),
 				},
 			},
 			"vulnerability_alerts": {


### PR DESCRIPTION
There is a length requirement for topic validation otherwise the following error is thrown:
```
 422 Validation Failed [{Resource: Field: Code: Message:Topics must start with a lowercase letter or number, consist of 35 characters or less, and can include hyphens.}]
```