### PR TITLE
Adding suspended_at attribute to github_user data source

### DIFF
--- a/github/data_source_github_user.go
+++ b/github/data_source_github_user.go
@@ -91,6 +91,10 @@ func dataSourceGithubUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"suspended_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"node_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -149,6 +153,7 @@ func dataSourceGithubUserRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("following", user.GetFollowing())
 	d.Set("created_at", user.GetCreatedAt())
 	d.Set("updated_at", user.GetUpdatedAt())
+	d.Set("suspended_at", user.GetSuspendedAt())
 	d.Set("node_id", user.GetNodeID())
 
 	return nil

--- a/website/docs/d/user.html.markdown
+++ b/website/docs/d/user.html.markdown
@@ -53,3 +53,4 @@ output "current_github_login" {
  * `following` - the number of following users.
  * `created_at` - the creation date.
  * `updated_at` - the update date.
+ * `suspended_at` - the suspended date if the user is suspended.


### PR DESCRIPTION
Closes https://github.com/integrations/terraform-provider-github/issues/978

Should be very low risk.

```
% go test -v ./... -run TestAccGithubUserDataSource
?   	github.com/terraform-providers/terraform-provider-github	[no test files]
=== RUN   TestAccGithubUserDataSource
=== RUN   TestAccGithubUserDataSource/queries_an_existing_individual_account_without_error
=== RUN   TestAccGithubUserDataSource/queries_an_existing_individual_account_without_error/with_an_anonymous_account
    data_source_github_user_test.go:40: anonymous account not supported for this operation
=== RUN   TestAccGithubUserDataSource/queries_an_existing_individual_account_without_error/with_an_individual_account
    testing.go:541: Acceptance tests skipped unless env 'TF_ACC' set
=== RUN   TestAccGithubUserDataSource/queries_an_existing_individual_account_without_error/with_an_organization_account
    testing.go:541: Acceptance tests skipped unless env 'TF_ACC' set
=== RUN   TestAccGithubUserDataSource/errors_when_querying_a_non-existing_individual_account
=== RUN   TestAccGithubUserDataSource/errors_when_querying_a_non-existing_individual_account/with_an_anonymous_account
    data_source_github_user_test.go:75: anonymous account not supported for this operation
=== RUN   TestAccGithubUserDataSource/errors_when_querying_a_non-existing_individual_account/with_an_individual_account
    testing.go:541: Acceptance tests skipped unless env 'TF_ACC' set
=== RUN   TestAccGithubUserDataSource/errors_when_querying_a_non-existing_individual_account/with_an_organization_account
    testing.go:541: Acceptance tests skipped unless env 'TF_ACC' set
--- PASS: TestAccGithubUserDataSource (0.00s)
    --- PASS: TestAccGithubUserDataSource/queries_an_existing_individual_account_without_error (0.00s)
        --- SKIP: TestAccGithubUserDataSource/queries_an_existing_individual_account_without_error/with_an_anonymous_account (0.00s)
        --- SKIP: TestAccGithubUserDataSource/queries_an_existing_individual_account_without_error/with_an_individual_account (0.00s)
        --- SKIP: TestAccGithubUserDataSource/queries_an_existing_individual_account_without_error/with_an_organization_account (0.00s)
    --- PASS: TestAccGithubUserDataSource/errors_when_querying_a_non-existing_individual_account (0.00s)
        --- SKIP: TestAccGithubUserDataSource/errors_when_querying_a_non-existing_individual_account/with_an_anonymous_account (0.00s)
        --- SKIP: TestAccGithubUserDataSource/errors_when_querying_a_non-existing_individual_account/with_an_individual_account (0.00s)
        --- SKIP: TestAccGithubUserDataSource/errors_when_querying_a_non-existing_individual_account/with_an_organization_account (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-github/github	(cached)
```