### PR TITLE
Add standardized issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -7,8 +7,8 @@ Run `terraform -v` to show the version. If you are not running the latest versio
 
 ### Affected Resource(s)
 Please list the resources as a list, for example:
-- opc_instance
-- opc_storage_volume
+- github_repository
+- github_branch_protection
 
 If this issue appears to affect multiple resources, it may be an issue with Terraform's core, so please mention this.
 

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,49 @@
+name: Documentation
+description: Update or add documentation
+title: "[DOCS]: "
+labels: ["Type: Documentation", "Status: Triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill this out!
+  - type: textarea
+    id: describe-need
+    attributes:
+      label: Describe the need
+      description: What do you wish was different about our docs?
+      placeholder: Describe the need for documentation updates here.
+    validations:
+      required: true
+  - type: input
+    id: sdk_version
+    attributes:
+      label: SDK Version
+      description: Do these docs apply to a specific SDK version?
+      placeholder: Octokit.NET v4.0.1
+    validations:
+      required: false
+  - type: input
+    id: api_version
+    attributes:
+      label: API Version
+      description: Do these docs apply to a specific version of the GitHub REST API or GraphQL API?
+      placeholder: ex. v1.1.1
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: |
+        Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+        Please check your logs before submission to ensure sensitive information is redacted.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,49 @@
+name: Feature
+description: Suggest an idea for a new feature or enhancement
+title: "[FEAT]: "
+labels: ["Type: Feature", "Status: Triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill this out!
+  - type: textarea
+    id: describe-need
+    attributes:
+      label: Describe the need
+      description: What do you want to happen? What problem are you trying to solve?
+      placeholder: Describe the need for the feature.
+    validations:
+      required: true
+  - type: input
+    id: sdk_version
+    attributes:
+      label: SDK Version
+      description: Does this feature suggestion apply to a specific SDK version?
+      placeholder: Octokit.rb v6.0.0
+    validations:
+      required: false
+  - type: input
+    id: api_version
+    attributes:
+      label: API Version
+      description: Does this feature suggestion apply to a specific version of the GitHub REST API or GraphQL API?
+      placeholder: ex. v1.1.1
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: |
+        Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+        Please check your logs before submission to ensure sensitive information is redacted.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -1,0 +1,49 @@
+name: Maintenance
+description: Dependencies, cleanup, refactoring, reworking of code
+title: "[MAINT]: "
+labels: ["Type: Maintenance", "Status: Triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill this out!
+  - type: textarea
+    id: describe-need
+    attributes:
+      label: Describe the need
+      description: What do you want to happen?
+      placeholder: Describe the maintenance need here.
+    validations:
+      required: true
+  - type: input
+    id: sdk_version
+    attributes:
+      label: SDK Version
+      description: Does this maintenance apply to a specific SDK version?
+      placeholder: terraform-provider-github v5.7.0
+    validations:
+      required: false
+  - type: input
+    id: api_version
+    attributes:
+      label: API Version
+      description: Does this maintenance apply to a specific version of the GitHub REST API or GraphQL API?
+      placeholder: ex. v1.1.1
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: |
+        Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+        Please check your logs before submission to ensure sensitive information is redacted.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true


### PR DESCRIPTION
This PR leaves in place the existing bug template since it's specific to Terraform concerns and brings us value. Otherwise, it adds the common issue templates from the Octokit organization.