### PR TITLE
CONTRIBUTING.md advice on searching for prior work before submissions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ Contributions to this project are [released](https://help.github.com/articles/gi
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
+Before submitting an issue or a pull request, please search the repository for existing content. Issues and PRs with multiple comments/experience reports increase the likelihood of a merged change.
+
 ## Submitting a pull request
 
 0. Fork and clone the repository


### PR DESCRIPTION
Today when looking at #1337 I foolishly made changes locally before checking if work existed on the repo: it turns out #1120 was already filed. Since I refer to the CONTRIBUTING.md doc frequently when developing for useful environment variables and shell commands, hopefully this will prevent further incidents of this nature for me and perhaps others. 

cc @nickfloyd