### PR TITLE
Fix commit_message when file resource is deleted

### DIFF
--- a/github/resource_github_repository_file.go
+++ b/github/resource_github_repository_file.go
@@ -79,7 +79,7 @@ func resourceGithubRepositoryFile() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				Description: "The commit message when creating or updating the file",
+				Description: "The commit message when creating, updating or deleting the file",
 			},
 			"commit_author": {
 				Type:        schema.TypeString,
@@ -311,8 +311,12 @@ func resourceGithubRepositoryFileDelete(d *schema.ResourceData, meta interface{}
 	repo := d.Get("repository").(string)
 	file := d.Get("file").(string)
 	branch := d.Get("branch").(string)
-
 	message := fmt.Sprintf("Delete %s", file)
+
+	if commitMessage, hasCommitMessage := d.GetOk("commit_message"); hasCommitMessage {
+		message = commitMessage.(string)
+	}
+
 	sha := d.Get("sha").(string)
 	opts := &github.RepositoryContentFileOptions{
 		Message: &message,


### PR DESCRIPTION
Small change that Fixes [#706 ](https://github.com/integrations/terraform-provider-github/issues/706)

**Context:** When a file resource is deleted, it always uses a static commit_message - "Delete $filename". This is leading to unwanted behaviours on repositories that have CI/CD enabled, because it is often desired to pass [skip ci]  in commit message to have control over automation workflows, but currently it is not supported. This PR fixes that and allows _commit_message_ also when the file is deleted.