### PR TITLE
feat(branch-protection): Push/Reviewer actors can be specified by name 

### DIFF
--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -276,7 +276,11 @@ func resourceGithubBranchProtectionRead(d *schema.ResourceData, meta interface{}
 		log.Printf("[DEBUG] Problem setting '%s' in %s %s branch protection (%s)", PROTECTION_REQUIRES_CONVERSATION_RESOLUTION, protection.Repository.Name, protection.Pattern, d.Id())
 	}
 
-	approvingReviews := setApprovingReviews(protection, d, meta)
+	approvingReviews, err := setApprovingReviews(protection, d, meta)
+	if err != nil {
+		return err
+	}
+
 	err = d.Set(PROTECTION_REQUIRES_APPROVING_REVIEWS, approvingReviews)
 	if err != nil {
 		log.Printf("[DEBUG] Problem setting '%s' in %s %s branch protection (%s)", PROTECTION_REQUIRES_APPROVING_REVIEWS, protection.Repository.Name, protection.Pattern, d.Id())
@@ -288,7 +292,10 @@ func resourceGithubBranchProtectionRead(d *schema.ResourceData, meta interface{}
 		log.Printf("[DEBUG] Problem setting '%s' in %s %s branch protection (%s)", PROTECTION_REQUIRES_STATUS_CHECKS, protection.Repository.Name, protection.Pattern, d.Id())
 	}
 
-	restrictsPushes := setPushes(protection, d, meta)
+	restrictsPushes, err := setPushes(protection, d, meta)
+	if err != nil {
+		return err
+	}
 	err = d.Set(PROTECTION_RESTRICTS_PUSHES, restrictsPushes)
 	if err != nil {
 		log.Printf("[DEBUG] Problem setting '%s' in %s %s branch protection (%s)", PROTECTION_RESTRICTS_PUSHES, protection.Repository.Name, protection.Pattern, d.Id())

--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -155,7 +155,7 @@ func resourceGithubBranchProtectionCreate(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	var reviewIds, pushIds []string
+	var reviewIds, pushIds, bypassIds []string
 	reviewIds, err = getActorIds(data.ReviewDismissalActorIDs, meta)
 	if err != nil {
 		return err
@@ -166,8 +166,14 @@ func resourceGithubBranchProtectionCreate(d *schema.ResourceData, meta interface
 		return err
 	}
 
+	bypassIds, err = getActorIds(data.BypassPullRequestActorIDs, meta)
+	if err != nil {
+		return err
+	}
+
 	data.PushActorIDs = pushIds
 	data.ReviewDismissalActorIDs = reviewIds
+	data.BypassPullRequestActorIDs = bypassIds
 
 	input := githubv4.CreateBranchProtectionRuleInput{
 		AllowsDeletions:                githubv4.NewBoolean(githubv4.Boolean(data.AllowsDeletions)),
@@ -270,7 +276,7 @@ func resourceGithubBranchProtectionRead(d *schema.ResourceData, meta interface{}
 		log.Printf("[DEBUG] Problem setting '%s' in %s %s branch protection (%s)", PROTECTION_REQUIRES_CONVERSATION_RESOLUTION, protection.Repository.Name, protection.Pattern, d.Id())
 	}
 
-	approvingReviews, _ := setApprovingReviews(protection, d, meta)
+	approvingReviews := setApprovingReviews(protection, d, meta)
 	err = d.Set(PROTECTION_REQUIRES_APPROVING_REVIEWS, approvingReviews)
 	if err != nil {
 		log.Printf("[DEBUG] Problem setting '%s' in %s %s branch protection (%s)", PROTECTION_REQUIRES_APPROVING_REVIEWS, protection.Repository.Name, protection.Pattern, d.Id())
@@ -282,7 +288,7 @@ func resourceGithubBranchProtectionRead(d *schema.ResourceData, meta interface{}
 		log.Printf("[DEBUG] Problem setting '%s' in %s %s branch protection (%s)", PROTECTION_REQUIRES_STATUS_CHECKS, protection.Repository.Name, protection.Pattern, d.Id())
 	}
 
-	restrictsPushes, _ := setPushes(protection, d, meta)
+	restrictsPushes := setPushes(protection, d, meta)
 	err = d.Set(PROTECTION_RESTRICTS_PUSHES, restrictsPushes)
 	if err != nil {
 		log.Printf("[DEBUG] Problem setting '%s' in %s %s branch protection (%s)", PROTECTION_RESTRICTS_PUSHES, protection.Repository.Name, protection.Pattern, d.Id())
@@ -304,7 +310,7 @@ func resourceGithubBranchProtectionUpdate(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	var reviewIds, pushIds []string
+	var reviewIds, pushIds, bypassIds []string
 	reviewIds, err = getActorIds(data.ReviewDismissalActorIDs, meta)
 	if err != nil {
 		return err
@@ -315,8 +321,14 @@ func resourceGithubBranchProtectionUpdate(d *schema.ResourceData, meta interface
 		return err
 	}
 
+	bypassIds, err = getActorIds(data.BypassPullRequestActorIDs, meta)
+	if err != nil {
+		return err
+	}
+
 	data.PushActorIDs = pushIds
 	data.ReviewDismissalActorIDs = reviewIds
+	data.BypassPullRequestActorIDs = bypassIds
 
 	input := githubv4.UpdateBranchProtectionRuleInput{
 		BranchProtectionRuleID:         d.Id(),

--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -154,6 +154,21 @@ func resourceGithubBranchProtectionCreate(d *schema.ResourceData, meta interface
 	if err != nil {
 		return err
 	}
+
+	var reviewIds, pushIds []string
+	reviewIds, err = getActorIds(data.ReviewDismissalActorIDs, meta)
+	if err != nil {
+		return err
+	}
+
+	pushIds, err = getActorIds(data.PushActorIDs, meta)
+	if err != nil {
+		return err
+	}
+
+	data.PushActorIDs = pushIds
+	data.ReviewDismissalActorIDs = reviewIds
+
 	input := githubv4.CreateBranchProtectionRuleInput{
 		AllowsDeletions:                githubv4.NewBoolean(githubv4.Boolean(data.AllowsDeletions)),
 		AllowsForcePushes:              githubv4.NewBoolean(githubv4.Boolean(data.AllowsForcePushes)),
@@ -255,7 +270,7 @@ func resourceGithubBranchProtectionRead(d *schema.ResourceData, meta interface{}
 		log.Printf("[DEBUG] Problem setting '%s' in %s %s branch protection (%s)", PROTECTION_REQUIRES_CONVERSATION_RESOLUTION, protection.Repository.Name, protection.Pattern, d.Id())
 	}
 
-	approvingReviews := setApprovingReviews(protection)
+	approvingReviews, _ := setApprovingReviews(protection, d, meta)
 	err = d.Set(PROTECTION_REQUIRES_APPROVING_REVIEWS, approvingReviews)
 	if err != nil {
 		log.Printf("[DEBUG] Problem setting '%s' in %s %s branch protection (%s)", PROTECTION_REQUIRES_APPROVING_REVIEWS, protection.Repository.Name, protection.Pattern, d.Id())
@@ -267,7 +282,7 @@ func resourceGithubBranchProtectionRead(d *schema.ResourceData, meta interface{}
 		log.Printf("[DEBUG] Problem setting '%s' in %s %s branch protection (%s)", PROTECTION_REQUIRES_STATUS_CHECKS, protection.Repository.Name, protection.Pattern, d.Id())
 	}
 
-	restrictsPushes := setPushes(protection)
+	restrictsPushes, _ := setPushes(protection, d, meta)
 	err = d.Set(PROTECTION_RESTRICTS_PUSHES, restrictsPushes)
 	if err != nil {
 		log.Printf("[DEBUG] Problem setting '%s' in %s %s branch protection (%s)", PROTECTION_RESTRICTS_PUSHES, protection.Repository.Name, protection.Pattern, d.Id())
@@ -288,6 +303,21 @@ func resourceGithubBranchProtectionUpdate(d *schema.ResourceData, meta interface
 	if err != nil {
 		return err
 	}
+
+	var reviewIds, pushIds []string
+	reviewIds, err = getActorIds(data.ReviewDismissalActorIDs, meta)
+	if err != nil {
+		return err
+	}
+
+	pushIds, err = getActorIds(data.PushActorIDs, meta)
+	if err != nil {
+		return err
+	}
+
+	data.PushActorIDs = pushIds
+	data.ReviewDismissalActorIDs = reviewIds
+
 	input := githubv4.UpdateBranchProtectionRuleInput{
 		BranchProtectionRuleID:         d.Id(),
 		AllowsDeletions:                githubv4.NewBoolean(githubv4.Boolean(data.AllowsDeletions)),

--- a/github/resource_github_branch_protection_test.go
+++ b/github/resource_github_branch_protection_test.go
@@ -380,6 +380,60 @@ func TestAccGithubBranchProtection(t *testing.T) {
 
 	})
 
+	t.Run("configures branch push restrictions with username", func(t *testing.T) {
+
+		user := fmt.Sprintf("/%s", testOwnerFunc())
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+			  name      = "tf-acc-test-%s"
+			  auto_init = true
+			}
+
+			resource "github_branch_protection" "test" {
+
+			  repository_id   = github_repository.test.name
+			  pattern       	= "main"
+
+			  push_restrictions = [
+			    "%s",
+			  ]
+
+			}
+	`, randomID, user)
+
+		check := resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_branch_protection.test", "push_restrictions.#", "1",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			t.Skip("individual account not supported for this operation")
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
+
 	t.Run("configures force pushes and deletions", func(t *testing.T) {
 
 		config := fmt.Sprintf(`

--- a/github/resource_github_repository_environment.go
+++ b/github/resource_github_repository_environment.go
@@ -134,9 +134,13 @@ func resourceGithubRepositoryEnvironmentRead(d *schema.ResourceData, meta interf
 			for _, r := range pr.Reviewers {
 				switch *r.Type {
 				case "Team":
-					teams = append(teams, *r.Reviewer.(*github.Team).ID)
+					if r.Reviewer.(*github.Team).ID != nil {
+						teams = append(teams, *r.Reviewer.(*github.Team).ID)
+					}
 				case "User":
-					users = append(users, *r.Reviewer.(*github.User).ID)
+					if r.Reviewer.(*github.User).ID != nil {
+						users = append(users, *r.Reviewer.(*github.User).ID)
+					}
 				}
 			}
 			d.Set("reviewers", []interface{}{

--- a/github/util_v4_branch_protection.go
+++ b/github/util_v4_branch_protection.go
@@ -239,7 +239,7 @@ func setDismissalActorIDs(actors []DismissalActorTypes, d *schema.ResourceData, 
 l:
 	for _, a := range actors {
 		for _, v := range data.ReviewDismissalActorIDs {
-			if a.Actor.Team.ID.(string) == v || a.Actor.User.ID.(string) == v {
+			if (a.Actor.Team.ID != nil && a.Actor.Team.ID.(string) == v) || (a.Actor.User.ID != nil && a.Actor.User.ID.(string) == v) {
 				dismissalActors = append(dismissalActors, v)
 				continue l
 			}
@@ -262,7 +262,7 @@ func setBypassPullRequestActorIDs(actors []BypassPullRequestActorTypes, d *schem
 l:
 	for _, a := range actors {
 		for _, v := range data.BypassPullRequestActorIDs {
-			if a.Actor.Team.ID.(string) == v || a.Actor.User.ID.(string) == v {
+			if (a.Actor.Team.ID != nil && a.Actor.Team.ID.(string) == v) || (a.Actor.User.ID != nil && a.Actor.User.ID.(string) == v) {
 				bypassActors = append(bypassActors, v)
 				continue l
 			}
@@ -285,7 +285,7 @@ func setPushActorIDs(actors []PushActorTypes, d *schema.ResourceData, meta inter
 l:
 	for _, a := range actors {
 		for _, v := range data.PushActorIDs {
-			if a.Actor.Team.ID.(string) == v || a.Actor.User.ID.(string) == v || a.Actor.App.ID.(string) == v {
+			if (a.Actor.Team.ID != nil && a.Actor.Team.ID.(string) == v) || (a.Actor.User.ID != nil && a.Actor.User.ID.(string) == v) || (a.Actor.App.ID != nil && a.Actor.App.ID.(string) == v) {
 				pushActors = append(pushActors, v)
 				continue l
 			}

--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -103,7 +103,7 @@ The following arguments are supported:
 * `dismiss_stale_reviews`: (Optional) Dismiss approved reviews automatically when a new commit is pushed. Defaults to `false`.
 * `restrict_dismissals`: (Optional) Restrict pull request review dismissals.
 * `dismissal_restrictions`: (Optional) The list of actor Names/IDs with dismissal access. If not empty, `restrict_dismissals` is ignored. Actor names must either begin with a "/" for users or the organization name followed by a "/" for teams.
-* `pull_request_bypassers`: (Optional) The list of actor IDs that are allowed to bypass pull request requirements.
+* `pull_request_bypassers`: (Optional) The list of actor Names/IDs that are allowed to bypass pull request requirements. Actor names must either begin with a "/" for users or the organization name followed by a "/" for teams.
 * `require_code_owner_reviews`: (Optional) Require an approved review in pull requests including files with a designated code owner. Defaults to `false`.
 * `required_approving_review_count`: (Optional) Require x number of approvals to satisfy branch protection requirements. If this is specified it must be a number between 0-6. This requirement matches GitHub's API, see the upstream [documentation](https://developer.github.com/v3/repos/branches/#parameters-1) for more information.
 

--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -38,11 +38,15 @@ resource "github_branch_protection" "example" {
     dismissal_restrictions = [
       data.github_user.example.node_id,
       github_team.example.node_id,
+      "/exampleuser",
+      "exampleorganization/exampleteam",
     ]
   }
 
   push_restrictions = [
     data.github_user.example.node_id,
+    "/exampleuser",
+    "exampleorganization/exampleteam",
     # limited to a list of one type of restriction (user, team, app)
     # github_team.example.node_id
   ]
@@ -80,7 +84,7 @@ The following arguments are supported:
 * `require_conversation_resolution` - (Optional) Boolean, setting this to `true` requires all conversations on code must be resolved before a pull request can be merged.
 * `required_status_checks` - (Optional) Enforce restrictions for required status checks. See [Required Status Checks](#required-status-checks) below for details.
 * `required_pull_request_reviews` - (Optional) Enforce restrictions for pull request reviews. See [Required Pull Request Reviews](#required-pull-request-reviews) below for details.
-* `push_restrictions` - (Optional) The list of actor IDs that may push to the branch.
+* `push_restrictions` - (Optional) The list of actor Names/IDs that may push to the branch. Actor names must either begin with a "/" for users or the organization name followed by a "/" for teams.
 * `allows_deletions` - (Optional) Boolean, setting this to `true` to allow the branch to be deleted.
 * `allows_force_pushes` - (Optional) Boolean, setting this to `true` to allow force pushes on the branch.
 * `blocks_creations` - (Optional) Boolean, setting this to `true` to block creating the branch.
@@ -98,7 +102,7 @@ The following arguments are supported:
 
 * `dismiss_stale_reviews`: (Optional) Dismiss approved reviews automatically when a new commit is pushed. Defaults to `false`.
 * `restrict_dismissals`: (Optional) Restrict pull request review dismissals.
-* `dismissal_restrictions`: (Optional) The list of actor IDs with dismissal access. If not empty, `restrict_dismissals` is ignored.
+* `dismissal_restrictions`: (Optional) The list of actor Names/IDs with dismissal access. If not empty, `restrict_dismissals` is ignored. Actor names must either begin with a "/" for users or the organization name followed by a "/" for teams.
 * `pull_request_bypassers`: (Optional) The list of actor IDs that are allowed to bypass pull request requirements.
 * `require_code_owner_reviews`: (Optional) Require an approved review in pull requests including files with a designated code owner. Defaults to `false`.
 * `required_approving_review_count`: (Optional) Require x number of approvals to satisfy branch protection requirements. If this is specified it must be a number between 0-6. This requirement matches GitHub's API, see the upstream [documentation](https://developer.github.com/v3/repos/branches/#parameters-1) for more information.


### PR DESCRIPTION
Changes the github_branch_protection resource.

This enables us to use the branch protection resource without using a data block just to retrieve the node ID for users/teams. Node IDs can still be used as an input but you can now use a prefix to define a username or team name

The / prefix defines a user (Ex.: /testuser), the orgname/ prefix defines a team. (Ex.: testorg/team)