### PR TITLE
Update github_organization_settings to only need RO permissions at plan time

### DIFF
--- a/github/provider.go
+++ b/github/provider.go
@@ -109,7 +109,7 @@ func Provider() terraform.ResourceProvider {
 			"github_membership":                                  resourceGithubMembership(),
 			"github_organization_block":                          resourceOrganizationBlock(),
 			"github_organization_project":                        resourceGithubOrganizationProject(),
-			"github_organization_settings":                       resouceGithubOrganizationSettings(),
+			"github_organization_settings":                       resourceGithubOrganizationSettings(),
 			"github_organization_webhook":                        resourceGithubOrganizationWebhook(),
 			"github_project_card":                                resourceGithubProjectCard(),
 			"github_project_column":                              resourceGithubProjectColumn(),

--- a/github/resource_github_organization_settings.go
+++ b/github/resource_github_organization_settings.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
-func resouceGithubOrganizationSettings() *schema.Resource {
+func resourceGithubOrganizationSettings() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceGithubOrganizationSettingsCreateOrUpdate,
 		Read:   resourceGithubOrganizationSettingsRead,
@@ -246,7 +246,7 @@ func resourceGithubOrganizationSettingsRead(d *schema.ResourceData, meta interfa
 	ctx := context.Background()
 	org := meta.(*Owner).name
 
-	orgSettings, _, err := client.Organizations.Edit(ctx, org, nil)
+	orgSettings, _, err := client.Organizations.Get(ctx, org)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR aims to fix #1322.

As part of #1125, a new resource was added that allows the manipulation of Github Organization Settings. 

In our setup, we mint Github tokens with read-only permissions in the CI for every terraform plan (which occurs `on:pull_request`) and we mint tokens with read-write permissions only on runs occuring on the main branch (after merging)

However, we found that at plan time, the `github_organization_settings` resource requires `"organization_administration": "write"` permissions, which doesn't meet the Principle of least privilege.

We've verified that the provider still works correctly with the changes proposed in this PR by building the provider locally & validating against it. We've also run all existing tests for this resource & they still pass as well.

The [Organizations.Get](https://github.com/google/go-github/blob/v47.0.0/github/orgs.go#L192) method returns the same object as the [Organizations.Edit](https://github.com/google/go-github/blob/v47.0.0/github/orgs.go#L233) method, however using the Get method meets least privilege criteria on terraform plan time.

I would love to provide any more information if required or produce changes deemed necessary by the maintainers of the provider to get this change in.

Thank you!