### PR TITLE
Feature/include all branches

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -240,6 +240,11 @@ func resourceGithubRepository() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"include_all_branches": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 						"owner": {
 							Type:     schema.TypeString,
 							Required: true,
@@ -346,12 +351,14 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 
 			templateRepo := templateConfigMap["repository"].(string)
 			templateRepoOwner := templateConfigMap["owner"].(string)
+			includeAllBranches := templateConfigMap["include_all_branches"].(bool)
 
 			templateRepoReq := github.TemplateRepoRequest{
-				Name:        &repoName,
-				Owner:       &owner,
-				Description: github.String(d.Get("description").(string)),
-				Private:     github.Bool(isPrivate),
+				Name:               &repoName,
+				Owner:              &owner,
+				Description:        github.String(d.Get("description").(string)),
+				Private:            github.Bool(isPrivate),
+				IncludeAllBranches: github.Bool(includeAllBranches),
 			}
 
 			repo, _, err := client.Repositories.CreateFromTemplate(ctx,

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -517,6 +517,55 @@ func TestAccGithubRepositories(t *testing.T) {
 
 	})
 
+	t.Run("creates a repository using a template and all branches", func(t *testing.T) {
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name        = "tf-acc-test-template-%s"
+				description = "Terraform acceptance tests %[1]s"
+
+				template {
+					owner = "%s"
+					repository = "%s"
+					include_all_branches = %t
+				}
+
+			}
+		`, randomID, testOrganization, "terraform-template-module", true)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_repository.test", "template.include_all_branches",
+				"true",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
+
 	t.Run("creates a repository using a template", func(t *testing.T) {
 
 		config := fmt.Sprintf(`

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -20,8 +20,9 @@ resource "github_repository" "example" {
   visibility = "public"
 
   template {
-    owner      = "github"
-    repository = "terraform-module-template"
+    owner                = "github"
+    repository           = "terraform-module-template"
+    include_all_branches = true
   }
 }
 ```
@@ -127,6 +128,7 @@ The `source` block supports the following:
 
 * `owner`: The GitHub organization or user the template repository is owned by.
 * `repository`: The name of the template repository.
+* `include_all_branches`: Whether the new repository should include all the branches from the template repository
 
 ## Attributes Reference
 


### PR DESCRIPTION
When creating a repository from a template, you can pass in a boolean to
include all the branches in the template repo.

This is documented here: https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template

In addition, the provider already supports that here: https://github.com/google/go-github/blob/3e8a7f0fbe0e4402f9ad5a80e0ab0a050786e0f8/github/repos.go#L441

Adding a variable under the template structure and then pass it in to
the provider function works.

This PR includes tests + docs for the new addition. It is backward compatible with the previous behavior

