### PR TITLE
Allow to set required_approving_review_count=0

### DIFF
--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -67,7 +67,7 @@ func resourceGithubBranchProtection() *schema.Resource {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							Default:      1,
-							ValidateFunc: validation.IntBetween(1, 6),
+							ValidateFunc: validation.IntBetween(0, 6),
 						},
 						PROTECTION_REQUIRES_CODE_OWNER_REVIEWS: {
 							Type:     schema.TypeBool,

--- a/github/resource_github_branch_protection_v3.go
+++ b/github/resource_github_branch_protection_v3.go
@@ -101,7 +101,7 @@ func resourceGithubBranchProtectionV3() *schema.Resource {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							Default:      1,
-							ValidateFunc: validation.IntBetween(1, 6),
+							ValidateFunc: validation.IntBetween(0, 6),
 						},
 					},
 				},

--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -99,7 +99,7 @@ The following arguments are supported:
 * `restrict_dismissals`: (Optional) Restrict pull request review dismissals.
 * `dismissal_restrictions`: (Optional) The list of actor IDs with dismissal access. If not empty, `restrict_dismissals` is ignored.
 * `require_code_owner_reviews`: (Optional) Require an approved review in pull requests including files with a designated code owner. Defaults to `false`.
-* `required_approving_review_count`: (Optional) Require x number of approvals to satisfy branch protection requirements. If this is specified it must be a number between 1-6. This requirement matches GitHub's API, see the upstream [documentation](https://developer.github.com/v3/repos/branches/#parameters-1) for more information.
+* `required_approving_review_count`: (Optional) Require x number of approvals to satisfy branch protection requirements. If this is specified it must be a number between 0-6. This requirement matches GitHub's API, see the upstream [documentation](https://developer.github.com/v3/repos/branches/#parameters-1) for more information.
 
 
 ## Import

--- a/website/docs/r/branch_protection_v3.html.markdown
+++ b/website/docs/r/branch_protection_v3.html.markdown
@@ -99,7 +99,7 @@ The following arguments are supported:
 * `dismissal_teams`: (Optional) The list of team slugs with dismissal access.
   Always use `slug` of the team, **not** its name. Each team already **has** to have access to the repository.
 * `require_code_owner_reviews`: (Optional) Require an approved review in pull requests including files with a designated code owner. Defaults to `false`.
-* `required_approving_review_count`: (Optional) Require x number of approvals to satisfy branch protection requirements. If this is specified it must be a number between 1-6. This requirement matches GitHub's API, see the upstream [documentation](https://developer.github.com/v3/repos/branches/#parameters-1) for more information.
+* `required_approving_review_count`: (Optional) Require x number of approvals to satisfy branch protection requirements. If this is specified it must be a number between 0-6. This requirement matches GitHub's API, see the upstream [documentation](https://developer.github.com/v3/repos/branches/#parameters-1) for more information.
 
 ### Restrictions
 


### PR DESCRIPTION
When using this branch protection settings:

```
[X] Require a pull request before merging
    [ ] Require approvals
    [X] Dismiss stale pull request approvals when new commits are pushed
    [ ] Require review from Code Owners
    [ ] Restrict who can dismiss pull request reviews
```
The following Terraform code is trying to change the `required_approving_review_count` value to `1`:

```terraform
resource "github_branch_protection" "main" {
  repository_id = github_repository.this.name
  pattern       = data.github_repository.this.default_branch

  required_pull_request_reviews {
    dismiss_stale_reviews = true
  }
}
```

This PR allows to set the `required_approving_review_count` to `0` as that seems to be the default value if _Require a pull request before merging_ is checked.