### PR TITLE
Add membership_type to data.github_team

### DIFF
--- a/github/data_source_github_team.go
+++ b/github/data_source_github_team.go
@@ -6,7 +6,10 @@ import (
 
 	"github.com/google/go-github/v45/github"
 
+	"github.com/shurcooL/githubv4"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func dataSourceGithubTeam() *schema.Resource {
@@ -48,6 +51,12 @@ func dataSourceGithubTeam() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"membership_type": {
+				Type:         schema.TypeString,
+				Default:      "all",
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"all", "immediate"}, false),
+			},
 		},
 	}
 }
@@ -71,22 +80,60 @@ func dataSourceGithubTeamRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	var members []string
-	for {
-		member, resp, err := client.Teams.ListTeamMembersByID(ctx, orgId, team.GetID(), &options)
-		if err != nil {
-			return err
-		}
+	if d.Get("membership_type").(string) == "all" {
+		for {
+			member, resp, err := client.Teams.ListTeamMembersByID(ctx, orgId, team.GetID(), &options)
+			if err != nil {
+				return err
+			}
 
-		for _, v := range member {
-			members = append(members, v.GetLogin())
-		}
+			for _, v := range member {
+				members = append(members, v.GetLogin())
+			}
 
-		if resp.NextPage == 0 {
-			break
+			if resp.NextPage == 0 {
+				break
+			}
+			options.Page = resp.NextPage
 		}
-		options.Page = resp.NextPage
+	} else {
+		type member struct {
+			Login string
+		}
+		var query struct {
+			Organization struct {
+				Team struct {
+					Members struct {
+						Nodes    []member
+						PageInfo struct {
+							EndCursor   githubv4.String
+							HasNextPage bool
+						}
+					} `graphql:"members(first:100,after:$memberCursor,membership:IMMEDIATE)"`
+				} `graphql:"team(slug:$slug)"`
+			} `graphql:"organization(login:$owner)"`
+		}
+		variables := map[string]interface{}{
+			"owner":        githubv4.String(meta.(*Owner).name),
+			"slug":         githubv4.String(slug),
+			"memberCursor": (*githubv4.String)(nil),
+		}
+		client := meta.(*Owner).v4client
+		for {
+			nameErr := client.Query(ctx, &query, variables)
+			if nameErr != nil {
+				return nameErr
+			}
+			for _, v := range query.Organization.Team.Members.Nodes {
+				members = append(members, v.Login)
+			}
+			if query.Organization.Team.Members.PageInfo.HasNextPage {
+				variables["memberCursor"] = query.Organization.Team.Members.PageInfo.EndCursor
+			} else {
+				break
+			}
+		}
 	}
-
 	var repositories []string
 	for {
 		repository, resp, err := client.Teams.ListTeamReposByID(ctx, orgId, team.GetID(), &options.ListOptions)

--- a/github/data_source_github_team_test.go
+++ b/github/data_source_github_team_test.go
@@ -56,6 +56,50 @@ func TestAccGithubTeamDataSource(t *testing.T) {
 
 	})
 
+	t.Run("queries an existing team without error with immediate membership", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+			resource "github_team" "test" {
+				name = "tf-acc-test-%s"
+			}
+
+			data "github_team" "test" {
+				slug            = github_team.test.slug
+				membership_type = "immediate"
+			}
+		`, randomID)
+
+		check := resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttrSet("data.github_team.test", "name"),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			t.Skip("individual account not supported for this operation")
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
+
 	t.Run("errors when querying a non-existing team", func(t *testing.T) {
 
 		config := `

--- a/github/data_source_github_team_test.go
+++ b/github/data_source_github_team_test.go
@@ -71,6 +71,7 @@ func TestAccGithubTeamDataSource(t *testing.T) {
 
 		check := resource.ComposeAggregateTestCheckFunc(
 			resource.TestCheckResourceAttrSet("data.github_team.test", "name"),
+			resource.TestCheckResourceAttr("data.github_team.test", "name", fmt.Sprintf("tf-acc-test-%s", randomID)),
 		)
 
 		testCase := func(t *testing.T, mode string) {
@@ -97,7 +98,6 @@ func TestAccGithubTeamDataSource(t *testing.T) {
 		t.Run("with an organization account", func(t *testing.T) {
 			testCase(t, organization)
 		})
-
 	})
 
 	t.Run("errors when querying a non-existing team", func(t *testing.T) {

--- a/website/docs/d/team.html.markdown
+++ b/website/docs/d/team.html.markdown
@@ -30,6 +30,6 @@ data "github_team" "example" {
  * `description` - the team's description.
  * `privacy` - the team's privacy type.
  * `permission` - the team's permission level.
- * `members` - List of team members (list of github logins)
+ * `members` - List of team members (list of GitHub usernames)
  * `repositories` - List of team repositories (list of repo names)
- 
+

--- a/website/docs/d/team.html.markdown
+++ b/website/docs/d/team.html.markdown
@@ -30,6 +30,6 @@ data "github_team" "example" {
  * `description` - the team's description.
  * `privacy` - the team's privacy type.
  * `permission` - the team's permission level.
- * `members` - List of team members
- * `repositories` - List of team repositories
+ * `members` - List of team members (list of github logins)
+ * `repositories` - List of team repositories (list of repo names)
  

--- a/website/docs/d/team.html.markdown
+++ b/website/docs/d/team.html.markdown
@@ -20,6 +20,7 @@ data "github_team" "example" {
 ## Argument Reference
 
  * `slug` - (Required) The team slug.
+ * `membership_type` - (Optional) Type of membershp to be requested to fill the list of members. Can be either "all" or "immediate". Default: "all"
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add an option to `data.github_team` to query only direct member.

We need to use graphql for this because the Rest API does not offer the feature.