### PR TITLE
Support import via team name

### DIFF
--- a/github/resource_github_team.go
+++ b/github/resource_github_team.go
@@ -19,7 +19,7 @@ func resourceGithubTeam() *schema.Resource {
 		Update: resourceGithubTeamUpdate,
 		Delete: resourceGithubTeamDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceGithubTeamImport,
 		},
 
 		CustomizeDiff: customdiff.Sequence(
@@ -293,6 +293,16 @@ func resourceGithubTeamDelete(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 	return err
+}
+
+func resourceGithubTeamImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	teamId, err := getTeamID(d.Id(), meta)
+	if err != nil {
+		return nil, err
+	}
+
+	d.SetId(strconv.FormatInt(teamId, 10))
+	return []*schema.ResourceData{d}, nil
 }
 
 func removeDefaultMaintainer(teamSlug string, meta interface{}) error {

--- a/github/resource_github_team_members.go
+++ b/github/resource_github_team_members.go
@@ -21,7 +21,7 @@ func resourceGithubTeamMembers() *schema.Resource {
 		Update: resourceGithubTeamMembersUpdate,
 		Delete: resourceGithubTeamMembersDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceGithubTeamImport,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -17,7 +17,20 @@ func resourceGithubTeamRepository() *schema.Resource {
 		Update: resourceGithubTeamRepositoryUpdate,
 		Delete: resourceGithubTeamRepositoryDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				teamIdString, username, err := parseTwoPartID(d.Id(), "team_id", "username")
+				if err != nil {
+					return nil, err
+				}
+
+				teamId, err := getTeamID(teamIdString, meta)
+				if err != nil {
+					return nil, err
+				}
+
+				d.SetId(buildTwoPartID(strconv.FormatInt(teamId, 10), username))
+				return []*schema.ResourceData{d}, nil
+			},
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -47,8 +47,9 @@ The following attributes are exported:
 
 ## Import
 
-GitHub Teams can be imported using the GitHub team ID e.g.
+GitHub Teams can be imported using the GitHub team ID or name e.g.
 
 ```
 $ terraform import github_team.core 1234567
+$ terraform import github_team.core Administrators
 ```

--- a/website/docs/r/team_members.html.markdown
+++ b/website/docs/r/team_members.html.markdown
@@ -72,8 +72,9 @@ The following arguments are supported:
 
 ## Import
 
-GitHub Team Membership can be imported using the team ID `teamid`, e.g.
+GitHub Team Membership can be imported using the team ID `teamid` or team name, e.g.
 
 ```
 $ terraform import github_team_members.some_team 1234567
+$ terraform import github_team_members.some_team Administrators
 ```

--- a/website/docs/r/team_membership.html.markdown
+++ b/website/docs/r/team_membership.html.markdown
@@ -50,8 +50,9 @@ The following arguments are supported:
 
 ## Import
 
-GitHub Team Membership can be imported using an ID made up of `teamid:username`, e.g.
+GitHub Team Membership can be imported using an ID made up of `teamid:username` or `teamname:username`, e.g.
 
 ```
 $ terraform import github_team_membership.member 1234567:someuser
+$ terraform import github_team_membership.member Administrators:someuser
 ```

--- a/website/docs/r/team_repository.html.markdown
+++ b/website/docs/r/team_repository.html.markdown
@@ -55,8 +55,9 @@ The following arguments are supported:
 
 ## Import
 
-GitHub Team Repository can be imported using an ID made up of `team_id:repository`, e.g.
+GitHub Team Repository can be imported using an ID made up of `team_id:repository` or `team_name:repository`, e.g.
 
 ```
 $ terraform import github_team_repository.terraform_repo 1234567:terraform
+$ terraform import github_team_repository.terraform_repo Administrators:terraform
 ```


### PR DESCRIPTION
Rather than make the user lookup the team name via the API, use the existing `getTeamID` function to do it for them.