### PR TITLE
fix: remove incorrect required schema key on ref data source

### DIFF
--- a/github/data_source_github_ref.go
+++ b/github/data_source_github_ref.go
@@ -14,21 +14,17 @@ func dataSourceGithubRef() *schema.Resource {
 		Read: dataSourceGithubRefRead,
 
 		Schema: map[string]*schema.Schema{
+			"ref": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
 			"repository": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"branch": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
 			"etag": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"ref": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -60,7 +56,6 @@ func dataSourceGithubRefRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(buildTwoPartID(repoName, ref))
 	d.Set("etag", resp.Header.Get("ETag"))
-	d.Set("ref", *refData.Ref)
 	d.Set("sha", *refData.Object.SHA)
 
 	return nil

--- a/github/data_source_github_ref_test.go
+++ b/github/data_source_github_ref_test.go
@@ -13,8 +13,7 @@ func TestAccGithubRefDataSource(t *testing.T) {
 
 	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
-	t.Run("queries an existing ref without error", func(t *testing.T) {
-
+	t.Run("queries an existing branch ref without error", func(t *testing.T) {
 		config := fmt.Sprintf(`
 			resource "github_repository" "test" {
 			  name = "tf-acc-test-%[1]s"
@@ -23,7 +22,7 @@ func TestAccGithubRefDataSource(t *testing.T) {
 
 			data "github_ref" "test" {
 				repository = github_repository.test.id
-				ref = "/heads/main"
+				ref = "heads/main"
 			}
 		`, randomID)
 

--- a/website/docs/d/ref.html.markdown
+++ b/website/docs/d/ref.html.markdown
@@ -5,7 +5,7 @@ description: |-
   Get information about a repository ref.
 ---
 
-# github\ref
+# github_ref
 
 Use this data source to retrieve information about a repository ref.
 


### PR DESCRIPTION
In #1084, I introduced a data source for refs, but it looks like the merged version is off an older commit I had pushed, which includes a required schema key on the data source that isn't used by the ref API. This PR introduces the correct code (along with a quick typo fix on the documentation). 

### Test output:
```
--- PASS: TestAccGithubRefDataSource (24.72s)
    --- PASS: TestAccGithubRefDataSource/queries_an_existing_branch_ref_without_error (12.40s)
        --- SKIP: TestAccGithubRefDataSource/queries_an_existing_branch_ref_without_error/with_an_anonymous_account (0.00s)
        --- PASS: TestAccGithubRefDataSource/queries_an_existing_branch_ref_without_error/with_an_individual_account (6.42s)
        --- PASS: TestAccGithubRefDataSource/queries_an_existing_branch_ref_without_error/with_an_organization_account (5.98s)
    --- PASS: TestAccGithubRefDataSource/queries_an_invalid_ref_without_error (12.31s)
        --- SKIP: TestAccGithubRefDataSource/queries_an_invalid_ref_without_error/with_an_anonymous_account (0.00s)
        --- PASS: TestAccGithubRefDataSource/queries_an_invalid_ref_without_error/with_an_individual_account (6.28s)
        --- PASS: TestAccGithubRefDataSource/queries_an_invalid_ref_without_error/with_an_organization_account (6.03s)
PASS
ok      github.com/integrations/terraform-provider-github/v4/github     24.745s
```
