### PR TITLE
Bump version number to v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/integrations/terraform-provider-github/v4
+module github.com/integrations/terraform-provider-github/v5
 
 go 1.16
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/integrations/terraform-provider-github/v4/github"
+	"github.com/integrations/terraform-provider-github/v5/github"
 )
 
 func main() {


### PR DESCRIPTION
#1117 has been merged, which creates a breaking change by refactoring branches out of the repository data source and into a new one. There already exists a `resource_github_branch` resource, so a new one of those isn't necessary. 

In order to stick to semantic versioning as much as possible, this increments the project's major version. In the future, incrementing major versions more often (similar to google/go-github's strategy) is a change I'd like this project to make. 

Note that this means the fixes proposed in #987, if adopted, will be added in another major version. 