### PR TITLE
Update team.html.markdown

### DIFF
--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -33,7 +33,7 @@ The following arguments are supported:
                Defaults to `secret`.
 * `parent_team_id` - (Optional) The ID of the parent team, if this is a nested team.
 * `ldap_dn` - (Optional) The LDAP Distinguished Name of the group where membership will be synchronized. Only available in GitHub Enterprise Server.
-* `create_default_maintainer` - (Optional) Adds a default maintainer to the team. Defaults to `true` and removes the default maintaner when `false`.
+* `create_default_maintainer` - (Optional) Adds a default maintainer to the team. Defaults to `false` and adds the creating user to the team when `true`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The default value for `create_default_maintainer` is `false`: https://github.com/integrations/terraform-provider-github/blob/e9de2388a60fa8c1f4f0ac29a09e3e8e54012f92/github/resource_github_team.go#L54-L57

This edit corrects the documentation to accurately reflect the code.