### PR TITLE
feat: allow toggling of state refresh

### DIFF
--- a/github/config.go
+++ b/github/config.go
@@ -15,11 +15,12 @@ import (
 )
 
 type Config struct {
-	Token      string
-	Owner      string
-	BaseURL    string
-	Insecure   bool
-	WriteDelay time.Duration
+	Token       string
+	Owner       string
+	BaseURL     string
+	Insecure    bool
+	DetectDrift bool
+	WriteDelay  time.Duration
 }
 
 type Owner struct {
@@ -28,6 +29,7 @@ type Owner struct {
 	v3client       *github.Client
 	v4client       *githubv4.Client
 	StopContext    context.Context
+	DetectDrift    bool
 	IsOrganization bool
 }
 

--- a/github/provider.go
+++ b/github/provider.go
@@ -32,6 +32,12 @@ func Provider() terraform.ResourceProvider {
 				Description: descriptions["organization"],
 				Deprecated:  "Use owner (or GITHUB_OWNER) instead of organization (or GITHUB_ORGANIZATION)",
 			},
+			"detect_drift": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: descriptions["detect_drift"],
+			},
 			"base_url": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -157,6 +163,8 @@ func init() {
 
 		"base_url": "The GitHub Base API URL",
 
+		"detect_drift": "Will disable state refresh if true",
+
 		"insecure": "Enable `insecure` mode for testing purposes",
 
 		"owner": "The GitHub owner name to manage. " +
@@ -181,6 +189,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 		baseURL := d.Get("base_url").(string)
 		token := d.Get("token").(string)
 		insecure := d.Get("insecure").(bool)
+		detectDrift := d.Get("detect_drift").(bool)
 
 		// BEGIN backwards compatibility
 		// OwnerOrOrgEnvDefaultFunc used to be the default value for both
@@ -249,11 +258,12 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 		log.Printf("[DEBUG] Setting write_delay_ms to %d", writeDelay)
 
 		config := Config{
-			Token:      token,
-			BaseURL:    baseURL,
-			Insecure:   insecure,
-			Owner:      owner,
-			WriteDelay: time.Duration(writeDelay) * time.Millisecond,
+			Token:       token,
+			BaseURL:     baseURL,
+			Insecure:    insecure,
+			Owner:       owner,
+			DetectDrift: detectDrift,
+			WriteDelay:  time.Duration(writeDelay) * time.Millisecond,
 		}
 
 		meta, err := config.Meta()
@@ -262,6 +272,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 		}
 
 		meta.(*Owner).StopContext = p.StopContext()
+		meta.(*Owner).DetectDrift = detectDrift
 
 		return meta, nil
 	}

--- a/github/resource_github_actions_environment_secret.go
+++ b/github/resource_github_actions_environment_secret.go
@@ -109,6 +109,11 @@ func resourceGithubActionsEnvironmentSecretCreateOrUpdate(d *schema.ResourceData
 }
 
 func resourceGithubActionsEnvironmentSecretRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	client := meta.(*Owner).v3client
 	owner := meta.(*Owner).name
 	ctx := context.Background()

--- a/github/resource_github_actions_organization_permissions.go
+++ b/github/resource_github_actions_organization_permissions.go
@@ -182,6 +182,11 @@ func resourceGithubActionsOrganizationPermissionsCreateOrUpdate(d *schema.Resour
 }
 
 func resourceGithubActionsOrganizationPermissionsRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	client := meta.(*Owner).v3client
 	ctx := context.Background()
 

--- a/github/resource_github_actions_organization_secret.go
+++ b/github/resource_github_actions_organization_secret.go
@@ -133,6 +133,11 @@ func resourceGithubActionsOrganizationSecretCreateOrUpdate(d *schema.ResourceDat
 }
 
 func resourceGithubActionsOrganizationSecretRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	client := meta.(*Owner).v3client
 	owner := meta.(*Owner).name
 	ctx := context.Background()

--- a/github/resource_github_actions_organization_secret_repositories.go
+++ b/github/resource_github_actions_organization_secret_repositories.go
@@ -66,6 +66,11 @@ func resourceGithubActionsOrganizationSecretRepositoriesCreateOrUpdate(d *schema
 }
 
 func resourceGithubActionsOrganizationSecretRepositoriesRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	client := meta.(*Owner).v3client
 	owner := meta.(*Owner).name
 	ctx := context.Background()

--- a/github/resource_github_actions_runner_group.go
+++ b/github/resource_github_actions_runner_group.go
@@ -124,6 +124,11 @@ func resourceGithubActionsRunnerGroupCreate(d *schema.ResourceData, meta interfa
 }
 
 func resourceGithubActionsRunnerGroupRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	err := checkOrganization(meta)
 	if err != nil {
 		return err

--- a/github/resource_github_actions_secret.go
+++ b/github/resource_github_actions_secret.go
@@ -98,6 +98,11 @@ func resourceGithubActionsSecretCreateOrUpdate(d *schema.ResourceData, meta inte
 }
 
 func resourceGithubActionsSecretRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	client := meta.(*Owner).v3client
 	owner := meta.(*Owner).name
 	ctx := context.Background()

--- a/github/resource_github_app_installation_repository.go
+++ b/github/resource_github_app_installation_repository.go
@@ -72,6 +72,11 @@ func resourceGithubAppInstallationRepositoryCreate(d *schema.ResourceData, meta 
 }
 
 func resourceGithubAppInstallationRepositoryRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	err := checkOrganization(meta)
 	if err != nil {
 		return err

--- a/github/resource_github_branch.go
+++ b/github/resource_github_branch.go
@@ -102,6 +102,11 @@ func resourceGithubBranchCreate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceGithubBranchRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 	if !d.IsNewResource() {
 		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))

--- a/github/resource_github_branch_default.go
+++ b/github/resource_github_branch_default.go
@@ -56,6 +56,10 @@ func resourceGithubBranchDefaultCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceGithubBranchDefaultRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
 
 	client := meta.(*Owner).v3client
 	owner := meta.(*Owner).name

--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -179,6 +179,11 @@ func resourceGithubBranchProtectionCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceGithubBranchProtectionRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	var query struct {
 		Node struct {
 			Node BranchProtectionRule `graphql:"... on BranchProtectionRule"`

--- a/github/resource_github_branch_protection_v3.go
+++ b/github/resource_github_branch_protection_v3.go
@@ -197,6 +197,11 @@ func resourceGithubBranchProtectionV3Create(d *schema.ResourceData, meta interfa
 }
 
 func resourceGithubBranchProtectionV3Read(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	err := checkOrganization(meta)
 	if err != nil {
 		return err

--- a/github/resource_github_branch_protection_v3_utils.go
+++ b/github/resource_github_branch_protection_v3_utils.go
@@ -58,6 +58,11 @@ func flattenAndSetRequiredStatusChecks(d *schema.ResourceData, protection *githu
 }
 
 func requireSignedCommitsRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	client := meta.(*Owner).v3client
 
 	repoName, branch, err := parseTwoPartID(d.Id(), "repository", "branch")

--- a/github/resource_github_issue_label.go
+++ b/github/resource_github_issue_label.go
@@ -143,6 +143,11 @@ func resourceGithubIssueLabelCreateOrUpdate(d *schema.ResourceData, meta interfa
 }
 
 func resourceGithubIssueLabelRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	client := meta.(*Owner).v3client
 	repoName, name, err := parseTwoPartID(d.Id(), "repository", "name")
 	if err != nil {

--- a/github/resource_github_membership.go
+++ b/github/resource_github_membership.go
@@ -74,6 +74,11 @@ func resourceGithubMembershipCreateOrUpdate(d *schema.ResourceData, meta interfa
 }
 
 func resourceGithubMembershipRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	err := checkOrganization(meta)
 	if err != nil {
 		return err

--- a/github/resource_github_organization_project.go
+++ b/github/resource_github_organization_project.go
@@ -71,6 +71,11 @@ func resourceGithubOrganizationProjectCreate(d *schema.ResourceData, meta interf
 }
 
 func resourceGithubOrganizationProjectRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	err := checkOrganization(meta)
 	if err != nil {
 		return err

--- a/github/resource_github_organization_webhook.go
+++ b/github/resource_github_organization_webhook.go
@@ -107,6 +107,11 @@ func resourceGithubOrganizationWebhookCreate(d *schema.ResourceData, meta interf
 }
 
 func resourceGithubOrganizationWebhookRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	err := checkOrganization(meta)
 	if err != nil {
 		return err

--- a/github/resource_github_project_card.go
+++ b/github/resource_github_project_card.go
@@ -70,6 +70,11 @@ func resourceGithubProjectCardCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceGithubProjectCardRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	client := meta.(*Owner).v3client
 	nodeID := d.Id()
 	cardID := d.Get("card_id").(int)

--- a/github/resource_github_project_column.go
+++ b/github/resource_github_project_column.go
@@ -79,6 +79,11 @@ func resourceGithubProjectColumnCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceGithubProjectColumnRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	client := meta.(*Owner).v3client
 
 	columnID, err := strconv.ParseInt(d.Id(), 10, 64)

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -399,6 +399,11 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	client := meta.(*Owner).v3client
 	owner := meta.(*Owner).name
 	repoName := d.Id()

--- a/github/resource_github_repository_autolink_reference.go
+++ b/github/resource_github_repository_autolink_reference.go
@@ -85,6 +85,11 @@ func resourceGithubRepositoryAutolinkReferenceCreate(d *schema.ResourceData, met
 }
 
 func resourceGithubRepositoryAutolinkReferenceRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	client := meta.(*Owner).v3client
 
 	owner := meta.(*Owner).name

--- a/github/resource_github_repository_collaborator.go
+++ b/github/resource_github_repository_collaborator.go
@@ -90,6 +90,11 @@ func resourceGithubRepositoryCollaboratorCreate(d *schema.ResourceData, meta int
 }
 
 func resourceGithubRepositoryCollaboratorRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	client := meta.(*Owner).v3client
 
 	owner := meta.(*Owner).name

--- a/github/resource_github_repository_deploy_key.go
+++ b/github/resource_github_repository_deploy_key.go
@@ -82,6 +82,11 @@ func resourceGithubRepositoryDeployKeyCreate(d *schema.ResourceData, meta interf
 }
 
 func resourceGithubRepositoryDeployKeyRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	client := meta.(*Owner).v3client
 
 	owner := meta.(*Owner).name

--- a/github/resource_github_repository_environment.go
+++ b/github/resource_github_repository_environment.go
@@ -99,6 +99,11 @@ func resourceGithubRepositoryEnvironmentCreate(d *schema.ResourceData, meta inte
 }
 
 func resourceGithubRepositoryEnvironmentRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	client := meta.(*Owner).v3client
 
 	owner := meta.(*Owner).name

--- a/github/resource_github_repository_file.go
+++ b/github/resource_github_repository_file.go
@@ -209,6 +209,10 @@ func resourceGithubRepositoryFileCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceGithubRepositoryFileRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
 
 	client := meta.(*Owner).v3client
 	owner := meta.(*Owner).name

--- a/github/resource_github_repository_milestone.go
+++ b/github/resource_github_repository_milestone.go
@@ -118,6 +118,11 @@ func resourceGithubRepositoryMilestoneCreate(d *schema.ResourceData, meta interf
 }
 
 func resourceGithubRepositoryMilestoneRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	conn := meta.(*Owner).v3client
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 

--- a/github/resource_github_repository_project.go
+++ b/github/resource_github_repository_project.go
@@ -82,6 +82,11 @@ func resourceGithubRepositoryProjectCreate(d *schema.ResourceData, meta interfac
 }
 
 func resourceGithubRepositoryProjectRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	client := meta.(*Owner).v3client
 	owner := meta.(*Owner).name
 

--- a/github/resource_github_repository_pull_request.go
+++ b/github/resource_github_repository_pull_request.go
@@ -160,6 +160,11 @@ func resourceGithubRepositoryPullRequestCreate(d *schema.ResourceData, meta inte
 }
 
 func resourceGithubRepositoryPullRequestRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	ctx := context.TODO()
 	client := meta.(*Owner).v3client
 

--- a/github/resource_github_repository_webhook.go
+++ b/github/resource_github_repository_webhook.go
@@ -127,6 +127,11 @@ func resourceGithubRepositoryWebhookCreate(d *schema.ResourceData, meta interfac
 }
 
 func resourceGithubRepositoryWebhookRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	client := meta.(*Owner).v3client
 
 	owner := meta.(*Owner).name

--- a/github/resource_github_team.go
+++ b/github/resource_github_team.go
@@ -129,6 +129,11 @@ func resourceGithubTeamCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceGithubTeamRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	err := checkOrganization(meta)
 	if err != nil {
 		return err

--- a/github/resource_github_team_members.go
+++ b/github/resource_github_team_members.go
@@ -182,6 +182,11 @@ func resourceGithubTeamMembersUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceGithubTeamMembersRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	client := meta.(*Owner).v3client
 	orgId := meta.(*Owner).id
 	teamIdString := d.Get("team_id").(string)

--- a/github/resource_github_team_membership.go
+++ b/github/resource_github_team_membership.go
@@ -81,6 +81,11 @@ func resourceGithubTeamMembershipCreateOrUpdate(d *schema.ResourceData, meta int
 }
 
 func resourceGithubTeamMembershipRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	client := meta.(*Owner).v3client
 	orgId := meta.(*Owner).id
 	teamIdString, username, err := parseTwoPartID(d.Id(), "team_id", "username")

--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -89,6 +89,11 @@ func resourceGithubTeamRepositoryCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceGithubTeamRepositoryRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	err := checkOrganization(meta)
 	if err != nil {
 		return err

--- a/github/resource_github_team_sync_group_mapping.go
+++ b/github/resource_github_team_sync_group_mapping.go
@@ -82,6 +82,11 @@ func resourceGithubTeamSyncGroupMappingCreate(d *schema.ResourceData, meta inter
 }
 
 func resourceGithubTeamSyncGroupMappingRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	err := checkOrganization(meta)
 	if err != nil {
 		return err

--- a/github/resource_github_user_gpg_key.go
+++ b/github/resource_github_user_gpg_key.go
@@ -52,6 +52,11 @@ func resourceGithubUserGpgKeyCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceGithubUserGpgKeyRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	client := meta.(*Owner).v3client
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)

--- a/github/resource_github_user_ssh_key.go
+++ b/github/resource_github_user_ssh_key.go
@@ -69,6 +69,11 @@ func resourceGithubUserSshKeyCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceGithubUserSshKeyRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	client := meta.(*Owner).v3client
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)

--- a/github/resource_organization_block.go
+++ b/github/resource_organization_block.go
@@ -55,6 +55,11 @@ func resourceOrganizationBlockCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceOrganizationBlockRead(d *schema.ResourceData, meta interface{}) error {
+	drift := meta.(*Owner).DetectDrift
+	if !drift {
+		return nil
+	}
+
 	client := meta.(*Owner).v3client
 	orgName := meta.(*Owner).name
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -109,6 +109,8 @@ The following arguments are supported in the `provider` block:
 
 * `write_delay_ms` - (Optional) The number of milliseconds to sleep in between write operations in order to satisfy the GitHub API rate limits. Defaults to 1000ms or 1 second if not provided.
 
+* `detect_drift` - (Optional) Enables or disables the providers ability to detect drift between whats in the configuration and reality. If `false`, drift detection will be disabled. Defaults to `true`.
+
 Note: If you have a PEM file on disk, you can pass it in via `pem_file = file("path/to/file.pem")`.
 
 For backwards compatibility, if more than one of `owner`, `organization`,


### PR DESCRIPTION
Im part of a large organization that manages github with this provider for everything. 

Unfortunately, our organization is so large that the `GITHUB_TOKEN` used to manage our org gets rate limited by GitHub in just the plan phase of terraform. By the time we get to the actual apply phase (if we even can) we have to wait over an hour for the token to be usable again. Additionally, plans cannot fail fast because of the refresh period (we were seeing up to 45 minute plans sometimes).

This change forces the provider to "trust" the state in terraform if `detect_drift = false`. This allows us to make changes quickly and keeps requests to the github api low, therefore avoiding rate limiting. It also allows us to turn on the state refresh feature `detect_drift = true` so we can, every so often, run a plan that will actually detect any drift within our configuration.