### PR TITLE
Feature(github_team_repository): add github_team_repository data source

### DIFF
--- a/github/data_source_github_team_repository.go
+++ b/github/data_source_github_team_repository.go
@@ -52,7 +52,6 @@ func dataSourceGithubTeamRepositoryRead(d *schema.ResourceData, meta interface{}
 	}
 
 	orgName := meta.(*Owner).name
-	permission := d.Get("permission").(string)
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 	var repoName string
 
@@ -84,18 +83,16 @@ func dataSourceGithubTeamRepositoryRead(d *schema.ResourceData, meta interface{}
 	if permErr != nil {
 		return permErr
 	}
-	if permName == permission {
-		d.Set("permission", permName)
 
-		d.Set("etag", resp.Header.Get("ETag"))
-		if d.Get("team_id") == "" {
-			// If team_id is empty, that means we are importing the resource.
-			// Set the team_id to be the id of the team.
-			d.Set("team_id", teamId)
-		}
-		d.Set("repository", repo.GetName())
+	d.Set("permission", permName)
 
+	d.Set("etag", resp.Header.Get("ETag"))
+	if d.Get("team_id") == "" {
+		// If team_id is empty, that means we are importing the resource.
+		// Set the team_id to be the id of the team.
+		d.Set("team_id", teamId)
 	}
+	d.Set("repository", repo.GetName())
 
 	return nil
 }

--- a/github/data_source_github_team_repository.go
+++ b/github/data_source_github_team_repository.go
@@ -1,0 +1,101 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/google/go-github/v45/github"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceGithubTeamRepository() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGithubTeamRepositoryRead,
+
+		Schema: map[string]*schema.Schema{
+			"team_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "ID or slug of team",
+			},
+			"repository": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"permission": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "pull",
+			},
+		},
+	}
+}
+
+func dataSourceGithubTeamRepositoryRead(d *schema.ResourceData, meta interface{}) error {
+	err := checkOrganization(meta)
+	if err != nil {
+		return err
+	}
+
+	client := meta.(*Owner).v3client
+	orgId := meta.(*Owner).id
+
+	// The given team id could be an id or a slug
+	givenTeamId := d.Get("team_id").(string)
+	teamId, err := getTeamID(givenTeamId, meta)
+	if err != nil {
+		return err
+	}
+
+	orgName := meta.(*Owner).name
+	permission := d.Get("permission").(string)
+	ctx := context.WithValue(context.Background(), ctxId, d.Id())
+	var repoName string
+
+	if name, ok := d.GetOk("name"); ok {
+		repoName = name.(string)
+	}
+
+	if repoName == "" {
+		return fmt.Errorf("%q has to be provided", "name")
+	}
+
+	repo, resp, repoErr := client.Teams.IsTeamRepoByID(ctx, orgId, teamId, orgName, repoName)
+	if repoErr != nil {
+		if ghErr, ok := repoErr.(*github.ErrorResponse); ok {
+			if ghErr.Response.StatusCode == http.StatusNotModified {
+				return nil
+			}
+			if ghErr.Response.StatusCode == http.StatusNotFound {
+				log.Printf("[INFO] Removing team repository association %s from state because it no longer exists in GitHub",
+					d.Id())
+				d.SetId("")
+				return nil
+			}
+		}
+		return err
+	}
+
+	permName, permErr := getRepoPermission(repo.GetPermissions())
+	if permErr != nil {
+		return permErr
+	}
+	if permName == permission {
+		d.Set("permission", permName)
+
+		d.Set("etag", resp.Header.Get("ETag"))
+		if d.Get("team_id") == "" {
+			// If team_id is empty, that means we are importing the resource.
+			// Set the team_id to be the id of the team.
+			d.Set("team_id", teamId)
+		}
+		d.Set("repository", repo.GetName())
+
+	}
+
+	return nil
+}

--- a/github/data_source_github_team_repository_test.go
+++ b/github/data_source_github_team_repository_test.go
@@ -97,7 +97,6 @@ func TestGithubTeamRepositoriesByPermission(t *testing.T) {
 			depends_on = ["github_repository.test", "github_team.test", "github_team_repository.test"]
 			team_id    = "${github_team.test.id}"
   			repository = "${github_repository.test.name}"
-  			permission = "${github_team_repository.test.permission}"
 		  }
 		`, randomID)
 

--- a/github/provider.go
+++ b/github/provider.go
@@ -151,6 +151,7 @@ func Provider() terraform.ResourceProvider {
 			"github_repository_pull_request":       dataSourceGithubRepositoryPullRequest(),
 			"github_repository_pull_requests":      dataSourceGithubRepositoryPullRequests(),
 			"github_team":                          dataSourceGithubTeam(),
+			"github_team_repository":               dataSourceGithubTeamRepository(),
 			"github_tree":                          dataSourceGithubTree(),
 			"github_user":                          dataSourceGithubUser(),
 			"github_users":                         dataSourceGithubUsers(),


### PR DESCRIPTION
Resolves https://github.com/integrations/terraform-provider-github/issues/1160

## Description

This PR adds a data source `github_team_repository`. Given a team slug or team id and repository name, it returns a `github_team_repository` resource.

Currently, there is no way to obtain the team role against a repository as the [github_collaborators](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/collaborators) block returns a list of users and not teams in the collaborators block and their permissions against a repository. Similarly, the [github_team](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/team) block returns a repositories attribute that is a list(string) of team collaborated repository names only.

## Testing

Please see `github/data_source_github_team_repository_test.go`