### PR TITLE
Added orgname in github_orgranization attributes

### DIFF
--- a/github/data_source_github_organization.go
+++ b/github/data_source_github_organization.go
@@ -17,6 +17,10 @@ func dataSourceGithubOrganization() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"orgname": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"node_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -120,6 +124,7 @@ func dataSourceGithubOrganizationRead(d *schema.ResourceData, meta interface{}) 
 	d.SetId(strconv.FormatInt(organization.GetID(), 10))
 	d.Set("login", organization.GetLogin())
 	d.Set("name", organization.GetName())
+	d.Set("orgname", name)
 	d.Set("description", organization.GetDescription())
 	d.Set("plan", planName)
 	d.Set("repositories", repoList)


### PR DESCRIPTION
Added the `orgname` attribute for the data source `github_organization` as described in the issue #709 
cc: @jcudit 