### PR TITLE
fix: use pagination to fetch all team members

### DIFF
--- a/github/resource_github_team_members.go
+++ b/github/resource_github_team_members.go
@@ -205,17 +205,52 @@ func resourceGithubTeamMembersRead(d *schema.ResourceData, meta interface{}) err
 		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
 	}
 
+	etags := make([]string, 0)
 	// List members & maintainers as list 'all' drops role information
 	log.Printf("[DEBUG] Reading team members: %s", teamIdString)
-	members, resp1, err := client.Teams.ListTeamMembersByID(ctx, orgId, teamId, &github.TeamListTeamMembersOptions{Role: "member"})
-	if err != nil {
-		return err
+	memberOptions := github.TeamListTeamMembersOptions{
+		ListOptions: github.ListOptions{
+			PerPage: maxPerPage,
+		},
+		Role: "member",
+	}
+
+	var members []*github.User
+	for {
+		member, resp, err := client.Teams.ListTeamMembersByID(ctx, orgId, teamId, &memberOptions)
+		if err != nil {
+			return err
+		}
+
+		etags = append(etags, resp.Header.Get("ETag"))
+		members = append(members, member...)
+		if resp.NextPage == 0 {
+			break
+		}
+		memberOptions.Page = resp.NextPage
 	}
 
 	log.Printf("[DEBUG] Reading team maintainers: %s", teamIdString)
-	maintainers, resp2, err := client.Teams.ListTeamMembersByID(ctx, orgId, teamId, &github.TeamListTeamMembersOptions{Role: "maintainer"})
-	if err != nil {
-		return err
+	maintainerOptions := github.TeamListTeamMembersOptions{
+		ListOptions: github.ListOptions{
+			PerPage: maxPerPage,
+		},
+		Role: "maintainer",
+	}
+	var maintainers []*github.User
+	for {
+		maintaner, resp, err := client.Teams.ListTeamMembersByID(ctx, orgId, teamId, &maintainerOptions)
+		if err != nil {
+			return err
+		}
+
+		etags = append(etags, resp.Header.Get("ETag"))
+		maintainers = append(maintainers, maintaner...)
+
+		if resp.NextPage == 0 {
+			break
+		}
+		maintainerOptions.Page = resp.NextPage
 	}
 
 	teamMembersAndMaintainers := make([]interface{}, len(members)+len(maintainers))
@@ -239,7 +274,7 @@ func resourceGithubTeamMembersRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	// Combine etag of both requests
-	d.Set("etag", buildTwoPartID(resp1.Header.Get("ETag"), resp2.Header.Get("ETag")))
+	d.Set("etag", buildChecksumID(etags))
 
 	return nil
 }

--- a/github/resource_github_team_members.go
+++ b/github/resource_github_team_members.go
@@ -273,7 +273,7 @@ func resourceGithubTeamMembersRead(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	// Combine etag of both requests
+	// Combine etag of all requests
 	d.Set("etag", buildChecksumID(etags))
 
 	return nil


### PR DESCRIPTION
## If applied, this pull request will...

- use pagination on the new github_team_members resource
- compute a new etag based on the etag of each request

## Why is this change needed?

- Because it currently fetches only 30 members so terraform tries to change the members on each run even though nothing changed

## References to relevant tickets, articles or other resources

- https://github.com/integrations/terraform-provider-github/pull/702
  - I used the same code from that PR