### PR TITLE
Add `template` details to `github_repository` data source

### DIFF
--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -62,6 +62,10 @@ func dataSourceGithubRepository() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"is_template": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"allow_merge_commit": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -171,6 +175,23 @@ func dataSourceGithubRepository() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"template": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"owner": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"repository": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"node_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -224,6 +245,7 @@ func dataSourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("visibility", repo.GetVisibility())
 	d.Set("has_issues", repo.GetHasIssues())
 	d.Set("has_wiki", repo.GetHasWiki())
+	d.Set("is_template", repo.GetIsTemplate())
 	d.Set("allow_merge_commit", repo.GetAllowMergeCommit())
 	d.Set("allow_squash_merge", repo.GetAllowSquashMerge())
 	d.Set("allow_rebase_merge", repo.GetAllowRebaseMerge())
@@ -255,6 +277,17 @@ func dataSourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) er
 		}
 	} else {
 		d.Set("pages", flattenPages(nil))
+	}
+
+	if repo.TemplateRepository != nil {
+		d.Set("template", []interface{}{
+			map[string]interface{}{
+				"owner":      repo.TemplateRepository.Owner.Login,
+				"repository": repo.TemplateRepository.Name,
+			},
+		})
+	} else {
+		d.Set("template", []interface{}{})
 	}
 
 	err = d.Set("topics", flattenStringList(repo.Topics))

--- a/github/data_source_github_repository_test.go
+++ b/github/data_source_github_repository_test.go
@@ -56,7 +56,6 @@ func TestAccGithubRepositoryDataSource(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
 		config := fmt.Sprintf(`
-		
 			resource "github_repository" "test" {
 				name         = "tf-acc-%s"
 				auto_init    = true
@@ -163,4 +162,108 @@ func TestAccGithubRepositoryDataSource(t *testing.T) {
 
 	})
 
+	t.Run("queries a repository that is a template", func(t *testing.T) {
+
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name        = "tf-acc-%s"
+				is_template = true
+			}
+
+			data "github_repository" "test" {
+				name = github_repository.test.name
+			}
+		`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"data.github_repository.test", "is_template",
+				"true",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
+
+	t.Run("queries a repository that was generated from a template", func(t *testing.T) {
+
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name = "tf-acc-%s"
+				template {
+					owner      = "template-repository"
+					repository = "template-repository"
+				}
+			}
+
+			data "github_repository" "test" {
+				name = github_repository.test.name
+			}
+		`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"data.github_repository.test", "template.0.owner",
+				"template-repository",
+			),
+			resource.TestCheckResourceAttr(
+				"data.github_repository.test", "template.0.repository",
+				"template-repository",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
 }

--- a/website/docs/d/repository.html.markdown
+++ b/website/docs/d/repository.html.markdown
@@ -43,6 +43,8 @@ The following arguments are supported:
 
 * `has_wiki` - Whether the repository has the GitHub Wiki enabled.
 
+* `is_template` - Whether the repository is a template repository.
+
 * `allow_merge_commit` - Whether the repository allows merge commits.
 
 * `allow_squash_merge` - Whether the repository allows squash merges.
@@ -68,6 +70,8 @@ The following arguments are supported:
 * `pages` - The repository's GitHub Pages configuration.
 
 * `topics` - The list of topics of the repository.
+
+* `template` - The repository source template configuration.
 
 * `html_url` - URL to the repository on the web.
 


### PR DESCRIPTION
This commit adds the `template` details to the `github_repository` data source result.

Following fields are added:
* `is_template` - `bool` - Is the repository a template
* `template` - `map` - Populated if the repo was generated from a template.
  * `owner` - `string` - Source template owner
  * `repository` - `string` - Source template repository

Updated tests to exercise new behavior.