### PR TITLE
Small CI cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: GitHub Actions CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request: {}
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,5 +12,6 @@ jobs:
           go-version: '1.17.6'
       - run: make tools
       - run: make lint
-      - run: make test
       - run: make website-lint
+      - run: make fmtcheck
+      - run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,5 @@ jobs:
       - run: make tools
       - run: make lint
       - run: make website-lint
-      - run: make fmtcheck
+      - run: make build
       - run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,11 @@ on: [push, pull_request]
 jobs:
   ci:
     runs-on: ubuntu-latest
-    env:
-      GOFLAGS: "-mod=vendor"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.13'
+          go-version: '1.17.6'
       - run: make tools
       - run: make lint
       - run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ website/node_modules
 *.iml
 *.tfvars
 .vscode/
+testdata/
 
 website/vendor
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,13 +156,7 @@ $ $GOPATH/bin/terraform-provider-github
 ...
 ```
 
-In order to test the provider, you can simply run `make test`.
-
-```sh
-$ make test
-```
-
-In order to run the full suite of Acceptance tests, run `make testacc`.
+In order to run the full suite of provider acceptance tests, run `make testacc`.
 
 *Note:* Acceptance tests create real resources, and often cost money to run.
 
@@ -200,6 +194,8 @@ export GITHUB_TEST_USER_TOKEN=
 ```
 
 See [this project](https://github.com/terraformtesting/acceptance-tests) for more information on how tests are run automatically.
+
+There are also a small amount of unit tests in the provider. Due to the nature of the provider, such tests are currently only recommended for exercising functionality completely internal to the provider. These may be executed by running `make test`.
 
 ### GitHub Personal Access Token
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,8 +6,8 @@ PKG_NAME=github
 default: build
 
 tools:
-	GO111MODULE=on go install github.com/client9/misspell/cmd/misspell
-	GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint
+	go install github.com/client9/misspell/cmd/misspell
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint
 
 build: fmtcheck
 	go install

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -10,7 +10,7 @@ tools:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint
 
 build: fmtcheck
-	go install
+	go build ./...
 
 fmt:
 	@echo "==> Fixing source code with gofmt..."
@@ -23,7 +23,8 @@ lint:
 	@echo "==> Checking source code against linters..."
 	golangci-lint run ./...
 
-test: fmtcheck
+test:
+	go test ./...
 	# commenting this out for release tooling, please run testacc instead
 
 testacc: fmtcheck

--- a/tools.go
+++ b/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package main


### PR DESCRIPTION
There's a couple of small fixes to our CI checks I'd like to make:
- `make build` was running `go install`, not `go build`
- `make test` ran a fmtchecker but not our actual unit tests, which are trivial to run
- Our CONTRIBUTING.md was recommending running unit tests, which we don't really encourage for local development validation
- `tools.go` was improperly formatted; not sure why our CI check didn't catch it
- Removed the `-mod=vendor` flag
    - In [this doc](https://go.dev/ref/mod), see the section that reads: "At go 1.14 or higher, automatic vendoring may be enabled. If the file vendor/modules.txt is present and consistent with go.mod, there is no need to explicitly use the -mod=vendor flag."
- Updated to the most recent version of Go for the Actions runner
    - The project remains low in version and able to be importable by a wide range of Go versions.
    - This should give us quicker build times and smaller binary sizes while retaining backards compatibility. 

I also added `testdata/` to the .gitignore file based on a personal preference, but I'm happy to revert that if desired. 