### PR TITLE
Allow for retrieving latest prerelease as data source.

### DIFF
--- a/github/provider_utils.go
+++ b/github/provider_utils.go
@@ -33,6 +33,9 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("GITHUB_TEMPLATE_REPOSITORY_RELEASE_ID"); v == "" {
 		t.Fatal("GITHUB_TEMPLATE_REPOSITORY_RELEASE_ID must be set for acceptance tests")
 	}
+	if v := os.Getenv("GITHUB_TEMPLATE_REPOSITORY_PRERELEASE_ID"); v == "" {
+		t.Fatal("GITHUB_TEMPLATE_REPOSITORY_PRERELEASE_ID must be set for acceptance tests")
+	}
 }
 
 func skipUnlessMode(t *testing.T, providerMode string) {


### PR DESCRIPTION
### Description
Being able to retrieve the latest release from a given repository is awesome, but there's circumstances in which it'd be beneficial to grab the latest prerelease. In a continuous deployment workflow where there's a "prerelease" like environment (staging, preproduction, prerelease, rc, etc.) it'd be great to be able to pull the tag information directly from the provider, rather than having to skip out to the API to do it.

This PR introduces that functionality by allowing for passing `latest_prerelease` as a valid value to `retrieve_by` on the release data source. It's a little more involved than retrieving just the latest release, because the GitHub API at the moment doesn't allow for allowing prereleases as a flag on `/latest`. Instead, we're retrieving a few pages worth of releases, filtering out the prereleases, and selecting the most recently published one. 

This _does_ mean that there's a pretty substantial performance difference, as there's both more data to process and more requests being made. 