### PR TITLE
[work in progress] Add ability to set checks field in required_status_checks of github_branch_protection_v3

### DIFF
--- a/github/resource_github_branch_protection_v3.go
+++ b/github/resource_github_branch_protection_v3.go
@@ -65,7 +65,8 @@ func resourceGithubBranchProtectionV3() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"context": {
-										Type: schema.TypeString,
+										Type:     schema.TypeString,
+										Required: true,
 									},
 									"app_id": {
 										Type:     schema.TypeInt,

--- a/github/resource_github_branch_protection_v3.go
+++ b/github/resource_github_branch_protection_v3.go
@@ -59,6 +59,22 @@ func resourceGithubBranchProtectionV3() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
+						"checks": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"context": {
+										Type: schema.TypeString,
+									},
+									"app_id": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										Default:  nil,
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/github/resource_github_branch_protection_v3_test.go
+++ b/github/resource_github_branch_protection_v3_test.go
@@ -151,10 +151,10 @@ func TestAccGithubBranchProtectionV3_conversation_resolution(t *testing.T) {
 	})
 }
 
-func TestAccGithubBranchProtectionV3_required_status_checks(t *testing.T) {
+func TestAccGithubBranchProtectionV3_required_status_checks_contexts(t *testing.T) {
 	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
-	t.Run("configures required status checks", func(t *testing.T) {
+	t.Run("configures required status checks (via contexts)", func(t *testing.T) {
 
 		config := fmt.Sprintf(`
 
@@ -173,6 +173,67 @@ func TestAccGithubBranchProtectionV3_required_status_checks(t *testing.T) {
 			    contexts = ["github/foo"]
 			  }
 
+			}
+
+	`, randomID)
+
+		check := resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_branch_protection_v3.test", "required_status_checks.#", "1",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			t.Skip("individual account not supported for this operation")
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
+}
+func TestAccGithubBranchProtectionV3_required_status_checks_checks(t *testing.T) {
+	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+	t.Run("configures required status checks (via checks)", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+
+			resource "github_repository" "test" {
+			  name      = "tf-acc-test-%s"
+			  auto_init = true
+			}
+
+			resource "github_branch_protection_v3" "test" {
+
+			  repository  = github_repository.test.name
+			  branch      = "main"
+
+			  required_status_checks {
+			    strict   = true
+			    checks   = [{
+					context = "github/foo"
+					app_id  = -1
+				}]
+			  }
 			}
 
 	`, randomID)

--- a/website/docs/r/branch_protection_v3.html.markdown
+++ b/website/docs/r/branch_protection_v3.html.markdown
@@ -89,6 +89,14 @@ The following arguments are supported:
 
 * `strict`: (Optional) Require branches to be up to date before merging. Defaults to `false`.
 * `contexts`: (Optional) The list of status checks to require in order to merge into this branch. No status checks are required by default.
+* `checks` - (Required) The source branch and directory for the rendered Pages site. See [checks configuration](#checks-configuration) below for details.
+
+#### Checks Configuration ####
+
+The `checks` block supports the following:
+
+* `context`: The name of the required check.
+* `app_id`: (Optional) The ID of the GitHub App that must provide this check. Omit this field to automatically select the GitHub App that has recently provided this check, or any app if it was not set by a GitHub App. Pass -1 to explicitly allow any app to set the status.
 
 ### Required Pull Request Reviews
 


### PR DESCRIPTION
Attempt to solve #985 for `github_branch_protection_v3`.

According to the [docs](https://docs.github.com/en/rest/reference/branches#update-branch-protection), the `checks` field contains a list of objects that contain the fields of `context` and `app_id`.

<img width="791" alt="Screen Shot 2022-01-27 at 11 44 01 AM" src="https://user-images.githubusercontent.com/15153943/151435318-2622380b-8c2a-4517-b0e0-ca7ebaece30b.png">

Note: I wrote a unit test to test out the `checks` field, but not sure how to actually run it to make sure this code works.
