### PR TITLE
Fix import bug for EMU behavior

### DIFF
--- a/github/resource_github_emu_group_mapping.go
+++ b/github/resource_github_emu_group_mapping.go
@@ -86,6 +86,13 @@ func resourceGithubEMUGroupMappingRead(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
+	if len(group.Teams) < 1 {
+		// if there's not a team linked, that means it was removed outside of terraform
+		// and we should remove it from our state
+		d.SetId("")
+		return nil
+	}
+
 	d.Set("etag", resp.Header.Get("ETag"))
 	d.Set("group", group)
 	return nil


### PR DESCRIPTION
Fixes #1141. 

When writing this resource initially, I neglected to account for the case in which the group association is deleted outside of Terraform, causing Terraform to erroneously think that local state is up-to-date when it's not. After this PR is merged, when the group associated is deleted outside of Terraform, we correctly decide to re-create it. 