### PR TITLE
[Feature] Adding `security_and_analysis` block to `github_repository` resource. closes#1104

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -812,14 +812,17 @@ func flattenSecurityAndAnalysis(securityAndAnalysis *github.SecurityAndAnalysis)
 
 	advancedSecurityMap := make(map[string]interface{})
 	advancedSecurityMap["status"] = securityAndAnalysis.GetAdvancedSecurity().GetStatus()
+
 	secretScanningMap := make(map[string]interface{})
 	secretScanningMap["status"] = securityAndAnalysis.GetSecretScanning().GetStatus()
+
 	secretScanningPushProtectionMap := make(map[string]interface{})
 	secretScanningPushProtectionMap["status"] = securityAndAnalysis.GetSecretScanningPushProtection().GetStatus()
 
 	securityAndAnalysisMap := make(map[string]interface{})
 	securityAndAnalysisMap["advanced_security"] = []interface{}{advancedSecurityMap}
 	securityAndAnalysisMap["secret_scanning"] = []interface{}{secretScanningMap}
+	securityAndAnalysisMap["secret_scanning_push_protection"] = []interface{}{secretScanningPushProtectionMap}
 
 	return []interface{}{securityAndAnalysisMap}
 }
@@ -841,6 +844,7 @@ func expandSecurityAndAnalysis(input []interface{}) *github.Repository {
 	update.SecretScanning = &github.SecretScanning{
 		Status: github.String(secretScanning["status"].(string)),
 	}
+
 	secretScanningPushProtection := securityAndAnalysis["secret_scanning_push_protection"].([]interface{})[0].(map[string]interface{})
 	update.SecretScanningPushProtection = &github.SecretScanningPushProtection{
 		Status: github.String(secretScanningPushProtection["status"].(string)),

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -88,9 +88,9 @@ func resourceGithubRepository() *schema.Resource {
 									},
 								},
 							},
-						}, /*TODO: SecretScanningPushProtection is not yet supported by the Go GitHub Client Library
+						},
 						"secret_scanning_push_protection": {
-							Type:     schema.List,
+							Type:     schema.TypeList,
 							Required: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
@@ -102,7 +102,7 @@ func resourceGithubRepository() *schema.Resource {
 									},
 								},
 							},
-						},*/
+						},
 					},
 				},
 			},
@@ -642,6 +642,8 @@ func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 					AdvancedSecurity: &github.AdvancedSecurity{
 						Status: github.String("disabled")},
 					SecretScanning: &github.SecretScanning{
+						Status: github.String("disabled")},
+					SecretScanningPushProtection: &github.SecretScanningPushProtection{
 						Status: github.String("disabled")}},
 			})
 			if err != nil {
@@ -812,9 +814,8 @@ func flattenSecurityAndAnalysis(securityAndAnalysis *github.SecurityAndAnalysis)
 	advancedSecurityMap["status"] = securityAndAnalysis.GetAdvancedSecurity().GetStatus()
 	secretScanningMap := make(map[string]interface{})
 	secretScanningMap["status"] = securityAndAnalysis.GetSecretScanning().GetStatus()
-	//TODO: SecretScanningPushProtection is not yet supported by the Go GitHub Client Library
-	//secretScanningPushProtectionMap := make(map[string]interface{})
-	//secretScanningPushProtectionMap["status"] = securityAndAnalysis.GetSecretScanningPushProtection().GetStatus()
+	secretScanningPushProtectionMap := make(map[string]interface{})
+	secretScanningPushProtectionMap["status"] = securityAndAnalysis.GetSecretScanningPushProtection().GetStatus()
 
 	securityAndAnalysisMap := make(map[string]interface{})
 	securityAndAnalysisMap["advanced_security"] = []interface{}{advancedSecurityMap}
@@ -840,11 +841,10 @@ func expandSecurityAndAnalysis(input []interface{}) *github.Repository {
 	update.SecretScanning = &github.SecretScanning{
 		Status: github.String(secretScanning["status"].(string)),
 	}
-	//TODO: SecretScanningPushProtection is not yet supported by the Go GitHub Client Library
-	//secretScanningPushProtection := securityAndAnalysis["secret_scanning_push_protection"].([]interface{})[0].(map[string]interface{})
-	//update.SecretScanningPushProtection = &github.SecretScanningPushProtection{
-	//	Status: github.String(secretScanningPushProtection["status"].(string)),
-	//}
+	secretScanningPushProtection := securityAndAnalysis["secret_scanning_push_protection"].([]interface{})[0].(map[string]interface{})
+	update.SecretScanningPushProtection = &github.SecretScanningPushProtection{
+		Status: github.String(secretScanningPushProtection["status"].(string)),
+	}
 
 	return &github.Repository{SecurityAndAnalysis: update}
 }

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -809,6 +809,65 @@ func TestAccGithubRepositoryPages(t *testing.T) {
 
 }
 
+func TestAccGithubRepositorySecurity(t *testing.T) {
+
+	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+	t.Run("manages the security feature for a repository", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+		resource "github_repository" "test" {
+			name        = "tf-acc-%s"
+			description = "A repository created by Terraform to test security features"
+			visibility  = "internal"
+			security_and_analysis {
+			  advanced_security {
+				status = "enabled"
+			  }
+			  secret_scanning {
+				status = "enabled"
+			  }
+			}
+		  }
+		`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_repository.test", "security_and_analysis.0.advanced_security.0.status",
+				"enabled",
+			),
+			resource.TestCheckResourceAttr(
+				"github_repository.test", "security_and_analysis.0.secret_scanning.0.status",
+				"enabled",
+			),
+		)
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			t.Skip("individual account not supported for this operation")
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+}
+
 func TestAccGithubRepositoryVisibility(t *testing.T) {
 
 	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -827,6 +827,8 @@ func TestAccGithubRepositorySecurity(t *testing.T) {
 			  secret_scanning {
 				status = "enabled"
 			  }
+			  secret_scanning_push_protection {
+				status = "enabled"
 			}
 		  }
 		`, randomID)

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -138,19 +138,25 @@ The `source` block supports the following:
 
 The `security_and_analysis` block supports the following:
 
-* `advanced_security` - (Optional) The advanced security configuration for the repository. See [Advanced Security Configuration](#advanced-security-configuration) below for details.
+* `advanced_security` - (Required) The advanced security configuration for the repository. See [Advanced Security Configuration](#advanced-security-configuration) below for details.
 
-* `secret_scanning` - (Optional) The secret scanning configuration for the repository. See [Secret Scanning Configuration](#secret-scanning-configuration) below for details.
+* `secret_scanning` - (Required) The secret scanning configuration for the repository. See [Secret Scanning Configuration](#secret-scanning-configuration) below for details.
+
+* `secret_scanning_push_protection` - (Required) The secret scanning push protection configuration for the repository. See [Secret Scanning Push Protection Configuration](#secret-scanning-push-protection-configuration) below for details.
 
 #### Advanced Security Configuration ####
 
 The `advanced_security` block supports the following:
 
-* `status` - (Optional) Set to `enabled` to enable advanced security features on the repository. Can be `enabled` or `disabled`.
+* `status` - (Required) Set to `enabled` to enable advanced security features on the repository. Can be `enabled` or `disabled`.
 
 #### Secret Scanning Configuration ####
 
-* `status` - (Optional) Set to `enabled` to enable secret scanning on the repository. Can be `enabled` or `disabled`.
+* `status` - (Required) Set to `enabled` to enable secret scanning on the repository. Can be `enabled` or `disabled`.
+
+#### Secret Scanning Push Protection Configuration ####
+
+* `status` - (Required) Set to `enabled` to enable secret scanning push protection on the repository. Can be `enabled` or `disabled`.
 
 ### Template Repositories
 

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -106,6 +106,8 @@ initial repository creation and create the target branch inside of the repositor
 
 * `pages` - (Optional) The repository's GitHub Pages configuration. See [GitHub Pages Configuration](#github-pages-configuration) below for details.
 
+* `security_and_analysis` - (Optional) The repository's [security and analysis](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-security-and-analysis-settings-for-your-repository) configuration. See [Security and Analysis Configuration](#security-and-analysis-configuration) below for details.
+
 * `topics` - (Optional) The list of topics of the repository.
 
 * `template` - (Optional) Use a template repository to create this resource. See [Template Repositories](#template-repositories) below for details.
@@ -131,6 +133,24 @@ The `source` block supports the following:
 * `branch` - (Required) The repository branch used to publish the site's source files. (i.e. `main` or `gh-pages`.
 
 * `path` - (Optional) The repository directory from which the site publishes (Default: `/`).
+
+### Security and Analysis Configuration
+
+The `security_and_analysis` block supports the following:
+
+* `advanced_security` - (Optional) The advanced security configuration for the repository. See [Advanced Security Configuration](#advanced-security-configuration) below for details.
+
+* `secret_scanning` - (Optional) The secret scanning configuration for the repository. See [Secret Scanning Configuration](#secret-scanning-configuration) below for details.
+
+#### Advanced Security Configuration ####
+
+The `advanced_security` block supports the following:
+
+* `status` - (Optional) Set to `enabled` to enable advanced security features on the repository. Can be `enabled` or `disabled`.
+
+#### Secret Scanning Configuration ####
+
+* `status` - (Optional) Set to `enabled` to enable secret scanning on the repository. Can be `enabled` or `disabled`.
 
 ### Template Repositories
 


### PR DESCRIPTION
Adding block for the `security_and_analysis` field in `github_repository` resource to configure [advanced security settings](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-security-and-analysis-settings-for-your-repository) for a repo. 

The Go GitHub client library does not currently support the `secret_scanning_push_protection` field in its current release but a [PR](https://github.com/google/go-github/pull/2476) has been merged and will be available on the next release. The necessary code to implement this field has been commented out and can be uncommented once a new release is available.

Closes:
https://github.com/integrations/terraform-provider-github/issues/1104