### PR TITLE
Add default binary name to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,8 @@ website/node_modules
 *.tfvars
 .vscode/
 testdata/
-
 website/vendor
+terraform-provider-github
 
 # Test exclusions
 !command/test-fixtures/**/*.tfstate


### PR DESCRIPTION
This provides a small guardrail so that future PRs won't accidentally introduce a binary with the default name of `terraform-provider-github`. 