### PR TITLE
Export `branches` attribute of `github_repository` resource

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -126,6 +126,22 @@ func resourceGithubRepository() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"branches": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"protected": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"pages": {
 				Type:     schema.TypeList,
 				MaxItems: 1,


### PR DESCRIPTION
In #892, the newly-added `branches` attribute was exported for the data source, but not the resource. This results in an error as noted in https://github.com/integrations/terraform-provider-github/pull/892#issuecomment-947950349. This PR exports the `branches` attribute in the resource too.

---

I considered adding a test, but it looks like a branch might need to exist, and in cases where multiple branches exist, the order of the branch names might not be deterministic. So I tested this manually by using the built provider in a Terraform project using `dev_overrides`.