### PR TITLE
Make data_github_repository work with non-existing repositories

### DIFF
--- a/github/data_source_github_branch.go
+++ b/github/data_source_github_branch.go
@@ -51,7 +51,7 @@ func dataSourceGithubBranchRead(d *schema.ResourceData, meta interface{}) error 
 	if err != nil {
 		if err, ok := err.(*github.ErrorResponse); ok {
 			if err.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[INFO] Error reading GitHub branch reference %s/%s (%s): %s", orgName, repoName, branchRefName, err)
+				log.Printf("[DEBUG] Missing GitHub branch %s/%s (%s)", orgName, repoName, branchRefName)
 				d.SetId("")
 				return nil
 			}

--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/google/go-github/v41/github"
+	"github.com/google/go-github/v42/github"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 

--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -208,7 +208,7 @@ func dataSourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		if err, ok := err.(*github.ErrorResponse); ok {
 			if err.Response.StatusCode == http.StatusNotFound {
-				log.Printf("Error reading GitHub branch reference %s/%s: %s", owner, repoName, err)
+				log.Printf("[DEBUG] Missing GitHub repository %s/%s", owner, repoName)
 				d.SetId("")
 				return nil
 			}

--- a/github/data_source_github_repository_test.go
+++ b/github/data_source_github_repository_test.go
@@ -55,16 +55,22 @@ func TestAccGithubRepositoryDataSource(t *testing.T) {
 
 		config := map[string]string{
 			"no_match_name": `
-				data "github_repository" "no_match_name" {
+				data "github_repository" "test" {
 					name = "owner/repo"
 				}
 			`,
 			"no_match_fullname": `
-				data "github_repository" "no_match_fullname" {
+				data "github_repository" "test" {
 					full_name = "owner/repo"
 				}
 			`,
 		}
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckNoResourceAttr(
+				"data.github_branch.test", "id",
+			),
+		)
 
 		testCase := func(t *testing.T, mode string) {
 			resource.Test(t, resource.TestCase{
@@ -72,12 +78,12 @@ func TestAccGithubRepositoryDataSource(t *testing.T) {
 				Providers: testAccProviders,
 				Steps: []resource.TestStep{
 					{
-						Config:      config["no_match_name"],
-						ExpectError: regexp.MustCompile(`Not Found`),
+						Config: config["no_match_name"],
+						Check:  check,
 					},
 					{
-						Config:      config["no_match_fullname"],
-						ExpectError: regexp.MustCompile(`Not Found`),
+						Config: config["no_match_fullname"],
+						Check:  check,
 					},
 				},
 			})

--- a/github/data_source_github_repository_test.go
+++ b/github/data_source_github_repository_test.go
@@ -51,57 +51,6 @@ func TestAccGithubRepositoryDataSource(t *testing.T) {
 
 	})
 
-	t.Run("raises expected errors when querying for a repository", func(t *testing.T) {
-
-		config := map[string]string{
-			"no_match_name": `
-				data "github_repository" "test" {
-					name = "owner/repo"
-				}
-			`,
-			"no_match_fullname": `
-				data "github_repository" "test" {
-					full_name = "owner/repo"
-				}
-			`,
-		}
-
-		check := resource.ComposeTestCheckFunc(
-			resource.TestCheckNoResourceAttr(
-				"data.github_branch.test", "id",
-			),
-		)
-
-		testCase := func(t *testing.T, mode string) {
-			resource.Test(t, resource.TestCase{
-				PreCheck:  func() { skipUnlessMode(t, mode) },
-				Providers: testAccProviders,
-				Steps: []resource.TestStep{
-					{
-						Config: config["no_match_name"],
-						Check:  check,
-					},
-					{
-						Config: config["no_match_fullname"],
-						Check:  check,
-					},
-				},
-			})
-		}
-
-		t.Run("with an anonymous account", func(t *testing.T) {
-			testCase(t, anonymous)
-		})
-
-		t.Run("with an individual account", func(t *testing.T) {
-			testCase(t, individual)
-		})
-
-		t.Run("with an organization account", func(t *testing.T) {
-			testCase(t, organization)
-		})
-	})
-
 	t.Run("queries a repository with pages configured", func(t *testing.T) {
 
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)


### PR DESCRIPTION
Fixes #933 – github_repository needs to not fail if repository doesn't exist.

This is my first stab at working with a Terraform provider, so bear with me. :)

I began by updating the tests and even with this new condition and no changes to the code, they still worked. So I'm not sure how useful they actually are. As for the implementation itself, I referenced c240bccda92652f74cffc98983aa3b0709b7b404 for the logic but since I don't trust the tests too much I'm not entirely sure how to best verify the change. Please advice!