### PR TITLE
feat: add `repo_ids` attribute to `github_repositories`

### DIFF
--- a/github/data_source_github_repositories_test.go
+++ b/github/data_source_github_repositories_test.go
@@ -29,6 +29,9 @@ func TestAccGithubRepositoriesDataSource(t *testing.T) {
 			resource.TestCheckResourceAttrSet(
 				"data.github_repositories.test", "names.0",
 			),
+			resource.TestCheckResourceAttrSet(
+				"data.github_repositories.test", "repo_ids.0",
+			),
 			resource.TestCheckResourceAttr(
 				"data.github_repositories.test", "sort",
 				"updated",
@@ -80,6 +83,10 @@ func TestAccGithubRepositoriesDataSource(t *testing.T) {
 			),
 			resource.TestCheckResourceAttr(
 				"data.github_repositories.test", "names.#",
+				"0",
+			),
+			resource.TestCheckResourceAttr(
+				"data.github_repositories.test", "repo_ids.#",
 				"0",
 			),
 		)

--- a/website/docs/d/repositories.html.markdown
+++ b/website/docs/d/repositories.html.markdown
@@ -32,3 +32,4 @@ The following arguments are supported:
 
 * `full_names` - A list of full names of found repositories (e.g. `hashicorp/terraform`)
 * `names` - A list of found repository names (e.g. `terraform`)
+* `repo_ids` - A list of found repository IDs


### PR DESCRIPTION
👋 Hello - this fixes issue #1077

The `github_repositories` data source now features a `repo_ids` attribute.

Thanks!