### PR TITLE
Add support for disabling the use of the vulnerability management endpoint

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -202,6 +202,10 @@ func resourceGithubRepository() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"ignore_vulnerability_alerts_during_read": {
+				Type: schema.TypeBool,
+				Optional: true,
+			},
 			"full_name": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -481,11 +485,13 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 		d.Set("template", []interface{}{})
 	}
 
-	vulnerabilityAlerts, _, err := client.Repositories.GetVulnerabilityAlerts(ctx, owner, repoName)
-	if err != nil {
-		return fmt.Errorf("Error reading repository vulnerability alerts: %v", err)
+	if !d.Get("ignore_vulnerability_alerts_during_read").(bool) {
+		vulnerabilityAlerts, _, err := client.Repositories.GetVulnerabilityAlerts(ctx, owner, repoName)
+		if err != nil {
+			return fmt.Errorf("Error reading repository vulnerability alerts: %v", err)
+		}
+		d.Set("vulnerability_alerts", vulnerabilityAlerts)
 	}
-	d.Set("vulnerability_alerts", vulnerabilityAlerts)
 
 	return nil
 }

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -103,6 +103,8 @@ initial repository creation and create the target branch inside of the repositor
 
 * `vulnerability_alerts` (Optional) - Set to `true` to enable security alerts for vulnerable dependencies. Enabling requires alerts to be enabled on the owner level. (Note for importing: GitHub enables the alerts on public repos but disables them on private repos by default.) See [GitHub Documentation](https://help.github.com/en/github/managing-security-vulnerabilities/about-security-alerts-for-vulnerable-dependencies) for details. Note that vulnerability alerts have not been successfully tested on any GitHub Enterprise instance and may be unavailable in those settings.
 
+* `ignore_vulnerability_alerts_during_read` (Optional) - Set to `true` to not call the vulnerability alerts endpoint so the resource can also be used without admin permissions during read.
+
 ### GitHub Pages Configuration
 
 The `pages` block supports the following:


### PR DESCRIPTION
This PR adds a flag to disable reading the GetVulnerabilityAlerts alerts endpoint on refresh which prevents terraform from running least privileges in the plan phase. 

The endpoint `GET /repos/:owner/:repo/vulnerability-alerts` needs administration :write permissions when using a Github App to deploy. In the plan phase this is unwanted because it forces us to expose high privileged secrets to branch builds rather than just to the main build. 