### PR TITLE
Allow required_approving_review_count to be 0

### DIFF
--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -67,7 +67,7 @@ func resourceGithubBranchProtection() *schema.Resource {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							Default:      1,
-							ValidateFunc: validation.IntBetween(1, 6),
+							ValidateFunc: validation.IntBetween(0, 6),
 						},
 						PROTECTION_REQUIRES_CODE_OWNER_REVIEWS: {
 							Type:     schema.TypeBool,

--- a/github/resource_github_branch_protection_test.go
+++ b/github/resource_github_branch_protection_test.go
@@ -323,6 +323,72 @@ func TestAccGithubBranchProtection(t *testing.T) {
 
 	})
 
+	t.Run("configures required pull request reviews: 0 required approving review count", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+
+			resource "github_repository" "test" {
+			  name      = "tf-acc-test-%s"
+			  auto_init = true
+			}
+
+			resource "github_branch_protection" "test" {
+
+			  repository_id  = github_repository.test.node_id
+			  pattern        = "main"
+
+				required_pull_request_reviews {
+						dismiss_stale_reviews           = true
+						require_code_owner_reviews      = true
+						required_approving_review_count = 0
+				}
+
+			}
+
+	`, randomID)
+
+		check := resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_branch_protection.test", "required_pull_request_reviews.#", "1",
+			),
+			resource.TestCheckResourceAttr(
+				"github_branch_protection.test", "required_pull_request_reviews.0.dismiss_stale_reviews", "true",
+			),
+			resource.TestCheckResourceAttr(
+				"github_branch_protection.test", "required_pull_request_reviews.0.require_code_owner_reviews", "true",
+			),
+			resource.TestCheckResourceAttr(
+				"github_branch_protection.test", "required_pull_request_reviews.0.required_approving_review_count", "0",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
+
 	t.Run("configures branch push restrictions", func(t *testing.T) {
 
 		config := fmt.Sprintf(`

--- a/github/resource_github_branch_protection_v3.go
+++ b/github/resource_github_branch_protection_v3.go
@@ -101,7 +101,7 @@ func resourceGithubBranchProtectionV3() *schema.Resource {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							Default:      1,
-							ValidateFunc: validation.IntBetween(1, 6),
+							ValidateFunc: validation.IntBetween(0, 6),
 						},
 					},
 				},

--- a/github/resource_github_branch_protection_v3_test.go
+++ b/github/resource_github_branch_protection_v3_test.go
@@ -279,6 +279,76 @@ func TestAccGithubBranchProtectionV3_required_pull_request_reviews(t *testing.T)
 	})
 }
 
+func TestAccGithubBranchProtectionV3_required_pull_request_reviews_zero_approvals(t *testing.T) {
+	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+	t.Run("configures required pull request reviews: 0 required approving review count", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+
+			resource "github_repository" "test" {
+			  name      = "tf-acc-test-%s"
+			  auto_init = true
+			}
+
+			resource "github_branch_protection_v3" "test" {
+
+			  repository  = github_repository.test.name
+			  branch      = "main"
+
+			  required_pull_request_reviews {
+				dismiss_stale_reviews           = true
+				require_code_owner_reviews      = true
+				required_approving_review_count = 0
+			  }
+
+			}
+
+	`, randomID)
+
+		check := resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_branch_protection_v3.test", "required_pull_request_reviews.#", "1",
+			),
+			resource.TestCheckResourceAttr(
+				"github_branch_protection_v3.test", "required_pull_request_reviews.0.dismiss_stale_reviews", "true",
+			),
+			resource.TestCheckResourceAttr(
+				"github_branch_protection_v3.test", "required_pull_request_reviews.0.require_code_owner_reviews", "true",
+			),
+			resource.TestCheckResourceAttr(
+				"github_branch_protection_v3.test", "required_pull_request_reviews.0.required_approving_review_count", "0",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			t.Skip("individual account not supported for this operation")
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
+}
+
 func TestAccGithubBranchProtectionV3_branch_push_restrictions(t *testing.T) {
 
 	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)

--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -99,7 +99,7 @@ The following arguments are supported:
 * `restrict_dismissals`: (Optional) Restrict pull request review dismissals.
 * `dismissal_restrictions`: (Optional) The list of actor IDs with dismissal access. If not empty, `restrict_dismissals` is ignored.
 * `require_code_owner_reviews`: (Optional) Require an approved review in pull requests including files with a designated code owner. Defaults to `false`.
-* `required_approving_review_count`: (Optional) Require x number of approvals to satisfy branch protection requirements. If this is specified it must be a number between 1-6. This requirement matches GitHub's API, see the upstream [documentation](https://developer.github.com/v3/repos/branches/#parameters-1) for more information.
+* `required_approving_review_count`: (Optional) Require x number of approvals to satisfy branch protection requirements. If this is specified it must be a number between 0-6. This requirement matches GitHub's API, see the upstream [documentation](https://docs.github.com/en/rest/reference/branches#update-branch-protection) for more information.
 
 
 ## Import

--- a/website/docs/r/branch_protection_v3.html.markdown
+++ b/website/docs/r/branch_protection_v3.html.markdown
@@ -99,7 +99,7 @@ The following arguments are supported:
 * `dismissal_teams`: (Optional) The list of team slugs with dismissal access.
   Always use `slug` of the team, **not** its name. Each team already **has** to have access to the repository.
 * `require_code_owner_reviews`: (Optional) Require an approved review in pull requests including files with a designated code owner. Defaults to `false`.
-* `required_approving_review_count`: (Optional) Require x number of approvals to satisfy branch protection requirements. If this is specified it must be a number between 1-6. This requirement matches GitHub's API, see the upstream [documentation](https://developer.github.com/v3/repos/branches/#parameters-1) for more information.
+* `required_approving_review_count`: (Optional) Require x number of approvals to satisfy branch protection requirements. If this is specified it must be a number between 0-6. This requirement matches GitHub's API, see the upstream [documentation](https://docs.github.com/en/rest/reference/branches#update-branch-protection) for more information.
 
 ### Restrictions
 


### PR DESCRIPTION
According to this comment: https://github.community/t/bug-in-rest-api-branch-protection-rules/212508/6 and the [docs](https://docs.github.com/en/rest/reference/branches#update-branch-protection) the Github API now accepts 0 as a possible value for `required_approving_review_count`.

<img width="742" alt="Screen Shot 2022-01-19 at 12 46 15 PM" src="https://user-images.githubusercontent.com/15153943/150211052-9b586b33-e24d-4215-9465-289c6ce705bc.png">


- Update the restrictions in the provider to allow 0 as a value for this API field.
- Add unit tests to make sure this works (haven't personally run these yet)
- Update docs
