### PR TITLE
Handles nil plan in org data source

### DIFF
--- a/github/data_source_github_organization.go
+++ b/github/data_source_github_organization.go
@@ -63,7 +63,11 @@ func dataSourceGithubOrganizationRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	plan := organization.GetPlan()
+	var planName string
+
+	if plan := organization.GetPlan(); plan != nil {
+		planName = plan.GetName()
+	}
 
 	opts := &github.RepositoryListByOrgOptions{
 		ListOptions: github.ListOptions{PerPage: 10, Page: 1},
@@ -117,7 +121,7 @@ func dataSourceGithubOrganizationRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("login", organization.GetLogin())
 	d.Set("name", organization.GetName())
 	d.Set("description", organization.GetDescription())
-	d.Set("plan", plan.Name)
+	d.Set("plan", planName)
 	d.Set("repositories", repoList)
 	d.Set("members", memberList)
 


### PR DESCRIPTION
When using the `github_organization` data source, if the `GITHUB_TOKEN` env is set but nil, a valid response is returned by the API, but the `plan` field is nil. 

Error:

```
⟩ TF_LOG=DEBUG terraform plan
╷
│ Error: Plugin did not respond
│
│   with module.github.data.github_organization.default,
│   on github/main.tf line 11, in data "github_organization" "default":
│   11: data "github_organization" "default" {
│
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ReadDataSource call. The plugin logs may contain more details.
╵

Stack trace from the terraform-provider-github_v4.19.0 plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x194f731]

goroutine 67 [running]:
github.com/terraform-providers/terraform-provider-github/github.dataSourceGithubOrganizationRead(0xc0000c7f80, 0x1a36b80, 0xc0005d67c0, 0xc0000c7f80, 0x0)
	github.com/terraform-providers/terraform-provider-github/github/data_source_github_organization.go:120 +0x8b1
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).ReadDataApply(0xc000542780, 0xc000383d40, 0x1a36b80, 0xc0005d67c0, 0xc0005585c0, 0x1, 0x0)
	github.com/hashicorp/terraform-plugin-sdk@v1.7.0/helper/schema/resource.go:398 +0x91
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Provider).ReadDataApply(0xc000543100, 0xc0002359a8, 0xc000383d40, 0xc000383d40, 0x0, 0x0)
	github.com/hashicorp/terraform-plugin-sdk@v1.7.0/helper/schema/provider.go:451 +0x8f
github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin.(*GRPCProviderServer).ReadDataSource(0xc00000eb50, 0x1d87690, 0xc00011e810, 0xc0004bc240, 0xc00000eb50, 0xc00011e810, 0xc0006cca50)
	github.com/hashicorp/terraform-plugin-sdk@v1.7.0/internal/helper/plugin/grpc_provider.go:1036 +0x42d
github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5._Provider_ReadDataSource_Handler(0x1bb3020, 0xc00000eb50, 0x1d87690, 0xc00011e810, 0xc000251aa0, 0x0, 0x1d87690, 0xc00011e810, 0xc00043e070, 0x65)
	github.com/hashicorp/terraform-plugin-sdk@v1.7.0/internal/tfplugin5/tfplugin5.pb.go:3225 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0000d8000, 0x1d8f0d8, 0xc000600a80, 0xc00021a200, 0xc00051e9c0, 0x2307650, 0x0, 0x0, 0x0)
	google.golang.org/grpc@v1.23.0/server.go:995 +0x482
google.golang.org/grpc.(*Server).handleStream(0xc0000d8000, 0x1d8f0d8, 0xc000600a80, 0xc00021a200, 0x0)
	google.golang.org/grpc@v1.23.0/server.go:1275 +0xd2c
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc000216170, 0xc0000d8000, 0x1d8f0d8, 0xc000600a80, 0xc00021a200)
	google.golang.org/grpc@v1.23.0/server.go:710 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.23.0/server.go:708 +0xa5
```