### PR TITLE
feat(github_team_repository): allow for custom repository roles

### DIFF
--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -35,7 +35,7 @@ func resourceGithubTeamRepository() *schema.Resource {
 			"permission": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "push",
+				Default:  "pull",
 			},
 			"etag": {
 				Type:     schema.TypeString,

--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -33,10 +33,9 @@ func resourceGithubTeamRepository() *schema.Resource {
 				ForceNew: true,
 			},
 			"permission": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "pull",
-				ValidateFunc: validateValueFunc([]string{"pull", "triage", "push", "maintain", "admin"}),
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "push",
 			},
 			"etag": {
 				Type:     schema.TypeString,

--- a/website/docs/r/team_repository.html.markdown
+++ b/website/docs/r/team_repository.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 * `team_id` - (Required) The GitHub team id or the GitHub team slug
 * `repository` - (Required) The repository to add to the team.
 * `permission` - (Optional) The permissions of team members regarding the repository.
-  Must be one of `pull`, `triage`, `push`, `maintain`, or `admin`. Defaults to `pull`.
+  Must be one of `pull`, `triage`, `push`, `maintain`, `admin` or the name an existing [custom repository role](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-peoples-access-to-your-organization-with-roles/managing-custom-repository-roles-for-an-organization) within the organisation. Defaults to `push`.
 
 
 ## Import

--- a/website/docs/r/team_repository.html.markdown
+++ b/website/docs/r/team_repository.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 * `team_id` - (Required) The GitHub team id or the GitHub team slug
 * `repository` - (Required) The repository to add to the team.
 * `permission` - (Optional) The permissions of team members regarding the repository.
-  Must be one of `pull`, `triage`, `push`, `maintain`, `admin` or the name of an existing [custom repository role](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-peoples-access-to-your-organization-with-roles/managing-custom-repository-roles-for-an-organization) within the organisation. Defaults to `push`.
+  Must be one of `pull`, `triage`, `push`, `maintain`, `admin` or the name of an existing [custom repository role](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-peoples-access-to-your-organization-with-roles/managing-custom-repository-roles-for-an-organization) within the organisation. Defaults to `pull`.
 
 
 ## Import

--- a/website/docs/r/team_repository.html.markdown
+++ b/website/docs/r/team_repository.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 * `team_id` - (Required) The GitHub team id or the GitHub team slug
 * `repository` - (Required) The repository to add to the team.
 * `permission` - (Optional) The permissions of team members regarding the repository.
-  Must be one of `pull`, `triage`, `push`, `maintain`, `admin` or the name an existing [custom repository role](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-peoples-access-to-your-organization-with-roles/managing-custom-repository-roles-for-an-organization) within the organisation. Defaults to `push`.
+  Must be one of `pull`, `triage`, `push`, `maintain`, `admin` or the name of an existing [custom repository role](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-peoples-access-to-your-organization-with-roles/managing-custom-repository-roles-for-an-organization) within the organisation. Defaults to `push`.
 
 
 ## Import


### PR DESCRIPTION
Allow custom repository roles to be passed to the `github_team_repository` resource by removing the string validation on the `permission` argument.

Update the default permission to `push`, which is the default for the [newer API resource](https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions--parameters); previously the API pulled the default from the (deprecated) `permission` parameter of the `team` resource. This may cause an unintended change for some provider users, so I'll leave this up for the maintainers to decide whether to include or not. 

I also opted to leave the tests unchanged as `"pull", "triage", "push", "maintain", "admin"` are still valid test cases.

Closes: https://github.com/integrations/terraform-provider-github/issues/988