### PR TITLE
feat: closes #862 by adding a `state` attribute for the state of org membership

### DIFF
--- a/github/data_source_github_membership.go
+++ b/github/data_source_github_membership.go
@@ -27,6 +27,10 @@ func dataSourceGithubMembership() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -55,5 +59,6 @@ func dataSourceGithubMembershipRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("username", membership.GetUser().GetLogin())
 	d.Set("role", membership.GetRole())
 	d.Set("etag", resp.Header.Get("ETag"))
+	d.Set("state", membership.GetState())
 	return nil
 }

--- a/github/data_source_github_membership_test.go
+++ b/github/data_source_github_membership_test.go
@@ -23,6 +23,7 @@ func TestAccGithubMembershipDataSource(t *testing.T) {
 			resource.TestCheckResourceAttr("data.github_membership.test", "username", testOwner),
 			resource.TestCheckResourceAttrSet("data.github_membership.test", "role"),
 			resource.TestCheckResourceAttrSet("data.github_membership.test", "etag"),
+			resource.TestCheckResourceAttrSet("data.github_membership.test", "state"),
 		)
 
 		testCase := func(t *testing.T, mode string) {

--- a/website/docs/d/membership.html.markdown
+++ b/website/docs/d/membership.html.markdown
@@ -31,3 +31,4 @@ data "github_membership" "membership_for_some_user" {
  * `username` - The username.
  * `role` - `admin` or `member` -- the role the user has within the organization.
  * `etag` - An etag representing the membership object.
+ * `state` - `active` or `pending` -- the state of membership within the organization.  `active` if the member has accepted the invite, or `pending` if the invite is still pending.


### PR DESCRIPTION
# Description
Adds a new `state` field to the membership data object so that you can tell if a user has accepted an invite to the organization or it is still pending.  This would resolve #862 by including the state information.

# Testing
Manually tested against an organization I setup (wwsean08-terraform-test) where I as the owner was a member and another user was invited but hadn't accepted using the following terraform for a minimal test:

```terraform
terraform {
  required_providers {
    github = {
      source  = "integrations/github"
      version = "~> 5.0"
    }
  }
}

provider "github" {
  owner = "wwsean08-terraform-test"
}

data "github_membership" "active" {
  username = "wwsean08"
}

data "github_membership" "pending" {
  username = "nealpsmith"
}

output "expected_active" {
  value = data.github_membership.active.state
}

output "expected_pending" {
  value = data.github_membership.pending.state
}
```

With that test I see the following output:
![Screen Shot 2022-09-15 at 10 11 50 AM](https://user-images.githubusercontent.com/839261/190468090-69fbbe75-a580-499d-a48f-986c03a3c211.png)
