### PR TITLE
Add support for `use_squash_pr_title_as_default` on repo

### DIFF
--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -28,6 +28,11 @@ func dataSourceGithubRepository() *schema.Resource {
 				Computed:      true,
 				ConflictsWith: []string{"full_name"},
 			},
+			"only_protected_branches": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 
 			"description": {
 				Type:     schema.TypeString,
@@ -242,7 +247,12 @@ func dataSourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("repo_id", repo.GetID())
 	d.Set("has_projects", repo.GetHasProjects())
 
-	branches, _, err := client.Repositories.ListBranches(context.TODO(), owner, repoName, nil)
+	onlyProtectedBranches := d.Get("only_protected_branches").(bool)
+	listBranchOptions := &github.BranchListOptions{
+		Protected: &onlyProtectedBranches,
+	}
+
+	branches, _, err := client.Repositories.ListBranches(context.TODO(), owner, repoName, listBranchOptions)
 	if err != nil {
 		return err
 	}

--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -84,6 +84,10 @@ func dataSourceGithubRepository() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"use_squash_pr_title_as_default": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"default_branch": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -234,6 +238,7 @@ func dataSourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("allow_squash_merge", repo.GetAllowSquashMerge())
 	d.Set("allow_rebase_merge", repo.GetAllowRebaseMerge())
 	d.Set("allow_auto_merge", repo.GetAllowAutoMerge())
+	d.Set("use_squash_pr_title_as_default", repo.GetUseSquashPRTitleAsDefault())
 	d.Set("has_downloads", repo.GetHasDownloads())
 	d.Set("full_name", repo.GetFullName())
 	d.Set("default_branch", repo.GetDefaultBranch())

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -94,6 +94,11 @@ func resourceGithubRepository() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"use_squash_pr_title_as_default": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"delete_branch_on_merge": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -282,25 +287,26 @@ func calculateVisibility(d *schema.ResourceData) string {
 
 func resourceGithubRepositoryObject(d *schema.ResourceData) *github.Repository {
 	return &github.Repository{
-		Name:                github.String(d.Get("name").(string)),
-		Description:         github.String(d.Get("description").(string)),
-		Homepage:            github.String(d.Get("homepage_url").(string)),
-		Visibility:          github.String(calculateVisibility(d)),
-		HasDownloads:        github.Bool(d.Get("has_downloads").(bool)),
-		HasIssues:           github.Bool(d.Get("has_issues").(bool)),
-		HasProjects:         github.Bool(d.Get("has_projects").(bool)),
-		HasWiki:             github.Bool(d.Get("has_wiki").(bool)),
-		IsTemplate:          github.Bool(d.Get("is_template").(bool)),
-		AllowMergeCommit:    github.Bool(d.Get("allow_merge_commit").(bool)),
-		AllowSquashMerge:    github.Bool(d.Get("allow_squash_merge").(bool)),
-		AllowRebaseMerge:    github.Bool(d.Get("allow_rebase_merge").(bool)),
-		AllowAutoMerge:      github.Bool(d.Get("allow_auto_merge").(bool)),
-		DeleteBranchOnMerge: github.Bool(d.Get("delete_branch_on_merge").(bool)),
-		AutoInit:            github.Bool(d.Get("auto_init").(bool)),
-		LicenseTemplate:     github.String(d.Get("license_template").(string)),
-		GitignoreTemplate:   github.String(d.Get("gitignore_template").(string)),
-		Archived:            github.Bool(d.Get("archived").(bool)),
-		Topics:              expandStringList(d.Get("topics").(*schema.Set).List()),
+		Name:                      github.String(d.Get("name").(string)),
+		Description:               github.String(d.Get("description").(string)),
+		Homepage:                  github.String(d.Get("homepage_url").(string)),
+		Visibility:                github.String(calculateVisibility(d)),
+		HasDownloads:              github.Bool(d.Get("has_downloads").(bool)),
+		HasIssues:                 github.Bool(d.Get("has_issues").(bool)),
+		HasProjects:               github.Bool(d.Get("has_projects").(bool)),
+		HasWiki:                   github.Bool(d.Get("has_wiki").(bool)),
+		IsTemplate:                github.Bool(d.Get("is_template").(bool)),
+		AllowMergeCommit:          github.Bool(d.Get("allow_merge_commit").(bool)),
+		AllowSquashMerge:          github.Bool(d.Get("allow_squash_merge").(bool)),
+		AllowRebaseMerge:          github.Bool(d.Get("allow_rebase_merge").(bool)),
+		AllowAutoMerge:            github.Bool(d.Get("allow_auto_merge").(bool)),
+		UseSquashPRTitleAsDefault: github.Bool(d.Get("use_squash_pr_title_as_default").(bool)),
+		DeleteBranchOnMerge:       github.Bool(d.Get("delete_branch_on_merge").(bool)),
+		AutoInit:                  github.Bool(d.Get("auto_init").(bool)),
+		LicenseTemplate:           github.String(d.Get("license_template").(string)),
+		GitignoreTemplate:         github.String(d.Get("gitignore_template").(string)),
+		Archived:                  github.Bool(d.Get("archived").(bool)),
+		Topics:                    expandStringList(d.Get("topics").(*schema.Set).List()),
 	}
 }
 
@@ -440,6 +446,7 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("allow_squash_merge", repo.GetAllowSquashMerge())
 	d.Set("allow_rebase_merge", repo.GetAllowRebaseMerge())
 	d.Set("allow_auto_merge", repo.GetAllowAutoMerge())
+	d.Set("use_squash_pr_title_as_default", repo.GetUseSquashPRTitleAsDefault())
 	d.Set("delete_branch_on_merge", repo.GetDeleteBranchOnMerge())
 	d.Set("has_downloads", repo.GetHasDownloads())
 	d.Set("full_name", repo.GetFullName())

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -24,14 +24,15 @@ func TestAccGithubRepositories(t *testing.T) {
 			  name         = "tf-acc-test-create-%[1]s"
 			  description  = "Terraform acceptance tests %[1]s"
 
-			  has_issues         = true
-			  has_wiki           = true
-			  has_downloads      = true
-			  allow_merge_commit = true
-			  allow_squash_merge = false
-			  allow_rebase_merge = false
-			  allow_auto_merge   = true
-			  auto_init          = false
+			  has_issues                     = true
+			  has_wiki                       = true
+			  has_downloads                  = true
+			  allow_merge_commit             = true
+			  allow_squash_merge             = false
+			  allow_rebase_merge             = false
+			  allow_auto_merge               = true
+			  use_squash_pr_title_as_default = true
+			  auto_init                      = false
 
 			}
 		`, randomID)
@@ -43,6 +44,10 @@ func TestAccGithubRepositories(t *testing.T) {
 			),
 			resource.TestCheckResourceAttr(
 				"github_repository.test", "allow_auto_merge",
+				"true",
+			),
+			resource.TestCheckResourceAttr(
+				"github_repository.test", "use_squash_pr_title_as_default",
 				"true",
 			),
 		)

--- a/website/docs/d/repository.html.markdown
+++ b/website/docs/d/repository.html.markdown
@@ -25,6 +25,8 @@ The following arguments are supported:
 
 * `full_name` - (Optional) Full name of the repository (in `org/name` format).
 
+* `only_protected_branches` - (Optional). If true, the `branches` attributes will be populated only with protected branches. Default: `false`.
+
 ## Attributes Reference
 
 * `node_id` - the Node ID of the repository.

--- a/website/docs/d/repository.html.markdown
+++ b/website/docs/d/repository.html.markdown
@@ -53,6 +53,8 @@ The following arguments are supported:
 
 * `allow_auto_merge` - Whether the repository allows auto-merging pull requests.
 
+* `use_squash_pr_title_as_default` - Whether the repository defaults to using PR titles for squash merge commit messages.
+
 * `has_downloads` - Whether the repository has Downloads feature enabled.
 
 * `default_branch` - The name of the default branch of the repository.

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -77,6 +77,8 @@ The following arguments are supported:
 
 * `allow_auto_merge` - (Optional) Set to `true` to allow auto-merging pull requests on the repository.
 
+* `use_squash_pr_title_as_default` - (Optional) Set to `true` to default to using PR titles for squash merge commit messages on the repository.
+
 * `delete_branch_on_merge` - (Optional) Automatically delete head branch after a pull request is merged. Defaults to `false`.
 
 * `has_downloads` - (Optional) Set to `true` to enable the (deprecated) downloads features on the repository.


### PR DESCRIPTION
Adds support for defaulting to using PR titles for squash merge commit messages ([Github announcement](https://github.blog/changelog/2022-05-11-default-to-pr-titles-for-squash-merge-commit-messages/))

Related: https://github.com/google/go-github/pull/2390

Closes #1150