### PR TITLE
Add note deprecating changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# NOTE: CHANGELOG.md is deprecated
+
+After the release of v4.24.0, please see the [GitHub release notes](https://github.com/integrations/terraform-provider-github/releases) for the provider in order to view the most up-to-date changes.
+
 # 4.24.0 (Apr 28, 2022)
 
 ENHANCEMENTS:


### PR DESCRIPTION
Fixes #1240.

We've been using the [GitHub release notes](https://github.com/integrations/terraform-provider-github/releases) feature instead of the CHANGELOG.md file for some time. 

This note makes that decision official. 