### PR TITLE
Add a data source for refs.

### DIFF
--- a/github/data_source_github_ref.go
+++ b/github/data_source_github_ref.go
@@ -1,0 +1,67 @@
+package github
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/google/go-github/v42/github"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceGithubRef() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGithubRefRead,
+
+		Schema: map[string]*schema.Schema{
+			"repository": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"branch": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"etag": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ref": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sha": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceGithubRefRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
+	repoName := d.Get("repository").(string)
+	ref := d.Get("ref").(string)
+
+	refData, resp, err := client.Git.GetRef(context.TODO(), orgName, repoName, ref)
+	if err != nil {
+		if err, ok := err.(*github.ErrorResponse); ok {
+			if err.Response.StatusCode == http.StatusNotFound {
+				log.Printf("[DEBUG] Missing GitHub ref %s/%s (%s)", orgName, repoName, ref)
+				d.SetId("")
+				return nil
+			}
+		}
+		return err
+	}
+
+	d.SetId(buildTwoPartID(repoName, ref))
+	d.Set("etag", resp.Header.Get("ETag"))
+	d.Set("ref", *refData.Ref)
+	d.Set("sha", *refData.Object.SHA)
+
+	return nil
+}

--- a/github/data_source_github_ref_test.go
+++ b/github/data_source_github_ref_test.go
@@ -1,0 +1,109 @@
+package github
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccGithubRefDataSource(t *testing.T) {
+
+	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+	t.Run("queries an existing ref without error", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+			  name = "tf-acc-test-%[1]s"
+				auto_init = true
+			}
+
+			data "github_ref" "test" {
+				repository = github_repository.test.id
+				ref = "/heads/main"
+			}
+		`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestMatchResourceAttr(
+				"data.github_ref.test", "id", regexp.MustCompile(randomID),
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
+
+	t.Run("queries an invalid ref without error", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+			  name = "tf-acc-test-%[1]s"
+				auto_init = true
+			}
+
+			data "github_ref" "test" {
+				repository = github_repository.test.id
+				ref = "heads/xxxxxx"
+			}
+		`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckNoResourceAttr(
+				"data.github_ref.test", "id",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
+}

--- a/github/provider.go
+++ b/github/provider.go
@@ -137,6 +137,7 @@ func Provider() terraform.ResourceProvider {
 			"github_organization":                  dataSourceGithubOrganization(),
 			"github_organization_team_sync_groups": dataSourceGithubOrganizationTeamSyncGroups(),
 			"github_organization_teams":            dataSourceGithubOrganizationTeams(),
+			"github_ref":                           dataSourceGithubRef(),
 			"github_release":                       dataSourceGithubRelease(),
 			"github_repositories":                  dataSourceGithubRepositories(),
 			"github_repository":                    dataSourceGithubRepository(),

--- a/website/docs/d/ref.html.markdown
+++ b/website/docs/d/ref.html.markdown
@@ -1,0 +1,35 @@
+---
+layout: "github"
+page_title: "GitHub: github_ref"
+description: |-
+  Get information about a repository ref.
+---
+
+# github\ref
+
+Use this data source to retrieve information about a repository ref.
+
+## Example Usage
+
+```hcl
+data "github_ref" "development" {
+  repository = "example"
+  ref     = "heads/development"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `repository` - (Required) The GitHub repository name.
+
+* `ref` - (Required) The repository ref to look up. Must be formatted `heads/<ref>` for branches, and `tags/<ref>` for tags.
+
+## Attribute Reference
+
+The following additional attributes are exported:
+
+* `etag` - An etag representing the ref.
+
+* `sha` - A string storing the reference's `HEAD` commit's SHA1.

--- a/website/github.erb
+++ b/website/github.erb
@@ -38,6 +38,9 @@
               <a href="/docs/providers/github/d/organization_teams.html">github_organization_teams</a>
             </li>
             <li>
+              <a href="/docs/providers/github/d/ref.html">github_ref</a>
+            </li>
+            <li>
               <a href="/docs/providers/github/d/release.html">github_release</a>
             </li>
             <li>


### PR DESCRIPTION
### Description
We're currently lacking a way to retrieve some basic information on a given ref within the Terraform provider. A crisp use case for this might be "I have a release that's based off of a tag, and I'd like to be able to retrieve the SHA1 for the HEAD commit in order to use elsewhere." This PR introduces a `github_ref` data source, which pretty shamelessly steals from the existing `github_branch` data source. I considered lifting out some of the code into a shared function, but the API calls are lightweight enough where I don't think there's that much harm from a few lines of duplication. 

Tests are currently passing and documentation has been added to the markdown.