### PR TITLE
test: checkout pull request via sha instead of ref

### DIFF
--- a/.github/workflows/dotcom-acceptance-tests-manual.yml
+++ b/.github/workflows/dotcom-acceptance-tests-manual.yml
@@ -19,8 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 2
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Acceptance Tests (Anonymous)
         id: acceptance-tests-anonymous
         uses: terraformtesting/acceptance-tests@v2.2.0
@@ -48,8 +47,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 2
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Acceptance Tests (Individual)
         id: acceptance-tests-individual
         uses: terraformtesting/acceptance-tests@v2.2.0
@@ -82,8 +80,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 2
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Acceptance Tests (Organization)
         id: acceptance-tests-organization


### PR DESCRIPTION
Reconfigures the manual acceptance run Action to checkout using `sha` instead of `ref`.