### PR TITLE
Fix strict branch protection

### DIFF
--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -85,9 +85,8 @@ func resourceGithubBranchProtection() *schema.Resource {
 				},
 			},
 			PROTECTION_REQUIRES_STATUS_CHECKS: {
-				Type:             schema.TypeList,
-				Optional:         true,
-				DiffSuppressFunc: statusChecksDiffSuppression,
+				Type:     schema.TypeList,
+				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						PROTECTION_REQUIRES_STRICT_STATUS_CHECKS: {

--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -85,8 +85,9 @@ func resourceGithubBranchProtection() *schema.Resource {
 				},
 			},
 			PROTECTION_REQUIRES_STATUS_CHECKS: {
-				Type:     schema.TypeList,
-				Optional: true,
+				Type:             schema.TypeList,
+				Optional:         true,
+				DiffSuppressFunc: statusChecksDiffSuppression,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						PROTECTION_REQUIRES_STRICT_STATUS_CHECKS: {

--- a/github/util_v4_branch_protection.go
+++ b/github/util_v4_branch_protection.go
@@ -155,6 +155,7 @@ func branchProtectionResourceData(d *schema.ResourceData, meta interface{}) (Bra
 	}
 
 	if v, ok := d.GetOk(PROTECTION_REQUIRES_STATUS_CHECKS); ok {
+		data.RequiresStatusChecks = true
 		vL := v.([]interface{})
 		if len(vL) > 1 {
 			return BranchProtectionResourceData{},
@@ -171,9 +172,6 @@ func branchProtectionResourceData(d *schema.ResourceData, meta interface{}) (Bra
 			}
 
 			data.RequiredStatusCheckContexts = expandNestedSet(m, PROTECTION_REQUIRED_STATUS_CHECK_CONTEXTS)
-			if len(data.RequiredStatusCheckContexts) > 0 {
-				data.RequiresStatusChecks = true
-			}
 		}
 	}
 

--- a/github/util_v4_branch_protection.go
+++ b/github/util_v4_branch_protection.go
@@ -318,7 +318,8 @@ func getBranchProtectionID(repoID githubv4.ID, pattern string, meta interface{})
 }
 
 func statusChecksDiffSuppression(k, old, new string, d *schema.ResourceData) bool {
-	data := BranchProtectionResourceData{}
+	return false
+	/*data := BranchProtectionResourceData{}
 	checks := false
 
 	if v, ok := d.GetOk(PROTECTION_REQUIRES_STATUS_CHECKS); ok {
@@ -339,5 +340,5 @@ func statusChecksDiffSuppression(k, old, new string, d *schema.ResourceData) boo
 	if old == "0" && new == "1" && !checks {
 		return true
 	}
-	return false
+	return false*/
 }

--- a/github/util_v4_branch_protection.go
+++ b/github/util_v4_branch_protection.go
@@ -316,29 +316,3 @@ func getBranchProtectionID(repoID githubv4.ID, pattern string, meta interface{})
 
 	return nil, fmt.Errorf("Could not find a branch protection rule with the pattern '%s'.", pattern)
 }
-
-func statusChecksDiffSuppression(k, old, new string, d *schema.ResourceData) bool {
-	return false
-	/*data := BranchProtectionResourceData{}
-	checks := false
-
-	if v, ok := d.GetOk(PROTECTION_REQUIRES_STATUS_CHECKS); ok {
-		vL := v.([]interface{})
-		for _, v := range vL {
-			if v == nil {
-				break
-			}
-
-			m := v.(map[string]interface{})
-			data.RequiredStatusCheckContexts = expandNestedSet(m, PROTECTION_REQUIRED_STATUS_CHECK_CONTEXTS)
-			if len(data.RequiredStatusCheckContexts) > 0 {
-				checks = true
-			}
-		}
-	}
-
-	if old == "0" && new == "1" && !checks {
-		return true
-	}
-	return false*/
-}


### PR DESCRIPTION
Strict protection on v4 branch protection doesn't work at the moment. This PR makes minor code changes and removes the diff suppression func in order to correct strict branch protection. 

The research to get to this point is chronicled in #880. 

The TL;DR is that by removing the diff suppression and making a minor code change to the branch protection processing, we can restore strict branch protection with the graphQL client.