### PR TITLE
Remove team from state if deletion failed and it does not exist

### DIFF
--- a/github/resource_github_team.go
+++ b/github/resource_github_team.go
@@ -243,6 +243,29 @@ func resourceGithubTeamDelete(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Deleting team: %s", d.Id())
 	_, err = client.Teams.DeleteTeamByID(ctx, orgId, id)
+	/*
+		When deleting a team and it failed, we need to check if it has already been deleted meanwhile.
+		This could be the case when deleting nested teams via Terraform by looping through a module
+		or resource and the parent team might have been deleted already. If the parent team had
+		been deleted already (via parallel runs), the child team is also already gone (deleted by
+		GitHub automatically).
+		So we're checking if it still exists and if not, simply remove it from TF state.
+	*/
+	if err != nil {
+		// Fetch the team in order to see if it exists or not (http 404)
+		_, _, err = client.Teams.GetTeamByID(ctx, orgId, id)
+		if err != nil {
+			if ghErr, ok := err.(*github.ErrorResponse); ok {
+				if ghErr.Response.StatusCode == http.StatusNotFound {
+					// If team we failed to delete does not exist, remove it from TF state.
+					log.Printf("[WARN] Removing team: %s from state because it no longer exists",
+						d.Id())
+					d.SetId("")
+					return nil
+				}
+			}
+		}
+	}
 	return err
 }
 


### PR DESCRIPTION
# Remove team from state if deletion failed and it does not exist

I experienced this behaviour while continuing the work on team slug: https://github.com/integrations/terraform-provider-github/pull/802 So in order not to submit all changes at once, I will make this a separete PR (it does affect current provider as well)

* **Type**: bugfix (similar to this one for repositories: https://github.com/integrations/terraform-provider-github/pull/1031)


## Current state

When deleting a team on GitHub, the API will automatically delete all of its child team. In case we want to remove a team with the terraform provider which parent team has already been deleted, the resource will fail and report back with a `404 - team not found` (or slightly similar).

## Improvement

When deleting a team with this terraform provider and it fails, we try to fetch it and check to see if it returns a 404. If the team we tried to delete does not exist, we will simply remove it from TF state and continue grafefully.


## Notes on code

As I am pretty new to golan, please give me any hints on styling, comments or best-practices which I might have done wrongly.
