### PR TITLE
fix topic regex to allow single characters

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -179,7 +179,7 @@ func resourceGithubRepository() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,34}$`), "must include only lowercase alphanumeric characters or hyphens and cannot start with a hyphen and consist of 35 characters or less"),
+					ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,34}$`), "must include only lowercase alphanumeric characters or hyphens and cannot start with a hyphen and consist of 35 characters or less"),
 				},
 			},
 			"vulnerability_alerts": {


### PR DESCRIPTION
The regex introduced with #951 does not match with single alphanumeric character topics, e.g., `"r"` and `"2"`. But those are valid topics.