### PR TITLE
Send a `User-Agent` in GitHub API requests with `terraform-provider-github` and the version

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,6 +15,7 @@ The release flow is as follows:
     ## BUG FIXES:
     ...
     ```
+1. Update the `Version` constant in `github/version.go`. (This is used to send a versioned `User-Agent` in requests to GitHub.)
 1. Tag the commit that adds the CHANGELOG entry with the release version and push:
     ```shell
     $ git tag x.y.z

--- a/github/config.go
+++ b/github/config.go
@@ -32,9 +32,10 @@ type Owner struct {
 	IsOrganization bool
 }
 
-func RateLimitedHTTPClient(client *http.Client, writeDelay time.Duration, readDelay time.Duration) *http.Client {
+func CustomizedHTTPClient(client *http.Client, writeDelay time.Duration, readDelay time.Duration) *http.Client {
 
 	client.Transport = NewEtagTransport(client.Transport)
+	client.Transport = NewUserAgentTransport(client.Transport)
 	client.Transport = NewRateLimitTransport(client.Transport, WithWriteDelay(writeDelay), WithReadDelay(readDelay))
 	client.Transport = logging.NewTransport("Github", client.Transport)
 
@@ -49,7 +50,7 @@ func (c *Config) AuthenticatedHTTPClient() *http.Client {
 	)
 	client := oauth2.NewClient(ctx, ts)
 
-	return RateLimitedHTTPClient(client, c.WriteDelay, c.ReadDelay)
+	return CustomizedHTTPClient(client, c.WriteDelay, c.ReadDelay)
 }
 
 func (c *Config) Anonymous() bool {
@@ -58,7 +59,7 @@ func (c *Config) Anonymous() bool {
 
 func (c *Config) AnonymousHTTPClient() *http.Client {
 	client := &http.Client{Transport: &http.Transport{}}
-	return RateLimitedHTTPClient(client, c.WriteDelay, c.ReadDelay)
+	return CustomizedHTTPClient(client, c.WriteDelay, c.ReadDelay)
 }
 
 func (c *Config) NewGraphQLClient(client *http.Client) (*githubv4.Client, error) {

--- a/github/transport.go
+++ b/github/transport.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	ctxEtag = ctxEtagType("etag")
-	ctxId   = ctxIdType("id")
+	ctxEtag        = ctxEtagType("etag")
+	ctxId          = ctxIdType("id")
+	packageVersion = "4.26.1"
 )
 
 // ctxIdType is used to avoid collisions between packages using context
@@ -185,4 +186,21 @@ func isWriteMethod(method string) bool {
 		return true
 	}
 	return false
+}
+
+type userAgentTransport struct {
+	transport http.RoundTripper
+}
+
+func (uat *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// The transport is the mechanism "by which individual HTTP requests are made"
+	// (<https://pkg.go.dev/net/http>), so this will generally overwrite `User-Agent`
+	// headers set elsewhere.
+	req.Header.Set("User-Agent", "terraform-provider-github/"+packageVersion)
+
+	return uat.transport.RoundTrip(req)
+}
+
+func NewUserAgentTransport(rt http.RoundTripper) *userAgentTransport {
+	return &userAgentTransport{transport: rt}
 }

--- a/github/transport.go
+++ b/github/transport.go
@@ -13,9 +13,8 @@ import (
 )
 
 const (
-	ctxEtag        = ctxEtagType("etag")
-	ctxId          = ctxIdType("id")
-	packageVersion = "4.26.1"
+	ctxEtag = ctxEtagType("etag")
+	ctxId   = ctxIdType("id")
 )
 
 // ctxIdType is used to avoid collisions between packages using context
@@ -196,7 +195,7 @@ func (uat *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, err
 	// The transport is the mechanism "by which individual HTTP requests are made"
 	// (<https://pkg.go.dev/net/http>), so this will generally overwrite `User-Agent`
 	// headers set elsewhere.
-	req.Header.Set("User-Agent", "terraform-provider-github/"+packageVersion)
+	req.Header.Set("User-Agent", "terraform-provider-github/"+Version)
 
 	return uat.transport.RoundTrip(req)
 }

--- a/github/transport_test.go
+++ b/github/transport_test.go
@@ -50,8 +50,7 @@ func TestUserAgentTransport(t *testing.T) {
 		{
 			ExpectedUri: "/repos/test/blah",
 			ExpectedHeaders: map[string]string{
-				// TODO: Figure out if there is a way to make this test more dynamic
-				"User-Agent": "terraform-provider-github/4.26.1",
+				"User-Agent": "terraform-provider-github/" + Version,
 			},
 
 			ResponseBody: `{"id": 1234}`,

--- a/github/version.go
+++ b/github/version.go
@@ -1,0 +1,3 @@
+package github
+
+const Version = "4.26.1"


### PR DESCRIPTION
This updates the transport used to make requests to the GitHub API to set a `User-Agent` request header with `terraform-provider- github` and the current version (e.g. `terraform-provider-github/4.26.1`).

Because this hooks in with the `RoundTrip` function, it can be expected to overwrite `User-Agent` values set elsewhere (e.g. as defaults or on a per-request basis by `go-github` or `shurcooL/githubv4`).

This change does mean that someone will have to update the `Version` constant with the new version when it is incremented. I have documented that in `RELEASE.md`.

This is only the second Go I've ever written, so I definitely won't be at all sensitive to feedback!