### PR TITLE
Small README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Terraform Provider GitHub
 
 <img src="https://raw.githubusercontent.com/hashicorp/terraform-website/d841a1e5fca574416b5ca24306f85a0f4f41b36d/content/source/assets/images/logo-terraform-main.svg" width="300px">
 
-This project is used to read and write changes on GitHub (repositories, teams, files, etc.) using Terraform. Its Terraform Registry page can be found [here](https://registry.terraform.io/providers/integrations/github/4.31.0).
+This project is used to read and write to/from GitHub (repositories, teams, files, etc.) using Terraform. Its Terraform Registry page can be found [here](https://registry.terraform.io/providers/integrations/github/).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ Terraform Provider GitHub
 
 <img src="https://raw.githubusercontent.com/hashicorp/terraform-website/d841a1e5fca574416b5ca24306f85a0f4f41b36d/content/source/assets/images/logo-terraform-main.svg" width="300px">
 
-- Website: https://www.terraform.io
-- Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
+This project is used to read and write changes on GitHub (repositories, teams, files, etc.) using Terraform. Its Terraform Registry page can be found [here](https://registry.terraform.io/providers/integrations/github/4.31.0).
 
 ## Requirements
 
@@ -23,7 +22,7 @@ Detailed documentation for contributing to the GitHub provider can be found [her
 
 ## Roadmap
 
-This project leverages [Milestones](https://github.com/integrations/terraform-provider-github/milestones) to scope upcoming features and bug fixes. Issues that receive the most recent discussion or the most reactions will be more likely to be included in an upcoming release.
+This project uses [Milestones](https://github.com/integrations/terraform-provider-github/milestones) to scope upcoming features and bug fixes. Issues that receive the most recent discussion or the most reactions will be more likely to be included in an upcoming release.
 
 ## Support
 


### PR DESCRIPTION
This small PR: 

- removes a link to the Terraform homepage that's not immediately relevant to this provider
- removes a link to a deprecated Google Group
- provides a brief description of the provider's purpose
- simplifies a word

:eyes: [New rendered README](https://github.com/integrations/terraform-provider-github/blob/32cea2ff5e37f37286d6c2708a2304aa9bb5c3b9/README.md) :eyes: 