### PR TITLE
Switch to Go1.19 in CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
       - run: make tools
       - run: make lint
       - run: make website-lint

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,7 +7,7 @@ default: build
 
 tools:
 	go install github.com/client9/misspell/cmd/misspell
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0
 
 build: fmtcheck
 	go build ./...

--- a/github/apps.go
+++ b/github/apps.go
@@ -6,7 +6,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -51,7 +51,7 @@ func getInstallationAccessToken(baseURL string, jwt string, installationID strin
 	}
 	defer func() { _ = res.Body.Close() }()
 
-	resBytes, err := ioutil.ReadAll(res.Body)
+	resBytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", err
 	}

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -24,7 +24,7 @@ const (
 var (
 	testEpochTime = time.Unix(0, 0)
 
-	testGitHubAppPrivateKeyPemData, _ = ioutil.ReadFile(testGitHubAppPrivateKeyFile)
+	testGitHubAppPrivateKeyPemData, _ = os.ReadFile(testGitHubAppPrivateKeyFile)
 )
 
 func TestGenerateAppJWT(t *testing.T) {
@@ -108,7 +108,7 @@ func TestGenerateAppJWT(t *testing.T) {
 	})
 
 	t.Run("produces a verifiable jwt", func(t *testing.T) {
-		publicKeyData, err := ioutil.ReadFile(testGitHubAppPublicKeyFile)
+		publicKeyData, err := os.ReadFile(testGitHubAppPublicKeyFile)
 		if err != nil {
 			t.Logf("Failed to read public key file '%s': %s", testGitHubAppPublicKeyFile, err)
 			t.FailNow()

--- a/github/transport.go
+++ b/github/transport.go
@@ -3,7 +3,6 @@ package github
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"sync"
@@ -176,7 +175,7 @@ func drainBody(b io.ReadCloser) (r1, r2 io.ReadCloser, err error) {
 	if err = b.Close(); err != nil {
 		return nil, b, err
 	}
-	return ioutil.NopCloser(&buf), ioutil.NopCloser(bytes.NewReader(buf.Bytes())), nil
+	return io.NopCloser(&buf), io.NopCloser(bytes.NewReader(buf.Bytes())), nil
 }
 
 func isWriteMethod(method string) bool {

--- a/github/transport_test.go
+++ b/github/transport_test.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -51,7 +51,7 @@ func githubApiMock(responseSequence []*mockResponse) *httptest.Server {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.Header().Set("Server", "GitHub.com")
 
-		bodyBytes, err := ioutil.ReadAll(r.Body)
+		bodyBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			log.Printf("[DEBUG] Error: %s", err)
 		}

--- a/github/util_v4_repository_test.go
+++ b/github/util_v4_repository_test.go
@@ -2,14 +2,14 @@ package github
 
 import (
 	"bytes"
-	"github.com/shurcooL/githubv4"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"text/template"
+
+	"github.com/shurcooL/githubv4"
 )
 
 // Heavily based on https://github.com/shurcooL/githubv4/blob/master/githubv4_test.go#L114-L144
@@ -202,7 +202,7 @@ func (l localRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 }
 
 func mustRead(r io.Reader) string {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This should fix the linting check failures I initially noticed [here](https://github.com/integrations/terraform-provider-github/runs/7844076651?check_suite_focus=true). 