### PR TITLE
Revert PR #1192 754d73f66bd3b5da49d5f3e0714a4186d40d0377

### DIFF
--- a/github/data_source_github_collaborators.go
+++ b/github/data_source_github_collaborators.go
@@ -179,7 +179,13 @@ func flattenGitHubCollaborators(collaborators []*github.User) ([]interface{}, er
 		result["received_events_url"] = c.GetReceivedEventsURL()
 		result["type"] = c.GetType()
 		result["site_admin"] = c.GetSiteAdmin()
-		result["permission"] = c.GetRoleName()
+
+		permissionName, err := getRepoPermission(c.GetPermissions())
+		if err != nil {
+			return nil, err
+		}
+
+		result["permission"] = permissionName
 		results = append(results, result)
 	}
 

--- a/github/resource_github_repository_collaborator.go
+++ b/github/resource_github_repository_collaborator.go
@@ -35,10 +35,11 @@ func resourceGithubRepositoryCollaborator() *schema.Resource {
 				ForceNew: true,
 			},
 			"permission": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  "push",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      "push",
+				ValidateFunc: validateValueFunc([]string{"pull", "triage", "push", "maintain", "admin"}),
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					if d.Get("permission_diff_suppression").(bool) {
 						if new == "triage" || new == "maintain" {
@@ -140,9 +141,14 @@ func resourceGithubRepositoryCollaboratorRead(d *schema.ResourceData, meta inter
 
 		for _, c := range collaborators {
 			if strings.EqualFold(c.GetLogin(), username) {
+				permissionName, err := getRepoPermission(c.GetPermissions())
+				if err != nil {
+					return err
+				}
+
 				d.Set("repository", repoName)
 				d.Set("username", c.GetLogin())
-				d.Set("permission", c.GetRoleName())
+				d.Set("permission", permissionName)
 				return nil
 			}
 		}

--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -131,7 +131,13 @@ func resourceGithubTeamRepositoryRead(d *schema.ResourceData, meta interface{}) 
 		d.Set("team_id", teamIdString)
 	}
 	d.Set("repository", repo.GetName())
-	d.Set("permission", repo.GetRoleName())
+
+	permName, permErr := getRepoPermission(repo.GetPermissions())
+	if permErr != nil {
+		return permErr
+	}
+
+	d.Set("permission", permName)
 
 	return nil
 }

--- a/github/util_permissions.go
+++ b/github/util_permissions.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/google/go-github/v45/github"
@@ -15,6 +16,27 @@ const (
 	writePermission    string = "write"
 	readPermission     string = "read"
 )
+
+func getRepoPermission(p map[string]bool) (string, error) {
+
+	// Permissions are returned in this map format such that if you have a certain level
+	// of permission, all levels below are also true. For example, if a team has push
+	// permission, the map will be: {"pull": true, "push": true, "admin": false}
+	if (p)[adminPermission] {
+		return adminPermission, nil
+	} else if (p)[maintainPermission] {
+		return maintainPermission, nil
+	} else if (p)[pushPermission] {
+		return pushPermission, nil
+	} else if (p)[triagePermission] {
+		return triagePermission, nil
+	} else {
+		if (p)[pullPermission] {
+			return pullPermission, nil
+		}
+		return "", errors.New("At least one permission expected from permissions map.")
+	}
+}
 
 func getInvitationPermission(i *github.RepositoryInvitation) (string, error) {
 	// Permissions for some GitHub API routes are expressed as "read",

--- a/website/docs/r/repository_collaborator.html.markdown
+++ b/website/docs/r/repository_collaborator.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 * `repository` - (Required) The GitHub repository
 * `username` - (Required) The user to add to the repository as a collaborator.
 * `permission` - (Optional) The permission of the outside collaborator for the repository.
-            Must be one of `pull`, `push`, `maintain`, `triage` or `admin` or the name of an existing [custom repository role](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-peoples-access-to-your-organization-with-roles/managing-custom-repository-roles-for-an-organization) within the organization for organization-owned repositories.
+            Must be one of `pull`, `push`, `maintain`, `triage` or `admin` for organization-owned repositories.
             Must be `push` for personal repositories. Defaults to `push`.
 * `permission_diff_suppression` - (Optional) Suppress plan diffs for `triage` and `maintain`.  Defaults to `false`.
 


### PR DESCRIPTION
Since I messed up and merged a binary into the tree, I've been trying to fix that issue. Thus far I've:
- force-pushed main to before the binary was introduced
- deleted the tags for the two releases with the accidental binary (v4.27.0 and v4.27.1)
- merged #1234 to add back the correct changes without the binary

Now, I need to:
- create and merge this PR to re-revert #1192 
- create a new release of the provider without the binary involved at all