### PR TITLE
Lowercase error strings

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -75,7 +75,7 @@ func getInstallationAccessToken(baseURL string, jwt string, installationID strin
 func generateAppJWT(appID string, now time.Time, pemData []byte) (string, error) {
 	block, _ := pem.Decode(pemData)
 	if block == nil {
-		return "", errors.New("No decodeable PEM data found")
+		return "", errors.New("no decodeable PEM data found")
 	}
 
 	privateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)

--- a/github/data_source_github_ip_ranges.go
+++ b/github/data_source_github_ip_ranges.go
@@ -238,7 +238,7 @@ func splitIpv4Ipv6Cidrs(cidrs *[]string) (*[]string, *[]string, error) {
 	for _, cidr := range *cidrs {
 		cidrHost, _, err := net.ParseCIDR(cidr)
 		if err != nil {
-			return nil, nil, fmt.Errorf("Failed parsing cidr %s (%v)", cidr, err)
+			return nil, nil, fmt.Errorf("failed parsing cidr %s (%v)", cidr, err)
 		}
 		if cidrHost.To4() != nil {
 			cidrIpv4 = append(cidrIpv4, cidr)

--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -268,7 +268,7 @@ func dataSourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) er
 func splitRepoFullName(fullName string) (string, string, error) {
 	parts := strings.Split(fullName, "/")
 	if len(parts) != 2 {
-		return "", "", fmt.Errorf("Unexpected full name format (%q), expected owner/repo_name", fullName)
+		return "", "", fmt.Errorf("unexpected full name format (%q), expected owner/repo_name", fullName)
 	}
 	return parts[0], parts[1], nil
 }

--- a/github/provider_utils.go
+++ b/github/provider_utils.go
@@ -75,7 +75,7 @@ func testAccCheckOrganization() error {
 	if owner == "" {
 		organization := os.Getenv("GITHUB_ORGANIZATION")
 		if organization == "" {
-			return fmt.Errorf("Neither `GITHUB_OWNER` or `GITHUB_ORGANIZATION` set in environment")
+			return fmt.Errorf("neither `GITHUB_OWNER` or `GITHUB_ORGANIZATION` set in environment")
 		}
 		owner = organization
 	}

--- a/github/resource_github_actions_organization_permissions.go
+++ b/github/resource_github_actions_organization_permissions.go
@@ -99,7 +99,7 @@ func resourceGithubActionsOrganizationAllowedObject(d *schema.ResourceData) (*gi
 		allowed.PatternsAllowed = patternsAllowed
 	} else {
 		return &github.ActionsAllowed{},
-			errors.New("The allowed_actions_config {} block must be specified if allowed_actions == 'selected'.")
+			errors.New("the allowed_actions_config {} block must be specified if allowed_actions == 'selected'")
 	}
 
 	return allowed, nil
@@ -118,7 +118,7 @@ func resourceGithubActionsEnabledRepositoriesObject(d *schema.ResourceData) ([]i
 			}
 		}
 	} else {
-		return nil, errors.New("The enabled_repositories_config {} block must be specified if enabled_repositories == 'selected'.")
+		return nil, errors.New("the enabled_repositories_config {} block must be specified if enabled_repositories == 'selected'")
 	}
 	return enabled, nil
 }

--- a/github/resource_github_actions_organization_secret.go
+++ b/github/resource_github_actions_organization_secret.go
@@ -86,7 +86,7 @@ func resourceGithubActionsOrganizationSecretCreateOrUpdate(d *schema.ResourceDat
 	selectedRepositories, hasSelectedRepositories := d.GetOk("selected_repository_ids")
 
 	if visibility != "selected" && hasSelectedRepositories {
-		return fmt.Errorf("Cannot use selected_repository_ids without visibility being set to selected")
+		return fmt.Errorf("cannot use selected_repository_ids without visibility being set to selected")
 	}
 
 	selectedRepositoryIDs := []int64{}

--- a/github/resource_github_actions_runner_group.go
+++ b/github/resource_github_actions_runner_group.go
@@ -81,7 +81,7 @@ func resourceGithubActionsRunnerGroupCreate(d *schema.ResourceData, meta interfa
 	selectedRepositories, hasSelectedRepositories := d.GetOk("selected_repository_ids")
 
 	if visibility != "selected" && hasSelectedRepositories {
-		return fmt.Errorf("Cannot use selected_repository_ids without visibility being set to selected")
+		return fmt.Errorf("cannot use selected_repository_ids without visibility being set to selected")
 	}
 
 	selectedRepositoryIDs := []int64{}

--- a/github/resource_github_branch.go
+++ b/github/resource_github_branch.go
@@ -76,7 +76,7 @@ func resourceGithubBranchCreate(d *schema.ResourceData, meta interface{}) error 
 	if _, hasSourceSHA := d.GetOk("source_sha"); !hasSourceSHA {
 		ref, _, err := client.Git.GetRef(ctx, orgName, repoName, sourceBranchRefName)
 		if err != nil {
-			return fmt.Errorf("Error querying GitHub branch reference %s/%s (%s): %s",
+			return fmt.Errorf("error querying GitHub branch reference %s/%s (%s): %s",
 				orgName, repoName, sourceBranchRefName, err)
 		}
 		d.Set("source_sha", *ref.Object.SHA)
@@ -88,7 +88,7 @@ func resourceGithubBranchCreate(d *schema.ResourceData, meta interface{}) error 
 		Object: &github.GitObject{SHA: &sourceBranchSHA},
 	})
 	if err != nil {
-		return fmt.Errorf("Error creating GitHub branch reference %s/%s (%s): %s",
+		return fmt.Errorf("error creating GitHub branch reference %s/%s (%s): %s",
 			orgName, repoName, branchRefName, err)
 	}
 
@@ -124,7 +124,7 @@ func resourceGithubBranchRead(d *schema.ResourceData, meta interface{}) error {
 				return nil
 			}
 		}
-		return fmt.Errorf("Error querying GitHub branch reference %s/%s (%s): %s",
+		return fmt.Errorf("error querying GitHub branch reference %s/%s (%s): %s",
 			orgName, repoName, branchRefName, err)
 	}
 
@@ -151,7 +151,7 @@ func resourceGithubBranchDelete(d *schema.ResourceData, meta interface{}) error 
 
 	_, err = client.Git.DeleteRef(ctx, orgName, repoName, branchRefName)
 	if err != nil {
-		return fmt.Errorf("Error deleting GitHub branch reference %s/%s (%s): %s",
+		return fmt.Errorf("error deleting GitHub branch reference %s/%s (%s): %s",
 			orgName, repoName, branchRefName, err)
 	}
 
@@ -182,7 +182,7 @@ func resourceGithubBranchImport(d *schema.ResourceData, meta interface{}) ([]*sc
 
 	// resourceGithubBranchRead calls d.SetId("") if the branch does not exist
 	if d.Id() == "" {
-		return nil, fmt.Errorf("Repository %s does not have a branch named %s.", repoName, branchName)
+		return nil, fmt.Errorf("repository %s does not have a branch named %s.", repoName, branchName)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/github/resource_github_branch_protection_test.go
+++ b/github/resource_github_branch_protection_test.go
@@ -676,11 +676,11 @@ func importBranchProtectionByRepoID(repoLogicalName, pattern string) resource.Im
 	return func(s *terraform.State) (string, error) {
 		repo := s.RootModule().Resources[repoLogicalName]
 		if repo == nil {
-			return "", fmt.Errorf("Cannot find %s in terraform state", repoLogicalName)
+			return "", fmt.Errorf("cannot find %s in terraform state", repoLogicalName)
 		}
 		repoID, found := repo.Primary.Attributes["node_id"]
 		if !found {
-			return "", fmt.Errorf("Repository %s does not have a node_id in terraform state", repo.Primary.ID)
+			return "", fmt.Errorf("repository %s does not have a node_id in terraform state", repo.Primary.ID)
 		}
 		return fmt.Sprintf("%s:%s", repoID, pattern), nil
 	}

--- a/github/resource_github_branch_protection_v3.go
+++ b/github/resource_github_branch_protection_v3.go
@@ -219,7 +219,7 @@ func resourceGithubBranchProtectionV3Read(d *schema.ResourceData, meta interface
 		if ghErr, ok := err.(*github.ErrorResponse); ok {
 			if ghErr.Response.StatusCode == http.StatusNotModified {
 				if err := requireSignedCommitsRead(d, meta); err != nil {
-					return fmt.Errorf("Error setting signed commit restriction: %v", err)
+					return fmt.Errorf("error setting signed commit restriction: %v", err)
 				}
 				return nil
 			}
@@ -243,19 +243,19 @@ func resourceGithubBranchProtectionV3Read(d *schema.ResourceData, meta interface
 	}
 
 	if err := flattenAndSetRequiredStatusChecks(d, githubProtection); err != nil {
-		return fmt.Errorf("Error setting required_status_checks: %v", err)
+		return fmt.Errorf("error setting required_status_checks: %v", err)
 	}
 
 	if err := flattenAndSetRequiredPullRequestReviews(d, githubProtection); err != nil {
-		return fmt.Errorf("Error setting required_pull_request_reviews: %v", err)
+		return fmt.Errorf("error setting required_pull_request_reviews: %v", err)
 	}
 
 	if err := flattenAndSetRestrictions(d, githubProtection); err != nil {
-		return fmt.Errorf("Error setting restrictions: %v", err)
+		return fmt.Errorf("error setting restrictions: %v", err)
 	}
 
 	if err := requireSignedCommitsRead(d, meta); err != nil {
-		return fmt.Errorf("Error setting signed commit restriction: %v", err)
+		return fmt.Errorf("error setting signed commit restriction: %v", err)
 	}
 
 	return nil

--- a/github/resource_github_dependabot_organization_secret.go
+++ b/github/resource_github_dependabot_organization_secret.go
@@ -87,7 +87,7 @@ func resourceGithubDependabotOrganizationSecretCreateOrUpdate(d *schema.Resource
 	selectedRepositories, hasSelectedRepositories := d.GetOk("selected_repository_ids")
 
 	if visibility != "selected" && hasSelectedRepositories {
-		return fmt.Errorf("Cannot use selected_repository_ids without visibility being set to selected")
+		return fmt.Errorf("cannot use selected_repository_ids without visibility being set to selected")
 	}
 
 	selectedRepositoryIDs := []string{}

--- a/github/resource_github_membership_test.go
+++ b/github/resource_github_membership_test.go
@@ -105,7 +105,7 @@ func testAccCheckGithubMembershipDestroy(s *terraform.State) error {
 		if err == nil {
 			if membership != nil &&
 				buildTwoPartID(orgName, username) == rs.Primary.ID {
-				return fmt.Errorf("Organization membership %q still exists", rs.Primary.ID)
+				return fmt.Errorf("organization membership %q still exists", rs.Primary.ID)
 			}
 		}
 		if resp.StatusCode != 404 {
@@ -120,11 +120,11 @@ func testAccCheckGithubMembershipExists(n string, membership *github.Membership)
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not Found: %s", n)
+			return fmt.Errorf("not Found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No membership ID is set")
+			return fmt.Errorf("no membership ID is set")
 		}
 
 		conn := testAccProvider.Meta().(*Owner).v3client
@@ -146,11 +146,11 @@ func testAccCheckGithubMembershipRoleState(n string, membership *github.Membersh
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not Found: %s", n)
+			return fmt.Errorf("not Found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No membership ID is set")
+			return fmt.Errorf("no membership ID is set")
 		}
 
 		conn := testAccProvider.Meta().(*Owner).v3client
@@ -168,7 +168,7 @@ func testAccCheckGithubMembershipRoleState(n string, membership *github.Membersh
 		actualRole := githubMembership.GetRole()
 
 		if resourceRole != actualRole {
-			return fmt.Errorf("Membership role %v in resource does match actual state of %v",
+			return fmt.Errorf("membership role %v in resource does match actual state of %v",
 				resourceRole, actualRole)
 		}
 		return nil

--- a/github/resource_github_organization_project_test.go
+++ b/github/resource_github_organization_project_test.go
@@ -62,7 +62,7 @@ func testAccGithubOrganizationProjectDestroy(s *terraform.State) error {
 		if err == nil {
 			if project != nil &&
 				project.GetID() == projectID {
-				return fmt.Errorf("Organization project still exists")
+				return fmt.Errorf("organization project still exists")
 			}
 		}
 		if res.StatusCode != 404 {
@@ -77,7 +77,7 @@ func testAccCheckGithubOrganizationProjectExists(n string, project *github.Proje
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not Found: %s", n)
+			return fmt.Errorf("not Found: %s", n)
 		}
 
 		projectID, err := strconv.ParseInt(rs.Primary.ID, 10, 64)

--- a/github/resource_github_project_column_test.go
+++ b/github/resource_github_project_column_test.go
@@ -69,7 +69,7 @@ func testAccGithubProjectColumnDestroy(s *terraform.State) error {
 		if err == nil {
 			if column != nil &&
 				column.GetID() == columnID {
-				return fmt.Errorf("Project column still exists")
+				return fmt.Errorf("project column still exists")
 			}
 		}
 		if res.StatusCode != 404 {
@@ -83,7 +83,7 @@ func testAccCheckGithubProjectColumnExists(n string, project *github.ProjectColu
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not Found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		columnID, err := strconv.ParseInt(rs.Primary.ID, 10, 64)

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -316,7 +316,7 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 	client := meta.(*Owner).v3client
 
 	if branchName, hasDefaultBranch := d.GetOk("default_branch"); hasDefaultBranch && (branchName != "main") {
-		return fmt.Errorf("Cannot set the default branch on a new repository to something other than 'main'.")
+		return fmt.Errorf("cannot set the default branch on a new repository to something other than 'main'.")
 	}
 
 	repoReq := resourceGithubRepositoryObject(d)
@@ -490,7 +490,7 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	if !d.Get("ignore_vulnerability_alerts_during_read").(bool) {
 		vulnerabilityAlerts, _, err := client.Repositories.GetVulnerabilityAlerts(ctx, owner, repoName)
 		if err != nil {
-			return fmt.Errorf("Error reading repository vulnerability alerts: %v", err)
+			return fmt.Errorf("error reading repository vulnerability alerts: %v", err)
 		}
 		d.Set("vulnerability_alerts", vulnerabilityAlerts)
 	}

--- a/github/resource_github_repository_autolink_reference.go
+++ b/github/resource_github_repository_autolink_reference.go
@@ -22,7 +22,7 @@ func resourceGithubRepositoryAutolinkReference() *schema.Resource {
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				parts := strings.Split(d.Id(), "/")
 				if len(parts) != 2 {
-					return nil, fmt.Errorf("Invalid ID specified. Supplied ID must be written as <repository>/<autolink_reference_id>")
+					return nil, fmt.Errorf("invalid ID specified: supplied ID must be written as <repository>/<autolink_reference_id>")
 				}
 				d.Set("repository", parts[0])
 				d.SetId(parts[1])

--- a/github/resource_github_repository_deploy_key_test.go
+++ b/github/resource_github_repository_deploy_key_test.go
@@ -125,11 +125,11 @@ func testAccCheckGithubRepositoryDeployKeyExists(n string) resource.TestCheckFun
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not Found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No membership ID is set")
+			return fmt.Errorf("no membership ID is set")
 		}
 
 		conn := testAccProvider.Meta().(*Owner).v3client

--- a/github/resource_github_repository_file.go
+++ b/github/resource_github_repository_file.go
@@ -23,7 +23,7 @@ func resourceGithubRepositoryFile() *schema.Resource {
 				branch := "main"
 
 				if len(parts) > 2 {
-					return nil, fmt.Errorf("Invalid ID specified. Supplied ID must be written as <repository>/<file path> (when branch is \"main\") or <repository>/<file path>:<branch>")
+					return nil, fmt.Errorf("invalid ID specified. Supplied ID must be written as <repository>/<file path> (when branch is \"main\") or <repository>/<file path>:<branch>")
 				}
 
 				if len(parts) == 2 {
@@ -128,11 +128,11 @@ func resourceGithubRepositoryFileOptions(d *schema.ResourceData) (*github.Reposi
 	commitEmail, hasCommitEmail := d.GetOk("commit_email")
 
 	if hasCommitAuthor && !hasCommitEmail {
-		return nil, fmt.Errorf("Cannot set commit_author without setting commit_email")
+		return nil, fmt.Errorf("cannot set commit_author without setting commit_email")
 	}
 
 	if hasCommitEmail && !hasCommitAuthor {
-		return nil, fmt.Errorf("Cannot set commit_email without setting commit_author")
+		return nil, fmt.Errorf("cannot set commit_email without setting commit_author")
 	}
 
 	if hasCommitAuthor && hasCommitEmail {

--- a/github/resource_github_repository_milestone.go
+++ b/github/resource_github_repository_milestone.go
@@ -24,7 +24,7 @@ func resourceGithubRepositoryMilestone() *schema.Resource {
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				parts := strings.Split(d.Id(), "/")
 				if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
-					return nil, fmt.Errorf("Invalid ID format, must be provided as OWNER/REPOSITORY/NUMBER")
+					return nil, fmt.Errorf("invalid ID format, must be provided as OWNER/REPOSITORY/NUMBER")
 				}
 				d.Set("owner", parts[0])
 				d.Set("repository", parts[1])

--- a/github/resource_github_repository_project.go
+++ b/github/resource_github_repository_project.go
@@ -22,7 +22,7 @@ func resourceGithubRepositoryProject() *schema.Resource {
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				parts := strings.Split(d.Id(), "/")
 				if len(parts) != 2 {
-					return nil, fmt.Errorf("Invalid ID specified. Supplied ID must be written as <repository>/<project_id>")
+					return nil, fmt.Errorf("invalid ID specified: supplied ID must be written as <repository>/<project_id>")
 				}
 				d.Set("repository", parts[0])
 				d.SetId(parts[1])

--- a/github/resource_github_repository_tag_protection.go
+++ b/github/resource_github_repository_tag_protection.go
@@ -21,7 +21,7 @@ func resourceGithubRepositoryTagProtection() *schema.Resource {
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				parts := strings.Split(d.Id(), "/")
 				if len(parts) != 2 {
-					return nil, fmt.Errorf("Invalid ID specified. Supplied ID must be written as <repository>/<tag_protection_id>")
+					return nil, fmt.Errorf("invalid ID specified: supplied ID must be written as <repository>/<tag_protection_id>")
 				}
 				d.Set("repository", parts[0])
 				d.Set("tag_protection_id", parts[1])

--- a/github/resource_github_repository_webhook.go
+++ b/github/resource_github_repository_webhook.go
@@ -22,7 +22,7 @@ func resourceGithubRepositoryWebhook() *schema.Resource {
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				parts := strings.Split(d.Id(), "/")
 				if len(parts) != 2 {
-					return nil, fmt.Errorf("Invalid ID specified. Supplied ID must be written as <repository>/<webhook_id>")
+					return nil, fmt.Errorf("invalid ID specified: supplied ID must be written as <repository>/<webhook_id>")
 				}
 				d.Set("repository", parts[0])
 				d.SetId(parts[1])

--- a/github/resource_github_team_members_test.go
+++ b/github/resource_github_team_members_test.go
@@ -89,7 +89,7 @@ func testAccCheckGithubTeamMembersDestroy(s *terraform.State) error {
 			orgId, teamId, nil)
 		if err == nil {
 			if len(members) > 0 {
-				return fmt.Errorf("Team has still members: %v", members)
+				return fmt.Errorf("team has still members: %v", members)
 			}
 		}
 		if resp.StatusCode != 404 {
@@ -104,11 +104,11 @@ func testAccCheckGithubTeamMembersExists(n string, membership *github.Membership
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not Found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No team ID is set")
+			return fmt.Errorf("no team ID is set")
 		}
 
 		conn := testAccProvider.Meta().(*Owner).v3client
@@ -126,7 +126,7 @@ func testAccCheckGithubTeamMembersExists(n string, membership *github.Membership
 		}
 
 		if len(members) != 1 {
-			return fmt.Errorf("Team has not one member: %d", len(members))
+			return fmt.Errorf("team has not one member: %d", len(members))
 		}
 
 		TeamMembership, _, err := conn.Teams.GetTeamMembershipByID(context.TODO(), orgId, teamId, *members[0].Login)
@@ -143,11 +143,11 @@ func testAccCheckGithubTeamMembersRoleState(n, expected string, membership *gith
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not Found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No team ID is set")
+			return fmt.Errorf("no team ID is set")
 		}
 
 		conn := testAccProvider.Meta().(*Owner).v3client
@@ -165,7 +165,7 @@ func testAccCheckGithubTeamMembersRoleState(n, expected string, membership *gith
 		}
 
 		if len(members) != 1 {
-			return fmt.Errorf("Team has not one member: %d", len(members))
+			return fmt.Errorf("team has not one member: %d", len(members))
 		}
 
 		TeamMembers, _, err := conn.Teams.GetTeamMembershipByID(context.TODO(),
@@ -178,11 +178,11 @@ func testAccCheckGithubTeamMembersRoleState(n, expected string, membership *gith
 		actualRole := TeamMembers.GetRole()
 
 		if resourceRole != expected {
-			return fmt.Errorf("Team membership role %v in resource does match expected state of %v", resourceRole, expected)
+			return fmt.Errorf("team membership role %v in resource does match expected state of %v", resourceRole, expected)
 		}
 
 		if resourceRole != actualRole {
-			return fmt.Errorf("Team membership role %v in resource does match actual state of %v", resourceRole, actualRole)
+			return fmt.Errorf("team membership role %v in resource does match actual state of %v", resourceRole, actualRole)
 		}
 		return nil
 	}

--- a/github/resource_github_team_membership_test.go
+++ b/github/resource_github_team_membership_test.go
@@ -124,7 +124,7 @@ func testAccCheckGithubTeamMembershipDestroy(s *terraform.State) error {
 			orgId, teamId, username)
 		if err == nil {
 			if membership != nil {
-				return fmt.Errorf("Team membership still exists")
+				return fmt.Errorf("team membership still exists")
 			}
 		}
 		if resp.StatusCode != 404 {
@@ -139,11 +139,11 @@ func testAccCheckGithubTeamMembershipExists(n string, membership *github.Members
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not Found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No team membership ID is set")
+			return fmt.Errorf("no team membership ID is set")
 		}
 
 		conn := testAccProvider.Meta().(*Owner).v3client
@@ -172,11 +172,11 @@ func testAccCheckGithubTeamMembershipRoleState(n, expected string, membership *g
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not Found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No team membership ID is set")
+			return fmt.Errorf("no team membership ID is set")
 		}
 
 		conn := testAccProvider.Meta().(*Owner).v3client
@@ -200,11 +200,11 @@ func testAccCheckGithubTeamMembershipRoleState(n, expected string, membership *g
 		actualRole := teamMembership.GetRole()
 
 		if resourceRole != expected {
-			return fmt.Errorf("Team membership role %v in resource does match expected state of %v", resourceRole, expected)
+			return fmt.Errorf("team membership role %v in resource does match expected state of %v", resourceRole, expected)
 		}
 
 		if resourceRole != actualRole {
-			return fmt.Errorf("Team membership role %v in resource does match actual state of %v", resourceRole, actualRole)
+			return fmt.Errorf("team membership role %v in resource does match actual state of %v", resourceRole, actualRole)
 		}
 		return nil
 	}

--- a/github/resource_github_team_sync_group_mapping_test.go
+++ b/github/resource_github_team_sync_group_mapping_test.go
@@ -156,7 +156,7 @@ func testAccCheckGithubTeamSyncGroupMappingDestroy(s *terraform.State) error {
 		groupList, resp, err := conn.Teams.ListIDPGroupsForTeamBySlug(ctx, orgName, slug)
 		if err == nil {
 			if groupList != nil && len(groupList.Groups) > 0 {
-				return fmt.Errorf("Team Sync Group Mapping still exists for team slug %s", slug)
+				return fmt.Errorf("team Sync Group Mapping still exists for team slug %s", slug)
 			}
 		}
 		if resp.StatusCode != 404 {
@@ -171,7 +171,7 @@ func testAccCheckGithubTeamSyncGroupMappingDisappears(resourceName string) resou
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
+			return fmt.Errorf("not found: %s", resourceName)
 		}
 		conn := testAccProvider.Meta().(*Owner).v3client
 		orgName := testAccProvider.Meta().(*Owner).name
@@ -188,7 +188,7 @@ func testAccGithubTeamSyncGroupMappingImportStateIdFunc(resourceName string) res
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return "", fmt.Errorf("Not found: %s", resourceName)
+			return "", fmt.Errorf("not found: %s", resourceName)
 		}
 
 		return rs.Primary.Attributes["team_slug"], nil

--- a/github/resource_github_user_invitation_accepter.go
+++ b/github/resource_github_user_invitation_accepter.go
@@ -30,7 +30,7 @@ func resourceGithubUserInvitationAccepterCreate(d *schema.ResourceData, meta int
 	invitationIdString := d.Get("invitation_id").(string)
 	invitationId, err := strconv.Atoi(invitationIdString)
 	if err != nil {
-		return fmt.Errorf("Failed to parse invitation ID: %s", err)
+		return fmt.Errorf("failed to parse invitation ID: %s", err)
 	}
 	ctx := context.Background()
 

--- a/github/resource_organization_block_test.go
+++ b/github/resource_organization_block_test.go
@@ -60,7 +60,7 @@ func testAccCheckOrganizationBlockExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not Found: %s", n)
+			return fmt.Errorf("not Found: %s", n)
 		}
 
 		username := rs.Primary.ID

--- a/github/util.go
+++ b/github/util.go
@@ -54,7 +54,7 @@ func validateValueFunc(values []string) schema.SchemaValidateFunc {
 func parseTwoPartID(id, left, right string) (string, string, error) {
 	parts := strings.SplitN(id, ":", 2)
 	if len(parts) != 2 {
-		return "", "", fmt.Errorf("Unexpected ID format (%q). Expected %s:%s", id, left, right)
+		return "", "", fmt.Errorf("unexpected ID format (%q); expected %s:%s", id, left, right)
 	}
 
 	return parts[0], parts[1], nil
@@ -69,7 +69,7 @@ func buildTwoPartID(a, b string) string {
 func parseThreePartID(id, left, center, right string) (string, string, string, error) {
 	parts := strings.SplitN(id, ":", 3)
 	if len(parts) != 3 {
-		return "", "", "", fmt.Errorf("Unexpected ID format (%q). Expected %s:%s:%s", id, left, center, right)
+		return "", "", "", fmt.Errorf("unexpected ID format (%q). Expected %s:%s:%s", id, left, center, right)
 	}
 
 	return parts[0], parts[1], parts[2], nil
@@ -183,11 +183,11 @@ func validateSecretNameFunc(v interface{}, keyName string) (we []string, errs []
 	}
 
 	if !secretNameRegexp.MatchString(name) {
-		errs = append(errs, errors.New("Secret names can only contain alphanumeric characters or underscores and must not start with a number"))
+		errs = append(errs, errors.New("secret names can only contain alphanumeric characters or underscores and must not start with a number"))
 	}
 
 	if strings.HasPrefix(strings.ToUpper(name), "GITHUB_") {
-		errs = append(errs, errors.New("Secret names must not start with the GITHUB_ prefix"))
+		errs = append(errs, errors.New("secret names must not start with the GITHUB_ prefix"))
 	}
 
 	return we, errs

--- a/github/util_permissions.go
+++ b/github/util_permissions.go
@@ -34,7 +34,7 @@ func getRepoPermission(p map[string]bool) (string, error) {
 		if (p)[pullPermission] {
 			return pullPermission, nil
 		}
-		return "", errors.New("At least one permission expected from permissions map.")
+		return "", errors.New("at least one permission expected from permissions map")
 	}
 }
 

--- a/github/util_v4_branch_protection.go
+++ b/github/util_v4_branch_protection.go
@@ -431,7 +431,7 @@ func getBranchProtectionID(repoID githubv4.ID, pattern string, meta interface{})
 		}
 	}
 
-	return nil, fmt.Errorf("Could not find a branch protection rule with the pattern '%s'.", pattern)
+	return nil, fmt.Errorf("could not find a branch protection rule with the pattern '%s'.", pattern)
 }
 
 func getActorIds(data []string, meta interface{}) ([]string, error) {


### PR DESCRIPTION
This is a small thing that's been bothering me for a while. According to the [Go wiki](https://github.com/golang/go/wiki/CodeReviewComments#error-strings), "Error strings should not be capitalized (unless beginning with proper nouns or acronyms) or end with punctuation, since they are usually printed following other context."

This change updates our error messages to be in line with that recommendation. 