### PR TITLE
test: add manual test runs

### DIFF
--- a/.github/workflows/dotcom-acceptance-tests-all.yml
+++ b/.github/workflows/dotcom-acceptance-tests-all.yml
@@ -8,7 +8,7 @@ on:
     #         │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
     #         │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
     #         * * * * *
-    - cron:  '0 0 * * *'
+    - cron:  '0 0 * * 3'
 
 jobs:
 

--- a/.github/workflows/dotcom-acceptance-tests-manual.yml
+++ b/.github/workflows/dotcom-acceptance-tests-manual.yml
@@ -1,0 +1,90 @@
+name: Dotcom Acceptance Tests (manual)
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+
+  acceptance-tests-anonymous:
+    runs-on: ubuntu-latest
+    if: contains(join(github.event.pull_request.labels.*.name, ', '), 'test')
+    steps:
+      - name: Parse Args
+        id: args
+        run: |
+          echo "::set-output name=run_allowed::$(
+            jq -rc .label.name $GITHUB_EVENT_PATH | cut -d/ -f 2
+          )"
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 2
+
+      - name: Acceptance Tests (Anonymous)
+        uses: terraformtesting/acceptance-tests@v2.2.0
+        with:
+          TF_LOG: INFO
+          RUN_ALLOWED: ${{ steps.args.outputs.run_allowed }}
+
+  acceptance-tests-individual:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 2
+
+      - name: Acceptance Tests (Individual)
+        id: acceptance-tests-individual
+        uses: terraformtesting/acceptance-tests@v2.2.0
+        with:
+          TF_LOG: INFO
+          RUN_ALL: true
+          GITHUB_OWNER: github-terraform-test-user
+          GITHUB_TEST_USER_TOKEN: ${{ secrets.DOTCOM_TEST_USER_TOKEN }}
+          GITHUB_TEST_ORGANIZATION: terraformtesting
+
+      - name: Failed Acceptance Tests (Individual)
+        if: ${{ failure() }}
+        uses: terraformtesting/acceptance-tests@v2.2.0
+        with:
+          TF_LOG: DEBUG
+          RUN_ALLOWED: ${{ steps.acceptance-tests-individual.outputs.failed }}
+          GITHUB_OWNER: github-terraform-test-user
+          GITHUB_TEST_USER_TOKEN: ${{ secrets.DOTCOM_TEST_USER_TOKEN }}
+          GITHUB_TEST_ORGANIZATION: terraformtesting
+
+  acceptance-tests-organization:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 2
+
+      - name: Acceptance Tests (Organization)
+        id: acceptance-tests-organization
+        uses: terraformtesting/acceptance-tests@v2.2.0
+        with:
+          TF_LOG: INFO
+          RUN_ALL: true
+          GITHUB_ORGANIZATION: terraformtesting
+          GITHUB_TEST_USER_TOKEN: ${{ secrets.DOTCOM_TEST_USER_TOKEN }}
+          GITHUB_TEST_OWNER: github-terraform-test-user
+
+      - name: Failed Acceptance Tests (Organization)
+        uses: terraformtesting/acceptance-tests@v2.2.0
+        if: ${{ failure() }}
+        with:
+          TF_LOG: DEBUG
+          RUN_ALLOWED: ${{ steps.acceptance-tests-organization.outputs.failed }}
+          GITHUB_ORGANIZATION: terraformtesting
+          GITHUB_TEST_USER_TOKEN: ${{ secrets.DOTCOM_TEST_USER_TOKEN }}
+          GITHUB_TEST_OWNER: github-terraform-test-user
+
+
+

--- a/.github/workflows/dotcom-acceptance-tests-manual.yml
+++ b/.github/workflows/dotcom-acceptance-tests-manual.yml
@@ -1,7 +1,6 @@
 name: Dotcom Acceptance Tests (manual)
 
 on:
-  push:
   pull_request:
     types: [labeled]
 
@@ -22,38 +21,50 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 2
-
       - name: Acceptance Tests (Anonymous)
+        id: acceptance-tests-anonymous
         uses: terraformtesting/acceptance-tests@v2.2.0
         with:
           TF_LOG: INFO
           RUN_ALLOWED: ${{ steps.args.outputs.run_allowed }}
+      - name: Failed Acceptance Tests (Anonymous)
+        if: ${{ failure() }}
+        uses: terraformtesting/acceptance-tests@v2.2.0
+        with:
+          TF_LOG: DEBUG
+          RUN_ALLOWED: ${{ steps.acceptance-tests-anonymous.outputs.run_allowed }}
+
 
   acceptance-tests-individual:
     runs-on: ubuntu-latest
+    if: contains(join(github.event.pull_request.labels.*.name, ', '), 'test')
     steps:
+      - name: Parse Args
+        id: args
+        run: |
+          echo "::set-output name=run_allowed::$(
+            jq -rc .label.name $GITHUB_EVENT_PATH | cut -d/ -f 2
+          )"
       - name: Checkout
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 2
-
       - name: Acceptance Tests (Individual)
         id: acceptance-tests-individual
         uses: terraformtesting/acceptance-tests@v2.2.0
         with:
           TF_LOG: INFO
-          RUN_ALL: true
+          RUN_ALLOWED: ${{ steps.args.outputs.run_allowed }}
           GITHUB_OWNER: github-terraform-test-user
           GITHUB_TEST_USER_TOKEN: ${{ secrets.DOTCOM_TEST_USER_TOKEN }}
           GITHUB_TEST_ORGANIZATION: terraformtesting
-
       - name: Failed Acceptance Tests (Individual)
         if: ${{ failure() }}
         uses: terraformtesting/acceptance-tests@v2.2.0
         with:
           TF_LOG: DEBUG
-          RUN_ALLOWED: ${{ steps.acceptance-tests-individual.outputs.failed }}
+          RUN_ALLOWED: ${{ steps.args.outputs.run_allowed }}
           GITHUB_OWNER: github-terraform-test-user
           GITHUB_TEST_USER_TOKEN: ${{ secrets.DOTCOM_TEST_USER_TOKEN }}
           GITHUB_TEST_ORGANIZATION: terraformtesting

--- a/.github/workflows/dotcom-acceptance-tests-manual.yml
+++ b/.github/workflows/dotcom-acceptance-tests-manual.yml
@@ -8,7 +8,7 @@ jobs:
 
   acceptance-tests-anonymous:
     runs-on: ubuntu-latest
-    if: contains(join(github.event.pull_request.labels.*.name, ', '), 'test')
+    if: contains(join(github.event.pull_request.labels.*.name, ', '), 'test/')
     steps:
       - name: Parse Args
         id: args

--- a/.github/workflows/dotcom-acceptance-tests-manual.yml
+++ b/.github/workflows/dotcom-acceptance-tests-manual.yml
@@ -71,7 +71,14 @@ jobs:
 
   acceptance-tests-organization:
     runs-on: ubuntu-latest
+    if: contains(join(github.event.pull_request.labels.*.name, ', '), 'test')
     steps:
+      - name: Parse Args
+        id: args
+        run: |
+          echo "::set-output name=run_allowed::$(
+            jq -rc .label.name $GITHUB_EVENT_PATH | cut -d/ -f 2
+          )"
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -83,7 +90,7 @@ jobs:
         uses: terraformtesting/acceptance-tests@v2.2.0
         with:
           TF_LOG: INFO
-          RUN_ALL: true
+          RUN_ALLOWED: ${{ steps.args.outputs.run_allowed }}
           GITHUB_ORGANIZATION: terraformtesting
           GITHUB_TEST_USER_TOKEN: ${{ secrets.DOTCOM_TEST_USER_TOKEN }}
           GITHUB_TEST_OWNER: github-terraform-test-user
@@ -93,7 +100,7 @@ jobs:
         if: ${{ failure() }}
         with:
           TF_LOG: DEBUG
-          RUN_ALLOWED: ${{ steps.acceptance-tests-organization.outputs.failed }}
+          RUN_ALLOWED: ${{ steps.args.outputs.run_allowed }}
           GITHUB_ORGANIZATION: terraformtesting
           GITHUB_TEST_USER_TOKEN: ${{ secrets.DOTCOM_TEST_USER_TOKEN }}
           GITHUB_TEST_OWNER: github-terraform-test-user

--- a/.github/workflows/dotcom-acceptance-tests-manual.yml
+++ b/.github/workflows/dotcom-acceptance-tests-manual.yml
@@ -1,6 +1,7 @@
 name: Dotcom Acceptance Tests (manual)
 
 on:
+  push:
   pull_request:
     types: [labeled]
 

--- a/.github/workflows/ghes-acceptance-tests-all.yml
+++ b/.github/workflows/ghes-acceptance-tests-all.yml
@@ -8,7 +8,7 @@ on:
     #         │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
     #         │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
     #         * * * * *
-    - cron:  '0 0 * * *'
+    - cron:  '0 0 * * 3'
 
 jobs:
   runtime:


### PR DESCRIPTION
This tunes our acceptance testing in a couple of ways:
- reduces frequency of automated runs to weekly
- re-instates a manual option that allows for labels applied to PRs to trigger tests

See https://github.com/jcudit/terraform-provider-github/actions/workflows/dotcom-acceptance-tests-manual.yml for example test runs and https://github.com/jcudit/terraform-provider-github/pull/1 as an example of labelling.