### PR TITLE
Fix broken TF logo, remove gitter chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@ Terraform Provider GitHub
 
 <img src="https://cloud.githubusercontent.com/assets/98681/24211275/c4ebd04e-0ee8-11e7-8606-061d656a42df.png" width="72" height="">
 
-<img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg" width="300px">
+<img src="https://raw.githubusercontent.com/hashicorp/terraform-website/d841a1e5fca574416b5ca24306f85a0f4f41b36d/content/source/assets/images/logo-terraform-main.svg" width="300px">
 
 - Website: https://www.terraform.io
-- [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.svg)](https://gitter.im/hashicorp-terraform/Lobby)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 
 ## Requirements


### PR DESCRIPTION
:eyes: [Rendered version](https://github.com/kfcampbell/terraform-provider-github/blob/readme-cleanup/README.md#terraform-provider-github) :eyes: 

The current HEAD branch has a broken Hashicorp/Terraform logo:

![image](https://user-images.githubusercontent.com/9327688/139706483-ac6fc7ab-f723-4dd5-8788-c6960022d2da.png)

as well as a reference to a gitter chat that neither Jeremy or I check. Let's clean up the README a bit!

I can also remove the Terraform logo entirely if that's desired!