### PR TITLE
Add validate func for repository name

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -29,8 +29,9 @@ func resourceGithubRepository() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 100),
 			},
 			"description": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
## WHY

Because the GitHub has the repository name length limit.
If we can configure this validate func, it will give the developer early failure in the plan rather the apply making the experience better.