### PR TITLE
Test for 'nil' on GetRequiredConversationResolution() to avoid crash.

### DIFF
--- a/github/resource_github_branch_protection_v3.go
+++ b/github/resource_github_branch_protection_v3.go
@@ -242,7 +242,9 @@ func resourceGithubBranchProtectionV3Read(d *schema.ResourceData, meta interface
 	d.Set("repository", repoName)
 	d.Set("branch", branch)
 	d.Set("enforce_admins", githubProtection.GetEnforceAdmins().Enabled)
-	d.Set("require_conversation_resolution", githubProtection.GetRequiredConversationResolution().Enabled)
+	if rcr := githubProtection.GetRequiredConversationResolution(); rcr != nil {
+		d.Set("require_conversation_resolution", rcr.Enabled)
+	}
 
 	if err := flattenAndSetRequiredStatusChecks(d, githubProtection); err != nil {
 		return fmt.Errorf("Error setting required_status_checks: %v", err)


### PR DESCRIPTION
On some repositories, we experienced a provider plugin crash at resource_github_branch_protection_v3.go:245 do to a 'nil' value returned from githubProtection.GetRequiredConversationResolution().

This change prevents the provider from crashing and allows the terraform plan to complete successfully.
