### PR TITLE
Standardize logs

### DIFF
--- a/github/config.go
+++ b/github/config.go
@@ -147,14 +147,14 @@ func (c *Config) Meta() (interface{}, error) {
 	owner.v3client = v3client
 
 	if c.Anonymous() {
-		log.Printf("[DEBUG] No token present; configuring anonymous owner.")
+		log.Printf("[INFO] No token present; configuring anonymous owner.")
 		return &owner, nil
 	} else {
 		_, err = c.ConfigureOwner(&owner)
 		if err != nil {
 			return &owner, err
 		}
-		log.Printf("[DEBUG] Token present; configuring authenticated owner: %s", owner.name)
+		log.Printf("[INFO] Token present; configuring authenticated owner: %s", owner.name)
 		return &owner, nil
 	}
 }

--- a/github/data_source_github_actions_public_key.go
+++ b/github/data_source_github_actions_public_key.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -31,7 +30,6 @@ func dataSourceGithubActionsPublicKey() *schema.Resource {
 func dataSourceGithubActionsPublicKeyRead(d *schema.ResourceData, meta interface{}) error {
 	repository := d.Get("repository").(string)
 	owner := meta.(*Owner).name
-	log.Printf("[INFO] Refreshing GitHub Actions Public Key from: %s/%s", owner, repository)
 
 	client := meta.(*Owner).v3client
 	ctx := context.Background()

--- a/github/data_source_github_branch.go
+++ b/github/data_source_github_branch.go
@@ -47,12 +47,11 @@ func dataSourceGithubBranchRead(d *schema.ResourceData, meta interface{}) error 
 	branchName := d.Get("branch").(string)
 	branchRefName := "refs/heads/" + branchName
 
-	log.Printf("[DEBUG] Reading GitHub branch reference %s/%s (%s)", orgName, repoName, branchRefName)
 	ref, resp, err := client.Git.GetRef(context.TODO(), orgName, repoName, branchRefName)
 	if err != nil {
 		if err, ok := err.(*github.ErrorResponse); ok {
 			if err.Response.StatusCode == http.StatusNotFound {
-				log.Printf("Error reading GitHub branch reference %s/%s (%s): %s", orgName, repoName, branchRefName, err)
+				log.Printf("[INFO] Error reading GitHub branch reference %s/%s (%s): %s", orgName, repoName, branchRefName, err)
 				d.SetId("")
 				return nil
 			}

--- a/github/data_source_github_membership.go
+++ b/github/data_source_github_membership.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -34,11 +33,10 @@ func dataSourceGithubMembership() *schema.Resource {
 
 func dataSourceGithubMembershipRead(d *schema.ResourceData, meta interface{}) error {
 	username := d.Get("username").(string)
-	log.Printf("[INFO] Refreshing GitHub membership: %s", username)
 
 	client := meta.(*Owner).v3client
-
 	orgName := meta.(*Owner).name
+
 	if configuredOrg := d.Get("organization").(string); configuredOrg != "" {
 		orgName = configuredOrg
 	}

--- a/github/data_source_github_organization.go
+++ b/github/data_source_github_organization.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"log"
 	"strconv"
 
 	"github.com/google/go-github/v42/github"
@@ -53,7 +52,6 @@ func dataSourceGithubOrganization() *schema.Resource {
 
 func dataSourceGithubOrganizationRead(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
-	log.Printf("[INFO] Refreshing GitHub Organization: %s", name)
 
 	client := meta.(*Owner).v3client
 	ctx := meta.(*Owner).StopContext

--- a/github/data_source_github_organization_team_sync_groups.go
+++ b/github/data_source_github_organization_team_sync_groups.go
@@ -3,7 +3,6 @@ package github
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/google/go-github/v42/github"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -39,8 +38,6 @@ func dataSourceGithubOrganizationTeamSyncGroups() *schema.Resource {
 }
 
 func dataSourceGithubOrganizationTeamSyncGroupsRead(d *schema.ResourceData, meta interface{}) error {
-	log.Print("[INFO] Refreshing GitHub Organization Team-Sync Groups")
-
 	client := meta.(*Owner).v3client
 	ctx := context.Background()
 

--- a/github/data_source_github_organization_teams.go
+++ b/github/data_source_github_organization_teams.go
@@ -3,7 +3,6 @@ package github
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/shurcooL/githubv4"
-	"log"
 )
 
 func dataSourceGithubOrganizationTeams() *schema.Resource {
@@ -71,8 +70,6 @@ func dataSourceGithubOrganizationTeamsRead(d *schema.ResourceData, meta interfac
 	client := meta.(*Owner).v4client
 	orgName := meta.(*Owner).name
 	rootTeamsOnly := d.Get("root_teams_only").(bool)
-
-	log.Print("[INFO] Refreshing GitHub Teams for Organization: ", orgName)
 
 	var query TeamsQuery
 	variables := map[string]interface{}{

--- a/github/data_source_github_release.go
+++ b/github/data_source_github_release.go
@@ -3,7 +3,6 @@ package github
 import (
 	"context"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 
@@ -111,7 +110,6 @@ func dataSourceGithubReleaseRead(d *schema.ResourceData, meta interface{}) error
 
 	switch retrieveBy := strings.ToLower(d.Get("retrieve_by").(string)); retrieveBy {
 	case "latest":
-		log.Printf("[INFO] Refreshing GitHub latest release from repository %s", repository)
 		release, _, err = client.Repositories.GetLatestRelease(ctx, owner, repository)
 	case "id":
 		releaseID := int64(d.Get("release_id").(int))
@@ -119,7 +117,6 @@ func dataSourceGithubReleaseRead(d *schema.ResourceData, meta interface{}) error
 			return fmt.Errorf("`release_id` must be set when `retrieve_by` = `id`")
 		}
 
-		log.Printf("[INFO] Refreshing GitHub release by id %d from repository %s", releaseID, repository)
 		release, _, err = client.Repositories.GetRelease(ctx, owner, repository, releaseID)
 	case "tag":
 		tag := d.Get("release_tag").(string)
@@ -127,7 +124,6 @@ func dataSourceGithubReleaseRead(d *schema.ResourceData, meta interface{}) error
 			return fmt.Errorf("`release_tag` must be set when `retrieve_by` = `tag`")
 		}
 
-		log.Printf("[INFO] Refreshing GitHub release by tag %s from repository %s", tag, repository)
 		release, _, err = client.Repositories.GetReleaseByTag(ctx, owner, repository, tag)
 	default:
 		return fmt.Errorf("one of: `latest`, `id`, `tag` must be set for `retrieve_by`")

--- a/github/data_source_github_repositories.go
+++ b/github/data_source_github_repositories.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"log"
 
 	"github.com/google/go-github/v42/github"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -53,7 +52,6 @@ func dataSourceGithubRepositoriesRead(d *schema.ResourceData, meta interface{}) 
 		},
 	}
 
-	log.Printf("[DEBUG] Searching for GitHub repositories: %q", query)
 	fullNames, names, err := searchGithubRepositories(client, query, opt)
 	if err != nil {
 		return err

--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -3,7 +3,6 @@ package github
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -199,10 +198,9 @@ func dataSourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if repoName == "" {
-		return fmt.Errorf("One of %q or %q has to be provided", "full_name", "name")
+		return fmt.Errorf("one of %q or %q has to be provided", "full_name", "name")
 	}
 
-	log.Printf("[DEBUG] Reading GitHub repository %s/%s", owner, repoName)
 	repo, _, err := client.Repositories.Get(context.TODO(), owner, repoName)
 	if err != nil {
 		return err

--- a/github/data_source_github_repository_file.go
+++ b/github/data_source_github_repository_file.go
@@ -76,7 +76,6 @@ func dataSourceGithubRepositoryFileRead(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	log.Printf("[DEBUG] Data Source reading repository file: %s/%s/%s, branch: %s", owner, repo, file, branch)
 	opts := &github.RepositoryContentGetOptions{Ref: branch}
 	fc, _, _, err := client.Repositories.GetContents(ctx, owner, repo, file, opts)
 	if err != nil {

--- a/github/data_source_github_team.go
+++ b/github/data_source_github_team.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"log"
 	"strconv"
 
 	"github.com/google/go-github/v42/github"
@@ -55,7 +54,6 @@ func dataSourceGithubTeam() *schema.Resource {
 
 func dataSourceGithubTeamRead(d *schema.ResourceData, meta interface{}) error {
 	slug := d.Get("slug").(string)
-	log.Printf("[INFO] Refreshing GitHub Team: %s", slug)
 
 	client := meta.(*Owner).v3client
 	orgId := meta.(*Owner).id

--- a/github/data_source_github_user.go
+++ b/github/data_source_github_user.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"log"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -101,7 +100,6 @@ func dataSourceGithubUser() *schema.Resource {
 
 func dataSourceGithubUserRead(d *schema.ResourceData, meta interface{}) error {
 	username := d.Get("username").(string)
-	log.Printf("[INFO] Refreshing GitHub User: %s", username)
 
 	client := meta.(*Owner).v3client
 	ctx := context.Background()

--- a/github/data_source_github_users.go
+++ b/github/data_source_github_users.go
@@ -3,11 +3,11 @@ package github
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/shurcooL/githubv4"
-	"log"
 	"reflect"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/shurcooL/githubv4"
 )
 
 func dataSourceGithubUsers() *schema.Resource {
@@ -69,7 +69,6 @@ func dataSourceGithubUsersRead(d *schema.ResourceData, meta interface{}) error {
 	query := reflect.New(reflect.StructOf(fields)).Elem()
 
 	if len(usernames) > 0 {
-		log.Printf("[INFO] Refreshing GitHub Users: %s", strings.Join(usernames, ", "))
 		ctx := context.WithValue(context.Background(), ctxId, d.Id())
 		client := meta.(*Owner).v4client
 		err := client.Query(ctx, query.Addr().Interface(), variables)

--- a/github/migrate_github_repository_webhook.go
+++ b/github/migrate_github_repository_webhook.go
@@ -11,16 +11,16 @@ import (
 func resourceGithubWebhookMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
 	switch v {
 	case 0:
-		log.Println("[INFO] Found GitHub Webhook State v0; migrating to v1")
+		log.Printf("[INFO] Found GitHub Webhook State v0; migrating to v1")
 		return migrateGithubWebhookStateV0toV1(is)
 	default:
-		return is, fmt.Errorf("Unexpected schema version: %d", v)
+		return is, fmt.Errorf("unexpected schema version: %d", v)
 	}
 }
 
 func migrateGithubWebhookStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
 	if is.Empty() {
-		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		log.Printf("[DEBUG] Empty InstanceState; nothing to migrate.")
 		return is, nil
 	}
 
@@ -48,7 +48,6 @@ func migrateGithubWebhookStateV0toV1(is *terraform.InstanceState) (*terraform.In
 	}
 
 	is.Attributes[prefix+"#"] = "1"
-
 	log.Printf("[DEBUG] GitHub Webhook Attributes after State Migration: %#v", is.Attributes)
 
 	return is, nil

--- a/github/provider.go
+++ b/github/provider.go
@@ -199,7 +199,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 
 		org := d.Get("organization").(string)
 		if org != "" {
-			log.Printf("[DEBUG] Selecting organization attribute as owner: %s", org)
+			log.Printf("[INFO] Selecting organization attribute as owner: %s", org)
 			owner = org
 		}
 
@@ -245,7 +245,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 		if writeDelay <= 0 {
 			return nil, fmt.Errorf("write_delay_ms must be greater than 0ms")
 		}
-		log.Printf("[DEBUG] Setting write_delay_ms to %d", writeDelay)
+		log.Printf("[INFO] Setting write_delay_ms to %d", writeDelay)
 
 		config := Config{
 			Token:      token,

--- a/github/provider_utils.go
+++ b/github/provider_utils.go
@@ -98,11 +98,11 @@ func testAccCheckOrganization() error {
 
 func OwnerOrOrgEnvDefaultFunc() (interface{}, error) {
 	if organization := os.Getenv("GITHUB_ORGANIZATION"); organization != "" {
-		log.Printf("[DEBUG] Selecting owner %s from GITHUB_ORGANIZATION environment variable", organization)
+		log.Printf("[INFO] Selecting owner %s from GITHUB_ORGANIZATION environment variable", organization)
 		return organization, nil
 	}
 	owner := os.Getenv("GITHUB_OWNER")
-	log.Printf("[DEBUG] Selecting owner %s from GITHUB_OWNER environment variable", owner)
+	log.Printf("[INFO] Selecting owner %s from GITHUB_OWNER environment variable", owner)
 	return owner, nil
 }
 

--- a/github/repository_utils.go
+++ b/github/repository_utils.go
@@ -3,7 +3,6 @@ package github
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 
@@ -17,7 +16,7 @@ func checkRepositoryBranchExists(client *github.Client, owner, repo, branch stri
 	if err != nil {
 		if ghErr, ok := err.(*github.ErrorResponse); ok {
 			if ghErr.Response.StatusCode == http.StatusNotFound {
-				return fmt.Errorf("Branch %s not found in repository %s/%s or repository is not readable", branch, owner, repo)
+				return fmt.Errorf("branch %s not found in repository %s/%s or repository is not readable", branch, owner, repo)
 			}
 		}
 		return err
@@ -34,7 +33,7 @@ func checkRepositoryFileExists(client *github.Client, owner, repo, file, branch 
 		return nil
 	}
 	if fc == nil {
-		return fmt.Errorf("File %s not a file in in repository %s/%s or repository is not readable", file, owner, repo)
+		return fmt.Errorf("file %s not a file in in repository %s/%s or repository is not readable", file, owner, repo)
 	}
 
 	return nil
@@ -77,11 +76,10 @@ func getFileCommit(client *github.Client, owner, repo, file, branch string) (*gi
 
 		for _, f := range rc.Files {
 			if f.GetFilename() == file && f.GetStatus() != "removed" {
-				log.Printf("[DEBUG] Found file: %s in commit: %s", file, sha)
 				return rc, nil
 			}
 		}
 	}
 
-	return nil, fmt.Errorf("Cannot find file %s in repo %s/%s", file, owner, repo)
+	return nil, fmt.Errorf("cannot find file %s in repo %s/%s", file, owner, repo)
 }

--- a/github/resource_github_actions_environment_secret.go
+++ b/github/resource_github_actions_environment_secret.go
@@ -127,7 +127,7 @@ func resourceGithubActionsEnvironmentSecretRead(d *schema.ResourceData, meta int
 	if err != nil {
 		if ghErr, ok := err.(*github.ErrorResponse); ok {
 			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[WARN] Removing environment secret %s from state because it no longer exists in GitHub",
+				log.Printf("[INFO] Removing environment secret %s from state because it no longer exists in GitHub",
 					d.Id())
 				d.SetId("")
 				return nil
@@ -156,7 +156,7 @@ func resourceGithubActionsEnvironmentSecretRead(d *schema.ResourceData, meta int
 	// as deleted (unset the ID) in order to fix potential drift by recreating
 	// the resource.
 	if updatedAt, ok := d.GetOk("updated_at"); ok && updatedAt != secret.UpdatedAt.String() {
-		log.Printf("[WARN] The environment secret %s has been externally updated in GitHub", d.Id())
+		log.Printf("[INFO] The environment secret %s has been externally updated in GitHub", d.Id())
 		d.SetId("")
 	} else if !ok {
 		d.Set("updated_at", secret.UpdatedAt.String())
@@ -178,7 +178,7 @@ func resourceGithubActionsEnvironmentSecretDelete(d *schema.ResourceData, meta i
 	if err != nil {
 		return err
 	}
-	log.Printf("[DEBUG] Deleting environment secret: %s", d.Id())
+	log.Printf("[INFO] Deleting environment secret: %s", d.Id())
 	_, err = client.Actions.DeleteEnvSecret(ctx, int(repo.GetID()), envName, secretName)
 
 	return err

--- a/github/resource_github_actions_organization_permissions.go
+++ b/github/resource_github_actions_organization_permissions.go
@@ -3,7 +3,6 @@ package github
 import (
 	"context"
 	"errors"
-	"log"
 
 	"github.com/google/go-github/v42/github"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -110,7 +109,6 @@ func resourceGithubActionsEnabledRepositoriesObject(d *schema.ResourceData) ([]i
 	var enabled []int64
 
 	config := d.Get("enabled_repositories_config").([]interface{})
-	log.Printf("[help] length of config in actopms enabled is %v", len(config))
 	if len(config) > 0 {
 		data := config[0].(map[string]interface{})
 		switch x := data["repository_ids"].(type) {

--- a/github/resource_github_actions_organization_secret.go
+++ b/github/resource_github_actions_organization_secret.go
@@ -141,7 +141,7 @@ func resourceGithubActionsOrganizationSecretRead(d *schema.ResourceData, meta in
 	if err != nil {
 		if ghErr, ok := err.(*github.ErrorResponse); ok {
 			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[WARN] Removing actions secret %s from state because it no longer exists in GitHub",
+				log.Printf("[INFO] Removing actions secret %s from state because it no longer exists in GitHub",
 					d.Id())
 				d.SetId("")
 				return nil
@@ -196,7 +196,7 @@ func resourceGithubActionsOrganizationSecretRead(d *schema.ResourceData, meta in
 	// as deleted (unset the ID) in order to fix potential drift by recreating
 	// the resource.
 	if updatedAt, ok := d.GetOk("updated_at"); ok && updatedAt != secret.UpdatedAt.String() {
-		log.Printf("[WARN] The secret %s has been externally updated in GitHub", d.Id())
+		log.Printf("[INFO] The secret %s has been externally updated in GitHub", d.Id())
 		d.SetId("")
 	} else if !ok {
 		d.Set("updated_at", secret.UpdatedAt.String())
@@ -210,7 +210,7 @@ func resourceGithubActionsOrganizationSecretDelete(d *schema.ResourceData, meta 
 	orgName := meta.(*Owner).name
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
-	log.Printf("[DEBUG] Deleting secret: %s", d.Id())
+	log.Printf("[INFO] Deleting secret: %s", d.Id())
 	_, err := client.Actions.DeleteOrgSecret(ctx, orgName, d.Id())
 	return err
 }

--- a/github/resource_github_actions_runner_group.go
+++ b/github/resource_github_actions_runner_group.go
@@ -96,7 +96,6 @@ func resourceGithubActionsRunnerGroupCreate(d *schema.ResourceData, meta interfa
 
 	ctx := context.Background()
 
-	log.Printf("[DEBUG] Creating organization runner group: %s (%s)", name, orgName)
 	runnerGroup, resp, err := client.Actions.CreateOrganizationRunnerGroup(ctx,
 		orgName,
 		github.CreateRunnerGroupRequest{
@@ -141,7 +140,6 @@ func resourceGithubActionsRunnerGroupRead(d *schema.ResourceData, meta interface
 		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
 	}
 
-	log.Printf("[DEBUG] Reading organization runner group: %s (%s)", d.Id(), orgName)
 	runnerGroup, resp, err := client.Actions.GetOrganizationRunnerGroup(ctx, orgName, runnerGroupID)
 	if err != nil {
 		if ghErr, ok := err.(*github.ErrorResponse); ok {
@@ -149,7 +147,7 @@ func resourceGithubActionsRunnerGroupRead(d *schema.ResourceData, meta interface
 				return nil
 			}
 			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[WARN] Removing organization runner group %s/%s from state because it no longer exists in GitHub",
+				log.Printf("[INFO] Removing organization runner group %s/%s from state because it no longer exists in GitHub",
 					orgName, d.Id())
 				d.SetId("")
 				return nil
@@ -168,7 +166,6 @@ func resourceGithubActionsRunnerGroupRead(d *schema.ResourceData, meta interface
 	d.Set("selected_repositories_url", runnerGroup.GetSelectedRepositoriesURL())
 	d.Set("visibility", runnerGroup.GetVisibility())
 
-	log.Printf("[DEBUG] Reading organization runner group repositories: %s (%s)", d.Id(), orgName)
 	selectedRepositoryIDs := []int64{}
 	options := github.ListOptions{
 		PerPage: maxPerPage,
@@ -191,7 +188,6 @@ func resourceGithubActionsRunnerGroupRead(d *schema.ResourceData, meta interface
 		options.Page = resp.NextPage
 	}
 
-	log.Printf("[DEBUG] Got selected_repository_ids: %v", selectedRepositoryIDs)
 	d.Set("selected_repository_ids", selectedRepositoryIDs)
 
 	return nil
@@ -220,7 +216,6 @@ func resourceGithubActionsRunnerGroupUpdate(d *schema.ResourceData, meta interfa
 	}
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
-	log.Printf("[DEBUG] Updating organization runner group: %s (%s)", d.Id(), orgName)
 	if _, _, err := client.Actions.UpdateOrganizationRunnerGroup(ctx, orgName, runnerGroupID, options); err != nil {
 		return err
 	}
@@ -238,7 +233,6 @@ func resourceGithubActionsRunnerGroupUpdate(d *schema.ResourceData, meta interfa
 
 	reposOptions := github.SetRepoAccessRunnerGroupRequest{SelectedRepositoryIDs: selectedRepositoryIDs}
 
-	log.Printf("[DEBUG] Updating organization runner group's selected repositries: %s (%s)", d.Id(), orgName)
 	if _, err := client.Actions.SetRepositoryAccessRunnerGroup(ctx, orgName, runnerGroupID, reposOptions); err != nil {
 		return err
 	}
@@ -260,7 +254,7 @@ func resourceGithubActionsRunnerGroupDelete(d *schema.ResourceData, meta interfa
 	}
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
-	log.Printf("[DEBUG] Deleting organization runner group: %s (%s)", d.Id(), orgName)
+	log.Printf("[INFO] Deleting organization runner group: %s (%s)", d.Id(), orgName)
 	_, err = client.Actions.DeleteOrganizationRunnerGroup(ctx, orgName, runnerGroupID)
 	return err
 }


### PR DESCRIPTION
Frequently while working with the project, I find the logs messy and unwieldy to work with. I end up having to wade through a lot of unrelated logs to find interesting information, and our log level practices are all over the place. 

This PR represents my best effort to standardize on [Dave Cheney's log levels best practices](https://dave.cheney.net/2015/11/05/lets-talk-about-logging). It removes all log levels except for two: `INFO` and `DEBUG`, which is information intended for the user and the developer, respectively. I've kept `INFO`-level logs to things like auth logic and when we make state correction for external changes. `DEBUG`-level logs tend to describe tricky logic, such as GitHub webhook state migration and commit lookup. In many cases, I've removed them entirely. 

My hope is this makes the provider a bit cleaner and easier to work with. 