### PR TITLE
Fix typo in github_ref docs

### DIFF
--- a/website/docs/d/ref.html.markdown
+++ b/website/docs/d/ref.html.markdown
@@ -5,7 +5,7 @@ description: |-
   Get information about a repository ref.
 ---
 
-# github\ref
+# github_ref
 
 Use this data source to retrieve information about a repository ref.
 


### PR DESCRIPTION
<img width="967" alt="Screen Shot 2022-04-18 at 6 50 23 PM" src="https://user-images.githubusercontent.com/15153943/163904213-dd8f6766-cf98-49f7-922d-d8a9705fd9d3.png">

https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/ref

Noticed a typo here ^