### PR TITLE
feat: add `tree` data source

### DIFF
--- a/github/data_source_github_tree.go
+++ b/github/data_source_github_tree.go
@@ -10,10 +10,6 @@ func dataSourceGithubTree() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceGithubTreeRead,
 		Schema: map[string]*schema.Schema{
-			"owner": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
 			"recursive": {
 				Type:     schema.TypeBool,
 				Default:  false,
@@ -23,7 +19,7 @@ func dataSourceGithubTree() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"tree": {
+			"entries": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -60,7 +56,7 @@ func dataSourceGithubTree() *schema.Resource {
 }
 
 func dataSourceGithubTreeRead(d *schema.ResourceData, meta interface{}) error {
-	owner := d.Get("owner").(string)
+	owner := meta.(*Owner).name
 	repository := d.Get("repository").(string)
 	sha := d.Get("tree_sha").(string)
 	recursive := d.Get("recursive").(bool)
@@ -74,7 +70,7 @@ func dataSourceGithubTreeRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	entries := make([]interface{}, 0)
+	entries := make([]interface{}, 0, len(tree.Entries))
 
 	for _, entry := range tree.Entries {
 		entries = append(entries, map[string]interface{}{
@@ -87,7 +83,7 @@ func dataSourceGithubTreeRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(tree.GetSHA())
-	d.Set("tree", entries)
+	d.Set("entries", entries)
 
 	return nil
 }

--- a/github/data_source_github_tree.go
+++ b/github/data_source_github_tree.go
@@ -24,23 +24,23 @@ func dataSourceGithubTree() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"path": &schema.Schema{
+						"path": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"mode": &schema.Schema{
+						"mode": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"type": &schema.Schema{
+						"type": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"size": &schema.Schema{
+						"size": {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
-						"sha": &schema.Schema{
+						"sha": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},

--- a/github/data_source_github_tree_test.go
+++ b/github/data_source_github_tree_test.go
@@ -1,0 +1,72 @@
+package github
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccGithubTreeDataSource(t *testing.T) {
+	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+	t.Run("get tree", func(t *testing.T) {
+		config := fmt.Sprintf(`
+			resource "github_repository" "this" {
+				auto_init = true
+				name      = "tf-acc-test-%s"
+			}
+
+			data "github_branch" "this" {
+				branch     = "main"
+				repository = github_repository.this.name
+			}
+
+			data "github_tree" "this" {
+				recursive  = false
+				repository = github_repository.this.name
+				tree_sha   = data.github_branch.this.sha
+			}
+		`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttrSet(
+				"data.github_tree.this", "entries.#",
+			),
+			resource.TestCheckResourceAttr(
+				"data.github_tree.this", "entries.0.path",
+				"README.md",
+			),
+			resource.TestCheckResourceAttr(
+				"data.github_tree.this", "entries.0.type",
+				"blob",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			testCase(t, anonymous)
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+}

--- a/github/provider.go
+++ b/github/provider.go
@@ -137,6 +137,7 @@ func Provider() terraform.ResourceProvider {
 			"github_repository_pull_request":       dataSourceGithubRepositoryPullRequest(),
 			"github_repository_pull_requests":      dataSourceGithubRepositoryPullRequests(),
 			"github_team":                          dataSourceGithubTeam(),
+			"github_tree":                          dataSourceGithubTree(),
 			"github_user":                          dataSourceGithubUser(),
 			"github_users":                         dataSourceGithubUsers(),
 		},

--- a/website/docs/d/tree.html.markdown
+++ b/website/docs/d/tree.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "github"
+page_title: "GitHub: github_tree"
+description: |-
+  Returns a single tree using the SHA1 value for that tree.
+---
+
+# github_tree
+
+Use this data source to retrieve information about a single tree.
+
+## Example Usage
+
+```hcl
+data "github_repository" "this" {
+  name = "example"
+}
+
+data "github_branch" "this" {
+  branch     = data.github_repository.this.default_branch
+  repository = data.github_repository.this.name
+}
+
+data "github_tree" "this" {
+  recursive  = false
+  repository = data.github_repository.this.name
+  tree_sha   = data.github_branch.this.sha
+}
+
+output "entries" {
+  value = data.github_tree.this.entries
+}
+
+```
+
+## Argument Reference
+
+- `recursive` - (Optional) Setting this parameter to `true` returns the objects or subtrees referenced by the tree specified in `tree_sha`.
+- `repository` - (Required) The name of the repository.
+- `tree_sha` - (Required) The SHA1 value for the tree.
+
+## Attributes Reference
+
+- `entries` - Objects (of `path`, `mode`, `type`, `size`, and `sha`) specifying a tree structure.

--- a/website/github.erb
+++ b/website/github.erb
@@ -61,6 +61,9 @@
             <li>
               <a href="/docs/providers/github/d/users.html">github_users</a>
             </li>
+            <li>
+              <a href="/docs/providers/github/d/tree.html">github_tree</a>
+            </li>
           </ul>
         </li>
 


### PR DESCRIPTION
Not sure if this is a desired data source, but I had a use case where I needed to find specific files in a GitHub repository using this provider and there was no such way. I ended up using the `http` data source to issue a request to the [Get a tree](https://docs.github.com/en/rest/reference/git#get-a-tree) endpoint, but decided to write a data source for it.

This is my first time contributing to a Terraform provider, so if I need to make any changes to the data source code or the acceptance tests, please let me know.

This pull request adds a new data source `github_tree` which returns a single tree given a SHA1 value. See [Get a tree](https://docs.github.com/en/rest/reference/git#get-a-tree) from the GitHub documentation.

An example is as follows:

```hcl
resource "github_repository" "this" {
  name = "my-repo"
}

data "github_branch" "this" {
  branch     = "main"
  repository = github_repository.this.name
}

data "github_tree" "this" {
  recursive  = true
  repository = github_repository.this.name
  tree_sha   = data.github_branch.this.sha
}

output "entries" {
  value = data.github_tree.this.entries
}

```

Which would output something like:

```hcl
entries = tolist([
  {
    "mode" = "100644"
    "path" = ".gitignore"
    "sha" = "7a3e2fd0945d0099d4f7604518b7e863c57069c0"
    "size" = 716
    "type" = "blob"
  },
  {
    "mode" = "100644"
    "path" = "LICENSE"
    "sha" = "4158a3a44c13ca0bcb249210565ae0cd718a2057"
    "size" = 1074
    "type" = "blob"
  },
  {
    "mode" = "100644"
    "path" = "README.md"
    "sha" = "5314ef162955d8e2bff4a6f5a565e14f30a5aa6c"
    "size" = 71
    "type" = "blob"
  },
])
```