### PR TITLE
Allow skip fetch members/repos for github_team data source

### DIFF
--- a/github/data_source_github_team_test.go
+++ b/github/data_source_github_team_test.go
@@ -56,6 +56,53 @@ func TestAccGithubTeamDataSource(t *testing.T) {
 
 	})
 
+	t.Run("queries an existing team without error when not fetching repos or members", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+			resource "github_team" "test" {
+				name = "tf-acc-test-%s"
+			}
+
+			data "github_team" "test" {
+				slug = github_team.test.slug
+				fetch_members = false
+				fetch_repositories = false
+			}
+		`, randomID)
+
+		check := resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttrSet("data.github_team.test", "name"),
+			resource.TestCheckResourceAttr("data.github_team.test", "repositories", "null"),
+			resource.TestCheckResourceAttr("data.github_team.test", "members", "null"),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			t.Skip("individual account not supported for this operation")
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
+
 	t.Run("errors when querying a non-existing team", func(t *testing.T) {
 
 		config := `

--- a/website/docs/d/team.html.markdown
+++ b/website/docs/d/team.html.markdown
@@ -20,6 +20,8 @@ data "github_team" "example" {
 ## Argument Reference
 
  * `slug` - (Required) The team slug.
+ * `fetch_members` - (Optional) Whether to also fetch the members of the team. Defaults to true.
+ * `fetch_repositories` - (Optional) Whether to also fetch the repositories that the team is associated with. Defaults to true.
 
 ## Attributes Reference
 
@@ -29,6 +31,6 @@ data "github_team" "example" {
  * `description` - the team's description.
  * `privacy` - the team's privacy type.
  * `permission` - the team's permission level.
- * `members` - List of team members
- * `repositories` - List of team repositories
+ * `members` - List of team members. Null if `fetch_members` is false.
+ * `repositories` - List of team repositories. Null if `fetch_repositories` is false.
  


### PR DESCRIPTION
Since a lot of resources (graphql-based ones) now require us to use the team's Node ID instead of just the slug, we often have to use data sources just to look up the ID of the team. However, this is an extreme performance drag because some teams have dozens or hundreds of repositories and members to look up page-wise. We don't need any of that, all we need is the Node ID. So we'd like an option to disable those lookups to speed this up and reduce the chance of rate limiting issues.