### PR TITLE
[maint]: bumps go-github from v48.0.0 to v48.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0 // indirect
 	github.com/golangci/misspell v0.3.5 // indirect
 	github.com/golangci/revgrep v0.0.0-20220804021717-745bb2f7c2e6 // indirect
-	github.com/google/go-github/v48 v48.0.0
+	github.com/google/go-github/v48 v48.1.0
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gostaticanalysis/analysisutil v0.7.1 // indirect
 	github.com/gostaticanalysis/testutil v0.4.0 // indirect
@@ -50,9 +50,7 @@ require (
 	github.com/timakin/bodyclose v0.0.0-20210704033933-f49887972144 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/ultraware/funlen v0.0.3 // indirect
-	github.com/vmihailenco/msgpack v4.0.1+incompatible // indirect
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
-	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
 	google.golang.org/api v0.81.0 // indirect
 	gopkg.in/ini.v1 v1.66.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -316,8 +316,8 @@ github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v48 v48.0.0 h1:9H5fWVXFK6ZsRriyPbjtnFAkJnoj0WKFtTYfpCRrTm8=
-github.com/google/go-github/v48 v48.0.0/go.mod h1:dDlehKBDo850ZPvCTK0sEqTCVWcrGl2LcDiajkYi89Y=
+github.com/google/go-github/v48 v48.1.0 h1:nqPqq+0oRY2AMR/SRskGrrP4nnewPB7e/m2+kbT/UvM=
+github.com/google/go-github/v48 v48.1.0/go.mod h1:dDlehKBDo850ZPvCTK0sEqTCVWcrGl2LcDiajkYi89Y=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
@@ -697,9 +697,8 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasthttp v1.2.0/go.mod h1:4vX61m6KN+xDduDNwXrhIAVZaZaZiQ1luJk8LWSxF3s=
 github.com/valyala/quicktemplate v1.1.1/go.mod h1:EH+4AkTd43SvgIbQHYu59/cJyxDoOVRUAfrukLPuGJ4=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
+github.com/vmihailenco/msgpack v3.3.3+incompatible h1:wapg9xDUZDzGCNFlwc5SqI1rvcciqcxEHac4CYj89xI=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
-github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvCazn8G65U=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
@@ -762,9 +761,8 @@ golang.org/x/exp v0.0.0-20191129062945-2f5052295587/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
+golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 h1:QE6XYQK6naiK1EPAe1g/ILLxN5RBoH5xkJk3CqlMI/Y=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
-golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/exp/typeparams v0.0.0-20220613132600-b0d781184e0d h1:+W8Qf4iJtMGKkyAygcKohjxTk4JPsL9DpzApJ22m5Ic=
 golang.org/x/exp/typeparams v0.0.0-20220613132600-b0d781184e0d/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=

--- a/vendor/github.com/google/go-github/v48/AUTHORS
+++ b/vendor/github.com/google/go-github/v48/AUTHORS
@@ -11,7 +11,10 @@
 178inaba <masahiro.furudate@gmail.com>
 2BFL <imqksl@gmail.com>
 413x <dedifferentiator@gmail.com>
+Abed Kibbe <abed.kibbe@gmail.com>
 Abhinav Gupta <mail@abhinavg.net>
+Abhishek Veeramalla <abhishek.veeramalla@gmail.com>
+aboy <b1011211@gmail.com>
 adrienzieba <adrien.zieba@appdirect.com>
 afdesk <work@afdesk.com>
 Ahmed Hagy <a.akram93@gmail.com>
@@ -24,15 +27,18 @@ Alec Thomas <alec@swapoff.org>
 Aleks Clark <aleks.clark@gmail.com>
 Alex Bramley <a.bramley@gmail.com>
 Alex Orr <Alexorr.CSE@gmail.com>
+Alex Su <alexsu@17.media>
 Alex Unger <zyxancf@gmail.com>
 Alexander Harkness <me@bearbin.net>
 Alexis Gauthiez <alexis.gauthiez@gmail.com>
 Ali Farooq <ali.farooq0@pm.me>
+Allan Guwatudde <guwats10@gmail.com>
 Allen Sun <shlallen1990@gmail.com>
 Amey Sakhadeo <me@ameyms.com>
 Anders Janmyr <anders@janmyr.com>
 Andreas Garnæs <https://github.com/andreas>
 Andrew Ryabchun <aryabchun@mail.ua>
+Andrew Svoboda <svoboda.andrew@gmail.com>
 Andy Grunwald <andygrunwald@gmail.com>
 Andy Hume <andyhume@gmail.com>
 Andy Lindeman <andy@lindeman.io>
@@ -58,21 +64,26 @@ Beshr Kayali <beshrkayali@gmail.com>
 Beyang Liu <beyang.liu@gmail.com>
 Billy Keyes <bluekeyes@gmail.com>
 Billy Lynch <wlynch92@gmail.com>
-Björn Häuser <b.haeuser@rebuy.de>
 Bjorn Neergaard <bjorn@neersighted.com>
+Björn Häuser <b.haeuser@rebuy.de>
 boljen <bol.christophe@gmail.com>
+Bracken <abdawson@gmail.com>
 Brad Harris <bmharris@gmail.com>
 Brad Moylan <moylan.brad@gmail.com>
 Bradley Falzon <brad@teambrad.net>
 Bradley McAllister <brad.mcallister@hotmail.com>
+Brandon Butler <b.butler@chia.net>
 Brandon Cook <phylake@gmail.com>
+Brett Kuhlman <kuhlman-labs@github.com>
 Brett Logan <lindluni@github.com>
 Brian Egizi <brian@mojotech.com>
 Bryan Boreham <bryan@weave.works>
+Bryan Peterson <Lazyshot@gmail.com>
 Cami Diez <diezcami@gmail.com>
 Carl Johnson <me@carlmjohnson.net>
 Carlos Alexandro Becker <caarlos0@gmail.com>
 Carlos Tadeu Panato Junior <ctadeu@gmail.com>
+ChandanChainani <chainanichan@gmail.com>
 chandresh-pancholi <chandreshpancholi007@gmail.com>
 Charles Fenwick Elliott <Charles@FenwickElliott.io>
 Charlie Yan <charlieyan08@gmail.com>
@@ -83,12 +94,17 @@ Chris Raborg <craborg57@gmail.com>
 Chris Roche <chris@vsco.co>
 Chris Schaefer <chris@dtzq.com>
 chrisforrette <chris@chrisforrette.com>
+Christian Bargmann <chris@cbrgm.net>
 Christian Muehlhaeuser <muesli@gmail.com>
 Christoph Sassenberg <defsprite@gmail.com>
+CI Monk <ci-monk@protonmail.com>
 Colin Misare <github.com/cmisare>
+Craig Gumbley <craiggumbley@gmail.com>
 Craig Peterson <cpeterson@stackoverflow.com>
 Cristian Maglie <c.maglie@bug.st>
+Cyb3r Jak3 <jake@jwhite.network>
 Daehyeok Mun <daehyeok@gmail.com>
+Dalton Hubble <dghubble@gmail.com>
 Daniel Lanner <lanner.dan@gmail.com>
 Daniel Leavitt <daniel.leavitt@gmail.com>
 Daniel Nilsson <daniel.nilsson1989@gmail.com>
@@ -98,6 +114,7 @@ Dave Henderson <dhenderson@gmail.com>
 Dave Perrett <hello@daveperrett.com>
 Dave Protasowski <dprotaso@gmail.com>
 David Deng <daviddengcn@gmail.com>
+David Gamba <davidgamba@gmail.com>
 David J. M. Karlsen <david@davidkarlsen.com>
 David Jannotta <djannotta@gmail.com>
 David Ji <github.com/davidji99>
@@ -105,6 +122,7 @@ David Lopez Reyes <davidlopezre@gmail.com>
 Davide Zipeto <dawez1@gmail.com>
 Dennis Webb <dennis@bluesentryit.com>
 Derek Jobst <derekjobst@gmail.com>
+DeviousLab <deviouslab@gmail.com>
 Dhi Aurrahman <diorahman@rockybars.com>
 Diego Lapiduz <diego.lapiduz@cfpb.gov>
 Dmitri Shuralyov <shurcooL@gmail.com>
@@ -117,6 +135,8 @@ Eivind <eivindkn@gmail.com>
 Eli Uriegas <seemethere101@gmail.com>
 Elliott Beach <elliott2.71828@gmail.com>
 Emerson Wood <emersonwood94@gmail.com>
+Emil V <emil.vaagland@schibsted.com>
+Eng Zer Jun <engzerjun@gmail.com>
 eperm <staffordworrell@gmail.com>
 Erick Fejta <erick@fejta.com>
 Erik Nobel <hendrik.nobel@transferwise.com>
@@ -124,13 +144,16 @@ erwinvaneyk <erwinvaneyk@gmail.com>
 Evan Elias <evanjelias@gmail.com>
 Fabian Holler <fabian.holler@simplesurance.de>
 Fabrice <fabrice.vaillant@student.ecp.fr>
+Fatema-Moaiyadi <fatema.i.moaiyadi@gmail.com>
 Felix Geisendörfer <felix@debuggable.com>
 Filippo Valsorda <hi@filippo.io>
 Florian Forster <ff@octo.it>
+Florian Wagner <h2floh@github.com>
 Francesc Gil <xescugil@gmail.com>
 Francis <hello@francismakes.com>
 Francisco Guimarães <francisco.cpg@gmail.com>
 Fredrik Jönsson <fredrik.jonsson@izettle.com>
+Gabriel <samfiragabriel@gmail.com>
 Garrett Squire <garrettsquire@gmail.com>
 George Kontridze <george.kontridze@gmail.com>
 Georgy Buranov <gburanov@gmail.com>
@@ -144,11 +167,15 @@ Guz Alexander <kalimatas@gmail.com>
 Guðmundur Bjarni Ólafsson <gudmundur@github.com>
 Hanno Hecker <hanno.hecker@zalando.de>
 Hari haran <hariharan.uno@gmail.com>
+Harikesh00 <prajapatiharikesh16@gmail.com>
 haya14busa <haya14busa@gmail.com>
 haya14busa <hayabusa1419@gmail.com>
+Hiroki Ito <hiroki.ito.dev@gmail.com>
+Hubot Jr <rreichel3@github.com>
 Huy Tr <kingbazoka@gmail.com>
 huydx <doxuanhuy@gmail.com>
 i2bskn <i2bskn@gmail.com>
+Iain Steers <iainsteers@gmail.com>
 Ikko Ashimine <eltociear@gmail.com>
 Ioannis Georgoulas <igeorgoulas21@gmail.com>
 Isao Jonas <isao.jonas@gmail.com>
@@ -158,8 +185,10 @@ Jacob Valdemar <jan@lunar.app>
 Jake Krammer <jake.krammer1@gmail.com>
 Jake White <jake@jwhite.network>
 Jameel Haffejee <RC1140@republiccommandos.co.za>
+James Bowes <jbowes@repl.ca>
 James Cockbain <james.cockbain@ibm.com>
 James Loh <github@jloh.co>
+Jamie West <jamieianwest@hotmail.com>
 Jan Kosecki <jan.kosecki91@gmail.com>
 Jan Švábík <jansvabik@jansvabik.cz>
 Javier Campanini <jcampanini@palantir.com>
@@ -169,15 +198,18 @@ Jeremy Morris <jeremylevanmorris@gmail.com>
 Jesse Haka <haka.jesse@gmail.com>
 Jesse Newland <jesse@jnewland.com>
 Jihoon Chung <j.c@navercorp.com>
+Jille Timmermans <jille@quis.cx>
 Jimmi Dyson <jimmidyson@gmail.com>
 Joan Saum <joan.saum@epitech.eu>
 Joe Tsai <joetsai@digital-static.net>
 John Barton <jrbarton@gmail.com>
 John Engelman <john.r.engelman@gmail.com>
+John Jones <john@exthilion.org>
 John Liu <john.liu@mongodb.com>
 Jordan Brockopp <jdbro94@gmail.com>
 Jordan Sussman <jordansail22@gmail.com>
 Joshua Bezaleel Abednego <joshua.bezaleel@gmail.com>
+João Cerqueira <joao@cerqueira.io>
 JP Phillips <jonphill9@gmail.com>
 jpbelanger-mtl <jp.belanger@gmail.com>
 Juan <juan.rios.28@gmail.com>
@@ -186,25 +218,34 @@ Julien Garcia Gonzalez <garciagonzalez.julien@gmail.com>
 Julien Rostand <jrostand@users.noreply.github.com>
 Junya Kono <junya03dance@gmail.com>
 Justin Abrahms <justin@abrah.ms>
+Justin Toh <tohjustin@hotmail.com>
 Jusung Lee <e.jusunglee@gmail.com>
 jzhoucliqr <jzhou@cliqr.com>
+k1rnt <eru08tera15mora@gmail.com>
 kadern0 <kaderno@gmail.com>
 Katrina Owen <kytrinyx@github.com>
 Kautilya Tripathi <tripathi.kautilya@gmail.com>
 Keita Urashima <ursm@ursm.jp>
 Kevin Burke <kev@inburke.com>
+Kevin Wang <kwangsan@gmail.com>
+Kevin Zhao <kzhao@lyft.com>
 Kirill <g4s8.public@gmail.com>
 Konrad Malawski <konrad.malawski@project13.pl>
 Kookheon Kwon <kucuny@gmail.com>
+Krishna Indani <indanikrishna@gmail.com>
 Krzysztof Kowalczyk <kkowalczyk@gmail.com>
 Kshitij Saraogi <KshitijSaraogi@gmail.com>
 Kumar Saurabh <itsksaurabh@gmail.com>
+Kyle Kurz <kyle@doublekaudio.com>
 kyokomi <kyoko1220adword@gmail.com>
 Laurent Verdoïa <verdoialaurent@gmail.com>
+leopoldwang <leopold.wang@gmail.com>
 Liam Galvin <liam@liam-galvin.co.uk>
+Lluis Campos <lluis.campos@northern.tech>
 Lovro Mažgon <lovro.mazgon@gmail.com>
 Luca Campese <me@campesel.net>
 Lucas Alcantara <lucasalcantaraf@gmail.com>
+Luis Davim <luis.davim@sendoso.com>
 Luke Evers <me@lukevers.com>
 Luke Kysow <lkysow@gmail.com>
 Luke Roberts <email@luke-roberts.co.uk>
@@ -227,12 +268,16 @@ Matt Gaunt <matt@gauntface.co.uk>
 Matt Landis <landis.matt@gmail.com>
 Matt Moore <mattmoor@vmware.com>
 Maxime Bury <maxime.bury@gmail.com>
+Michael Meng <mmeng@lyft.com>
 Michael Spiegel <michael.m.spiegel@gmail.com>
 Michael Tiller <michael.tiller@gmail.com>
 Michał Glapa <michal.glapa@gmail.com>
 Michelangelo Morrillo <michelangelo@morrillo.it>
+Miguel Elias dos Santos <migueleliasweb@gmail.com>
+Mohammed AlDujaili <avainer11@gmail.com>
 Mukundan Senthil <mukundan314@gmail.com>
 Munia Balayil <munia.247@gmail.com>
+Mustafa Abban <mustafaabban@utexas.edu>
 Nadav Kaner <nadavkaner1@gmail.com>
 Nathan VanBenschoten <nvanbenschoten@gmail.com>
 Navaneeth Suresh <navaneeths1998@gmail.com>
@@ -242,6 +287,7 @@ Nick Platt <hello@nickplatt.co.uk>
 Nick Spragg <nick.spragg@bbc.co.uk>
 Nikhita Raghunath <nikitaraghunath@gmail.com>
 Nilesh Singh <nilesh.singh24@outlook.com>
+Noah Hanjun Lee <noah.lee@buzzvil.com>
 Noah Zoschke <noah+sso2@convox.com>
 ns-cweber <cweber@narrativescience.com>
 Ole Orhagen <ole.orhagen@northern.tech>
@@ -252,13 +298,16 @@ Pablo Pérez Schröder <pablo.perezschroder@wetransfer.com>
 Palash Nigam <npalash25@gmail.com>
 Panagiotis Moustafellos <pmoust@gmail.com>
 Parham Alvani <parham.alvani@gmail.com>
+pari-27 <sonamajumdar2012@gmail.com>
 Parker Moore <parkrmoore@gmail.com>
 parkhyukjun89 <park.hyukjun89@gmail.com>
+Pat Alwell <pat.alwell@gmail.com>
 Patrick DeVivo <patrick.devivo@gmail.com>
 Patrick Marabeas <patrick@marabeas.io>
 Pavel Shtanko <pavel.shtanko@gmail.com>
 Pete Wagner <thepwagner@github.com>
 Petr Shevtsov <petr.shevtsov@gmail.com>
+Pierce McEntagart <pierce@nightfall.ai>
 Pierre Carrier <pierre@meteor.com>
 Piotr Zurek <p.zurek@gmail.com>
 Piyush Chugh <piyushchugh1993@gmail.com>
@@ -272,18 +321,23 @@ Radek Simko <radek.simko@gmail.com>
 Radliński Ignacy <radlinsk@student.agh.edu.pl>
 Rajat Jindal <rajatjindal83@gmail.com>
 Rajendra arora <rajendraarora16@yahoo.com>
+Rajkumar <princegosavi12@gmail.com>
 Ranbir Singh <binkkatal.r@gmail.com>
 Ravi Shekhar Jethani <rsjethani@gmail.com>
 RaviTeja Pothana <ravi-teja@live.com>
 rc1140 <jameel@republiccommandos.co.za>
 Red Hat, Inc.
 Reetuparna Mukherjee <reetuparna.1988@gmail.com>
+reeves122 <reeves122@gmail.com>
 Reinier Timmer <reinier.timmer@ah.nl>
 Renjith R <renjithr201097@gmail.com>
 Ricco Førgaard <ricco@fiskeben.dk>
+Richard de Vries <richard.de.vries@topicus.nl>
 Rob Figueiredo <robfig@yext.com>
 Rohit Upadhyay <urohit011@gmail.com>
+Rojan Dinc <rojand94@gmail.com>
 Ronak Jain <ronakjain@outlook.in>
+Ronan Pelliard <ronan.pelliard@datadoghq.com>
 Ross Gustafson <srgustafson8@icloud.com>
 Ruben Vereecken <rubenvereecken@gmail.com>
 Russell Boley <raboley@gmail.com>
@@ -299,7 +353,9 @@ Sandeep Sukhani <sandeep.d.sukhani@gmail.com>
 Sander Knape <s.knape88@gmail.com>
 Sander van Harmelen <svanharmelen@schubergphilis.com>
 Sanket Payghan <sanket.payghan8@gmail.com>
+Sarah Funkhouser <sarah.k.funkhouser@gmail.com>
 Sarasa Kisaragi <lingsamuelgrace@gmail.com>
+Sasha Melentyev <sasha@melentyev.io>
 Sean Wang <sean@decrypted.org>
 Sebastian Mandrean <sebastian.mandrean@gmail.com>
 Sebastian Mæland Pedersen <sem.pedersen@stud.uis.no>
@@ -312,6 +368,7 @@ shakeelrao <shakeelrao79@gmail.com>
 Shawn Catanzarite <me@shawncatz.com>
 Shawn Smith <shawnpsmith@gmail.com>
 Shibasis Patel <patelshibasis@gmail.com>
+Sho Okada <shokada3@gmail.com>
 Shrikrishna Singh <krishnasingh.ss30@gmail.com>
 Simon Davis <sdavis@hashicorp.com>
 sona-tar <sona.zip@gmail.com>
@@ -322,17 +379,25 @@ Stefan Sedich <stefan.sedich@gmail.com>
 Steve Teuber <github@steveteuber.com>
 Stian Eikeland <stian@eikeland.se>
 Suhaib Mujahid <suhaibmujahid@gmail.com>
+sushmita wable <sw09007@gmail.com>
 Szymon Kodrebski <simonkey007@gmail.com>
 Søren Hansen <soren@dinero.dk>
+Takashi Yoneuchi <takashi.yoneuchi@shift-js.info>
 Takayuki Watanabe <takanabe.w@gmail.com>
 Taketoshi Fujiwara <fujiwara@leapmind.io>
 Taketoshi Fujiwara <taketoshi.fujiwara@gmail.com>
+Takuma Kajikawa <kj1ktk@gmail.com>
 Tasya Aditya Rukmana <tadityar@gmail.com>
 Theo Henson <theodorehenson@protonmail.com>
+Theofilos Petsios <theofilos.pe@gmail.com>
 Thomas Aidan Curran <thomas@ory.sh>
 Thomas Bruyelle <thomas.bruyelle@gmail.com>
+Tim Rogers <timrogers@github.com>
 Timothée Peignier <timothee.peignier@tryphon.org>
+Tingluo Huang <tingluohuang@github.com>
 tkhandel <tarunkhandelwal.iitr@gmail.com>
+Tobias Gesellchen <tobias@gesellix.de>
+Tom Payne <twpayne@gmail.com>
 Trey Tacon <ttacon@gmail.com>
 ttacon <ttacon@gmail.com>
 Vaibhav Singh <vaibhav.singh.14cse@bml.edu.in>
@@ -347,12 +412,16 @@ Will Maier <wcmaier@gmail.com>
 Willem D'Haeseleer <dhwillem@gmail.com>
 William Bailey <mail@williambailey.org.uk>
 William Cooke <pipeston@gmail.com>
+Xabi <xmartinez1702@gmail.com>
 xibz <impactbchang@gmail.com>
 Yann Malet <yann.malet@gmail.com>
 Yannick Utard <yannickutard@gmail.com>
 Yicheng Qin <qycqycqycqycqyc@gmail.com>
 Yosuke Akatsuka <yosuke.akatsuka@access-company.com>
 Yumikiyo Osanai <yumios.art@gmail.com>
+Yusef Mohamadi <yuseferi@gmail.com>
 Yusuke Kuoka <ykuoka@gmail.com>
 Zach Latta <zach@zachlatta.com>
 zhouhaibing089 <zhouhaibing089@gmail.com>
+六开箱 <lkxed@outlook.com>
+缘生 <i@ysicing.me>

--- a/vendor/github.com/google/go-github/v48/github/actions_runner_groups.go
+++ b/vendor/github.com/google/go-github/v48/github/actions_runner_groups.go
@@ -12,14 +12,17 @@ import (
 
 // RunnerGroup represents a self-hosted runner group configured in an organization.
 type RunnerGroup struct {
-	ID                       *int64  `json:"id,omitempty"`
-	Name                     *string `json:"name,omitempty"`
-	Visibility               *string `json:"visibility,omitempty"`
-	Default                  *bool   `json:"default,omitempty"`
-	SelectedRepositoriesURL  *string `json:"selected_repositories_url,omitempty"`
-	RunnersURL               *string `json:"runners_url,omitempty"`
-	Inherited                *bool   `json:"inherited,omitempty"`
-	AllowsPublicRepositories *bool   `json:"allows_public_repositories,omitempty"`
+	ID                           *int64   `json:"id,omitempty"`
+	Name                         *string  `json:"name,omitempty"`
+	Visibility                   *string  `json:"visibility,omitempty"`
+	Default                      *bool    `json:"default,omitempty"`
+	SelectedRepositoriesURL      *string  `json:"selected_repositories_url,omitempty"`
+	RunnersURL                   *string  `json:"runners_url,omitempty"`
+	Inherited                    *bool    `json:"inherited,omitempty"`
+	AllowsPublicRepositories     *bool    `json:"allows_public_repositories,omitempty"`
+	RestrictedToWorkflows        *bool    `json:"restricted_to_workflows,omitempty"`
+	SelectedWorkflows            []string `json:"selected_workflows,omitempty"`
+	WorkflowRestrictionsReadOnly *bool    `json:"workflow_restrictions_read_only,omitempty"`
 }
 
 // RunnerGroups represents a collection of self-hosted runner groups configured for an organization.
@@ -38,13 +41,19 @@ type CreateRunnerGroupRequest struct {
 	Runners []int64 `json:"runners,omitempty"`
 	// If set to True, public repos can use this runner group
 	AllowsPublicRepositories *bool `json:"allows_public_repositories,omitempty"`
+	// If true, the runner group will be restricted to running only the workflows specified in the SelectedWorkflows slice.
+	RestrictedToWorkflows *bool `json:"restricted_to_workflows,omitempty"`
+	// List of workflows the runner group should be allowed to run. This setting will be ignored unless RestrictedToWorkflows is set to true.
+	SelectedWorkflows []string `json:"selected_workflows,omitempty"`
 }
 
 // UpdateRunnerGroupRequest represents a request to update a Runner group for an organization.
 type UpdateRunnerGroupRequest struct {
-	Name                     *string `json:"name,omitempty"`
-	Visibility               *string `json:"visibility,omitempty"`
-	AllowsPublicRepositories *bool   `json:"allows_public_repositories,omitempty"`
+	Name                     *string  `json:"name,omitempty"`
+	Visibility               *string  `json:"visibility,omitempty"`
+	AllowsPublicRepositories *bool    `json:"allows_public_repositories,omitempty"`
+	RestrictedToWorkflows    *bool    `json:"restricted_to_workflows,omitempty"`
+	SelectedWorkflows        []string `json:"selected_workflows,omitempty"`
 }
 
 // SetRepoAccessRunnerGroupRequest represents a request to replace the list of repositories

--- a/vendor/github.com/google/go-github/v48/github/code-scanning.go
+++ b/vendor/github.com/google/go-github/v48/github/code-scanning.go
@@ -87,6 +87,7 @@ type Alert struct {
 	DismissedBy        *User                 `json:"dismissed_by,omitempty"`
 	DismissedAt        *Timestamp            `json:"dismissed_at,omitempty"`
 	DismissedReason    *string               `json:"dismissed_reason,omitempty"`
+	DismissedComment   *string               `json:"dismissed_comment,omitempty"`
 	InstancesURL       *string               `json:"instances_url,omitempty"`
 }
 
@@ -121,6 +122,10 @@ type AlertListOptions struct {
 	// Return code scanning alerts for a specific branch reference. The ref must be formatted as heads/<branch name>.
 	Ref string `url:"ref,omitempty"`
 
+	ListCursorOptions
+
+	// Add ListOptions so offset pagination with integer type "page" query parameter is accepted
+	// since ListCursorOptions accepts "page" as string only.
 	ListOptions
 }
 

--- a/vendor/github.com/google/go-github/v48/github/dependabot_alerts.go
+++ b/vendor/github.com/google/go-github/v48/github/dependabot_alerts.go
@@ -1,0 +1,134 @@
+// Copyright 2022 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// Dependency reprensents the vulnerable dependency.
+type Dependency struct {
+	Package      *VulnerabilityPackage `json:"package,omitempty"`
+	ManifestPath *string               `json:"manifest_path,omitempty"`
+	Scope        *string               `json:"scope,omitempty"`
+}
+
+// AdvisoryCVSs represents the advisory pertaining to the Common Vulnerability Scoring System.
+type AdvisoryCVSs struct {
+	Score        *float64 `json:"score,omitempty"`
+	VectorString *string  `json:"vector_string,omitempty"`
+}
+
+// AdvisoryCWEs reprensent the advisory pertaining to Common Weakness Enumeration.
+type AdvisoryCWEs struct {
+	CWEID *string `json:"cwe_id,omitempty"`
+	Name  *string `json:"name,omitempty"`
+}
+
+// DependabotSecurityAdvisory represents the GitHub Security Advisory.
+type DependabotSecurityAdvisory struct {
+	GHSAID          *string                  `json:"ghsa_id,omitempty"`
+	CVEID           *string                  `json:"cve_id,omitempty"`
+	Summary         *string                  `json:"summary,omitempty"`
+	Description     *string                  `json:"description,omitempty"`
+	Vulnerabilities []*AdvisoryVulnerability `json:"vulnerabilities,omitempty"`
+	Severity        *string                  `json:"severity,omitempty"`
+	CVSs            *AdvisoryCVSs            `json:"cvss,omitempty"`
+	CWEs            []*AdvisoryCWEs          `json:"cwes,omitempty"`
+	Identifiers     []*AdvisoryIdentifier    `json:"identifiers,omitempty"`
+	References      []*AdvisoryReference     `json:"references,omitempty"`
+	PublishedAt     *Timestamp               `json:"published_at,omitempty"`
+	UpdatedAt       *Timestamp               `json:"updated_at,omitempty"`
+	WithdrawnAt     *Timestamp               `json:"withdrawn_at,omitempty"`
+}
+
+// DependabotAlert represents a Dependabot alert.
+type DependabotAlert struct {
+	Number                *int                        `json:"number,omitempty"`
+	State                 *string                     `json:"state,omitempty"`
+	Dependency            *Dependency                 `json:"dependency,omitempty"`
+	SecurityAdvisory      *DependabotSecurityAdvisory `json:"security_advisory,omitempty"`
+	SecurityVulnerability *AdvisoryVulnerability      `json:"security_vulnerability,omitempty"`
+	URL                   *string                     `json:"url,omitempty"`
+	HTMLURL               *string                     `json:"html_url,omitempty"`
+	CreatedAt             *Timestamp                  `json:"created_at,omitempty"`
+	UpdatedAt             *Timestamp                  `json:"updated_at,omitempty"`
+	DismissedAt           *Timestamp                  `json:"dismissed_at,omitempty"`
+	DismissedBy           *User                       `json:"dismissed_by,omitempty"`
+	DismissedReason       *string                     `json:"dismissed_reason,omitempty"`
+	DismissedComment      *string                     `json:"dismissed_comment,omitempty"`
+	FixedAt               *Timestamp                  `json:"fixed_at,omitempty"`
+}
+
+// ListAlertsOptions specifies the optional parameters to the DependabotService.ListRepoAlerts
+// and DependabotService.ListOrgAlerts methods.
+type ListAlertsOptions struct {
+	State     *string `url:"state,omitempty"`
+	Severity  *string `url:"severity,omitempty"`
+	Ecosystem *string `url:"ecosystem,omitempty"`
+	Package   *string `url:"package,omitempty"`
+	Scope     *string `url:"scope,omitempty"`
+	Sort      *string `url:"sort,omitempty"`
+	Direction *string `url:"direction,omitempty"`
+
+	ListCursorOptions
+}
+
+func (s *DependabotService) listAlerts(ctx context.Context, url string, opts *ListAlertsOptions) ([]*DependabotAlert, *Response, error) {
+	u, err := addOptions(url, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var alerts []*DependabotAlert
+	resp, err := s.client.Do(ctx, req, &alerts)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return alerts, resp, nil
+}
+
+// ListRepoAlerts lists all Dependabot alerts of a repository.
+//
+// GitHub API docs: https://docs.github.com/en/rest/dependabot/alerts#list-dependabot-alerts-for-a-repository
+func (s *DependabotService) ListRepoAlerts(ctx context.Context, owner, repo string, opts *ListAlertsOptions) ([]*DependabotAlert, *Response, error) {
+	url := fmt.Sprintf("repos/%v/%v/dependabot/alerts", owner, repo)
+	return s.listAlerts(ctx, url, opts)
+}
+
+// ListOrgAlerts lists all Dependabot alerts of an organization.
+//
+// GitHub API docs: https://docs.github.com/en/rest/dependabot/alerts#list-dependabot-alerts-for-an-organization
+func (s *DependabotService) ListOrgAlerts(ctx context.Context, org string, opts *ListAlertsOptions) ([]*DependabotAlert, *Response, error) {
+	url := fmt.Sprintf("orgs/%v/dependabot/alerts", org)
+	return s.listAlerts(ctx, url, opts)
+}
+
+// GetRepoAlert gets a single repository Dependabot alert.
+//
+// GitHub API docs: https://docs.github.com/en/rest/dependabot/alerts#get-a-dependabot-alert
+func (s *DependabotService) GetRepoAlert(ctx context.Context, owner, repo string, number int) (*DependabotAlert, *Response, error) {
+	url := fmt.Sprintf("repos/%v/%v/dependabot/alerts/%v", owner, repo, number)
+	req, err := s.client.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	alert := new(DependabotAlert)
+	resp, err := s.client.Do(ctx, req, alert)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return alert, resp, nil
+}

--- a/vendor/github.com/google/go-github/v48/github/event.go
+++ b/vendor/github.com/google/go-github/v48/github/event.go
@@ -76,6 +76,8 @@ func (e *Event) ParsePayload() (payload interface{}, err error) {
 		payload = &MemberEvent{}
 	case "MembershipEvent":
 		payload = &MembershipEvent{}
+	case "MergeGroupEvent":
+		payload = &MergeGroupEvent{}
 	case "MetaEvent":
 		payload = &MetaEvent{}
 	case "MilestoneEvent":

--- a/vendor/github.com/google/go-github/v48/github/event_types.go
+++ b/vendor/github.com/google/go-github/v48/github/event_types.go
@@ -559,6 +559,37 @@ type MembershipEvent struct {
 	Installation *Installation `json:"installation,omitempty"`
 }
 
+// MergeGroup represents the merge group in a merge queue.
+type MergeGroup struct {
+	// The SHA of the merge group.
+	HeadSHA *string `json:"head_sha,omitempty"`
+	// The full ref of the merge group.
+	HeadRef *string `json:"head_ref,omitempty"`
+	// The SHA of the merge group's parent commit.
+	BaseSHA *string `json:"base_sha,omitempty"`
+	// The full ref of the branch the merge group will be merged into.
+	BaseRef *string `json:"base_ref,omitempty"`
+	// An expanded representation of the head_sha commit.
+	HeadCommit *Commit `json:"head_commit,omitempty"`
+}
+
+// MergeGroupEvent represents activity related to merge groups in a merge queue. The type of activity is specified
+// in the action property of the payload object.
+//
+// GitHub API docs: https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#merge_group
+type MergeGroupEvent struct {
+	// The action that was performed. Currently, can only be checks_requested.
+	Action *string `json:"action,omitempty"`
+	// The merge group.
+	MergeGroup *MergeGroup `json:"merge_group,omitempty"`
+
+	// The following fields are only populated by Webhook events.
+	Repo         *Repository   `json:"repository,omitempty"`
+	Org          *Organization `json:"organization,omitempty"`
+	Installation *Installation `json:"installation,omitempty"`
+	Sender       *User         `json:"sender,omitempty"`
+}
+
 // MetaEvent is triggered when the webhook that this event is configured on is deleted.
 // This event will only listen for changes to the particular hook the event is installed on.
 // Therefore, it must be selected for each hook that you'd like to receive meta events for.

--- a/vendor/github.com/google/go-github/v48/github/github-accessors.go
+++ b/vendor/github.com/google/go-github/v48/github/github-accessors.go
@@ -206,6 +206,38 @@ func (a *AdvancedSecurityCommittersBreakdown) GetUserLogin() string {
 	return *a.UserLogin
 }
 
+// GetScore returns the Score field.
+func (a *AdvisoryCVSs) GetScore() *float64 {
+	if a == nil {
+		return nil
+	}
+	return a.Score
+}
+
+// GetVectorString returns the VectorString field if it's non-nil, zero value otherwise.
+func (a *AdvisoryCVSs) GetVectorString() string {
+	if a == nil || a.VectorString == nil {
+		return ""
+	}
+	return *a.VectorString
+}
+
+// GetCWEID returns the CWEID field if it's non-nil, zero value otherwise.
+func (a *AdvisoryCWEs) GetCWEID() string {
+	if a == nil || a.CWEID == nil {
+		return ""
+	}
+	return *a.CWEID
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (a *AdvisoryCWEs) GetName() string {
+	if a == nil || a.Name == nil {
+		return ""
+	}
+	return *a.Name
+}
+
 // GetType returns the Type field if it's non-nil, zero value otherwise.
 func (a *AdvisoryIdentifier) GetType() string {
 	if a == nil || a.Type == nil {
@@ -300,6 +332,14 @@ func (a *Alert) GetDismissedBy() *User {
 		return nil
 	}
 	return a.DismissedBy
+}
+
+// GetDismissedComment returns the DismissedComment field if it's non-nil, zero value otherwise.
+func (a *Alert) GetDismissedComment() string {
+	if a == nil || a.DismissedComment == nil {
+		return ""
+	}
+	return *a.DismissedComment
 }
 
 // GetDismissedReason returns the DismissedReason field if it's non-nil, zero value otherwise.
@@ -3614,6 +3654,14 @@ func (c *CreateRunnerGroupRequest) GetName() string {
 	return *c.Name
 }
 
+// GetRestrictedToWorkflows returns the RestrictedToWorkflows field if it's non-nil, zero value otherwise.
+func (c *CreateRunnerGroupRequest) GetRestrictedToWorkflows() bool {
+	if c == nil || c.RestrictedToWorkflows == nil {
+		return false
+	}
+	return *c.RestrictedToWorkflows
+}
+
 // GetVisibility returns the Visibility field if it's non-nil, zero value otherwise.
 func (c *CreateRunnerGroupRequest) GetVisibility() string {
 	if c == nil || c.Visibility == nil {
@@ -3724,6 +3772,214 @@ func (d *DeleteEvent) GetSender() *User {
 		return nil
 	}
 	return d.Sender
+}
+
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (d *DependabotAlert) GetCreatedAt() Timestamp {
+	if d == nil || d.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *d.CreatedAt
+}
+
+// GetDependency returns the Dependency field.
+func (d *DependabotAlert) GetDependency() *Dependency {
+	if d == nil {
+		return nil
+	}
+	return d.Dependency
+}
+
+// GetDismissedAt returns the DismissedAt field if it's non-nil, zero value otherwise.
+func (d *DependabotAlert) GetDismissedAt() Timestamp {
+	if d == nil || d.DismissedAt == nil {
+		return Timestamp{}
+	}
+	return *d.DismissedAt
+}
+
+// GetDismissedBy returns the DismissedBy field.
+func (d *DependabotAlert) GetDismissedBy() *User {
+	if d == nil {
+		return nil
+	}
+	return d.DismissedBy
+}
+
+// GetDismissedComment returns the DismissedComment field if it's non-nil, zero value otherwise.
+func (d *DependabotAlert) GetDismissedComment() string {
+	if d == nil || d.DismissedComment == nil {
+		return ""
+	}
+	return *d.DismissedComment
+}
+
+// GetDismissedReason returns the DismissedReason field if it's non-nil, zero value otherwise.
+func (d *DependabotAlert) GetDismissedReason() string {
+	if d == nil || d.DismissedReason == nil {
+		return ""
+	}
+	return *d.DismissedReason
+}
+
+// GetFixedAt returns the FixedAt field if it's non-nil, zero value otherwise.
+func (d *DependabotAlert) GetFixedAt() Timestamp {
+	if d == nil || d.FixedAt == nil {
+		return Timestamp{}
+	}
+	return *d.FixedAt
+}
+
+// GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
+func (d *DependabotAlert) GetHTMLURL() string {
+	if d == nil || d.HTMLURL == nil {
+		return ""
+	}
+	return *d.HTMLURL
+}
+
+// GetNumber returns the Number field if it's non-nil, zero value otherwise.
+func (d *DependabotAlert) GetNumber() int {
+	if d == nil || d.Number == nil {
+		return 0
+	}
+	return *d.Number
+}
+
+// GetSecurityAdvisory returns the SecurityAdvisory field.
+func (d *DependabotAlert) GetSecurityAdvisory() *DependabotSecurityAdvisory {
+	if d == nil {
+		return nil
+	}
+	return d.SecurityAdvisory
+}
+
+// GetSecurityVulnerability returns the SecurityVulnerability field.
+func (d *DependabotAlert) GetSecurityVulnerability() *AdvisoryVulnerability {
+	if d == nil {
+		return nil
+	}
+	return d.SecurityVulnerability
+}
+
+// GetState returns the State field if it's non-nil, zero value otherwise.
+func (d *DependabotAlert) GetState() string {
+	if d == nil || d.State == nil {
+		return ""
+	}
+	return *d.State
+}
+
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (d *DependabotAlert) GetUpdatedAt() Timestamp {
+	if d == nil || d.UpdatedAt == nil {
+		return Timestamp{}
+	}
+	return *d.UpdatedAt
+}
+
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (d *DependabotAlert) GetURL() string {
+	if d == nil || d.URL == nil {
+		return ""
+	}
+	return *d.URL
+}
+
+// GetCVEID returns the CVEID field if it's non-nil, zero value otherwise.
+func (d *DependabotSecurityAdvisory) GetCVEID() string {
+	if d == nil || d.CVEID == nil {
+		return ""
+	}
+	return *d.CVEID
+}
+
+// GetCVSs returns the CVSs field.
+func (d *DependabotSecurityAdvisory) GetCVSs() *AdvisoryCVSs {
+	if d == nil {
+		return nil
+	}
+	return d.CVSs
+}
+
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (d *DependabotSecurityAdvisory) GetDescription() string {
+	if d == nil || d.Description == nil {
+		return ""
+	}
+	return *d.Description
+}
+
+// GetGHSAID returns the GHSAID field if it's non-nil, zero value otherwise.
+func (d *DependabotSecurityAdvisory) GetGHSAID() string {
+	if d == nil || d.GHSAID == nil {
+		return ""
+	}
+	return *d.GHSAID
+}
+
+// GetPublishedAt returns the PublishedAt field if it's non-nil, zero value otherwise.
+func (d *DependabotSecurityAdvisory) GetPublishedAt() Timestamp {
+	if d == nil || d.PublishedAt == nil {
+		return Timestamp{}
+	}
+	return *d.PublishedAt
+}
+
+// GetSeverity returns the Severity field if it's non-nil, zero value otherwise.
+func (d *DependabotSecurityAdvisory) GetSeverity() string {
+	if d == nil || d.Severity == nil {
+		return ""
+	}
+	return *d.Severity
+}
+
+// GetSummary returns the Summary field if it's non-nil, zero value otherwise.
+func (d *DependabotSecurityAdvisory) GetSummary() string {
+	if d == nil || d.Summary == nil {
+		return ""
+	}
+	return *d.Summary
+}
+
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (d *DependabotSecurityAdvisory) GetUpdatedAt() Timestamp {
+	if d == nil || d.UpdatedAt == nil {
+		return Timestamp{}
+	}
+	return *d.UpdatedAt
+}
+
+// GetWithdrawnAt returns the WithdrawnAt field if it's non-nil, zero value otherwise.
+func (d *DependabotSecurityAdvisory) GetWithdrawnAt() Timestamp {
+	if d == nil || d.WithdrawnAt == nil {
+		return Timestamp{}
+	}
+	return *d.WithdrawnAt
+}
+
+// GetManifestPath returns the ManifestPath field if it's non-nil, zero value otherwise.
+func (d *Dependency) GetManifestPath() string {
+	if d == nil || d.ManifestPath == nil {
+		return ""
+	}
+	return *d.ManifestPath
+}
+
+// GetPackage returns the Package field.
+func (d *Dependency) GetPackage() *VulnerabilityPackage {
+	if d == nil {
+		return nil
+	}
+	return d.Package
+}
+
+// GetScope returns the Scope field if it's non-nil, zero value otherwise.
+func (d *Dependency) GetScope() string {
+	if d == nil || d.Scope == nil {
+		return ""
+	}
+	return *d.Scope
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
@@ -4556,6 +4812,14 @@ func (d *DiscussionEvent) GetSender() *User {
 		return nil
 	}
 	return d.Sender
+}
+
+// GetApps returns the Apps field if it's non-nil, zero value otherwise.
+func (d *DismissalRestrictionsRequest) GetApps() []string {
+	if d == nil || d.Apps == nil {
+		return nil
+	}
+	return *d.Apps
 }
 
 // GetTeams returns the Teams field if it's non-nil, zero value otherwise.
@@ -8262,6 +8526,62 @@ func (l *LinearHistoryRequirementEnforcementLevelChanges) GetFrom() string {
 	return *l.From
 }
 
+// GetDirection returns the Direction field if it's non-nil, zero value otherwise.
+func (l *ListAlertsOptions) GetDirection() string {
+	if l == nil || l.Direction == nil {
+		return ""
+	}
+	return *l.Direction
+}
+
+// GetEcosystem returns the Ecosystem field if it's non-nil, zero value otherwise.
+func (l *ListAlertsOptions) GetEcosystem() string {
+	if l == nil || l.Ecosystem == nil {
+		return ""
+	}
+	return *l.Ecosystem
+}
+
+// GetPackage returns the Package field if it's non-nil, zero value otherwise.
+func (l *ListAlertsOptions) GetPackage() string {
+	if l == nil || l.Package == nil {
+		return ""
+	}
+	return *l.Package
+}
+
+// GetScope returns the Scope field if it's non-nil, zero value otherwise.
+func (l *ListAlertsOptions) GetScope() string {
+	if l == nil || l.Scope == nil {
+		return ""
+	}
+	return *l.Scope
+}
+
+// GetSeverity returns the Severity field if it's non-nil, zero value otherwise.
+func (l *ListAlertsOptions) GetSeverity() string {
+	if l == nil || l.Severity == nil {
+		return ""
+	}
+	return *l.Severity
+}
+
+// GetSort returns the Sort field if it's non-nil, zero value otherwise.
+func (l *ListAlertsOptions) GetSort() string {
+	if l == nil || l.Sort == nil {
+		return ""
+	}
+	return *l.Sort
+}
+
+// GetState returns the State field if it's non-nil, zero value otherwise.
+func (l *ListAlertsOptions) GetState() string {
+	if l == nil || l.State == nil {
+		return ""
+	}
+	return *l.State
+}
+
 // GetAppID returns the AppID field if it's non-nil, zero value otherwise.
 func (l *ListCheckRunsOptions) GetAppID() int64 {
 	if l == nil || l.AppID == nil {
@@ -8860,6 +9180,94 @@ func (m *MembershipEvent) GetTeam() *Team {
 		return nil
 	}
 	return m.Team
+}
+
+// GetBaseRef returns the BaseRef field if it's non-nil, zero value otherwise.
+func (m *MergeGroup) GetBaseRef() string {
+	if m == nil || m.BaseRef == nil {
+		return ""
+	}
+	return *m.BaseRef
+}
+
+// GetBaseSHA returns the BaseSHA field if it's non-nil, zero value otherwise.
+func (m *MergeGroup) GetBaseSHA() string {
+	if m == nil || m.BaseSHA == nil {
+		return ""
+	}
+	return *m.BaseSHA
+}
+
+// GetHeadCommit returns the HeadCommit field.
+func (m *MergeGroup) GetHeadCommit() *Commit {
+	if m == nil {
+		return nil
+	}
+	return m.HeadCommit
+}
+
+// GetHeadRef returns the HeadRef field if it's non-nil, zero value otherwise.
+func (m *MergeGroup) GetHeadRef() string {
+	if m == nil || m.HeadRef == nil {
+		return ""
+	}
+	return *m.HeadRef
+}
+
+// GetHeadSHA returns the HeadSHA field if it's non-nil, zero value otherwise.
+func (m *MergeGroup) GetHeadSHA() string {
+	if m == nil || m.HeadSHA == nil {
+		return ""
+	}
+	return *m.HeadSHA
+}
+
+// GetAction returns the Action field if it's non-nil, zero value otherwise.
+func (m *MergeGroupEvent) GetAction() string {
+	if m == nil || m.Action == nil {
+		return ""
+	}
+	return *m.Action
+}
+
+// GetInstallation returns the Installation field.
+func (m *MergeGroupEvent) GetInstallation() *Installation {
+	if m == nil {
+		return nil
+	}
+	return m.Installation
+}
+
+// GetMergeGroup returns the MergeGroup field.
+func (m *MergeGroupEvent) GetMergeGroup() *MergeGroup {
+	if m == nil {
+		return nil
+	}
+	return m.MergeGroup
+}
+
+// GetOrg returns the Org field.
+func (m *MergeGroupEvent) GetOrg() *Organization {
+	if m == nil {
+		return nil
+	}
+	return m.Org
+}
+
+// GetRepo returns the Repo field.
+func (m *MergeGroupEvent) GetRepo() *Repository {
+	if m == nil {
+		return nil
+	}
+	return m.Repo
+}
+
+// GetSender returns the Sender field.
+func (m *MergeGroupEvent) GetSender() *User {
+	if m == nil {
+		return nil
+	}
+	return m.Sender
 }
 
 // GetText returns the Text field if it's non-nil, zero value otherwise.
@@ -16582,6 +16990,14 @@ func (r *RunnerGroup) GetName() string {
 	return *r.Name
 }
 
+// GetRestrictedToWorkflows returns the RestrictedToWorkflows field if it's non-nil, zero value otherwise.
+func (r *RunnerGroup) GetRestrictedToWorkflows() bool {
+	if r == nil || r.RestrictedToWorkflows == nil {
+		return false
+	}
+	return *r.RestrictedToWorkflows
+}
+
 // GetRunnersURL returns the RunnersURL field if it's non-nil, zero value otherwise.
 func (r *RunnerGroup) GetRunnersURL() string {
 	if r == nil || r.RunnersURL == nil {
@@ -16604,6 +17020,14 @@ func (r *RunnerGroup) GetVisibility() string {
 		return ""
 	}
 	return *r.Visibility
+}
+
+// GetWorkflowRestrictionsReadOnly returns the WorkflowRestrictionsReadOnly field if it's non-nil, zero value otherwise.
+func (r *RunnerGroup) GetWorkflowRestrictionsReadOnly() bool {
+	if r == nil || r.WorkflowRestrictionsReadOnly == nil {
+		return false
+	}
+	return *r.WorkflowRestrictionsReadOnly
 }
 
 // GetID returns the ID field if it's non-nil, zero value otherwise.
@@ -19068,6 +19492,14 @@ func (u *UpdateRunnerGroupRequest) GetName() string {
 		return ""
 	}
 	return *u.Name
+}
+
+// GetRestrictedToWorkflows returns the RestrictedToWorkflows field if it's non-nil, zero value otherwise.
+func (u *UpdateRunnerGroupRequest) GetRestrictedToWorkflows() bool {
+	if u == nil || u.RestrictedToWorkflows == nil {
+		return false
+	}
+	return *u.RestrictedToWorkflows
 }
 
 // GetVisibility returns the Visibility field if it's non-nil, zero value otherwise.

--- a/vendor/github.com/google/go-github/v48/github/github.go
+++ b/vendor/github.com/google/go-github/v48/github/github.go
@@ -15,7 +15,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -236,6 +235,14 @@ type ListCursorOptions struct {
 
 	// For paginated result sets, the number of results to include per page.
 	PerPage int `url:"per_page,omitempty"`
+
+	// For paginated result sets, the number of results per page (max 100), starting from the first matching result.
+	// This parameter must not be used in combination with last.
+	First int `url:"first,omitempty"`
+
+	// For paginated result sets, the number of results per page (max 100), starting from the last matching result.
+	// This parameter must not be used in combination with first.
+	Last int `url:"last,omitempty"`
 
 	// A cursor, as given in the Link header. If specified, the query only searches for events after this cursor.
 	After string `url:"after,omitempty"`
@@ -710,7 +717,7 @@ func (c *Client) BareDo(ctx context.Context, req *http.Request) (*Response, erro
 		// Issue #1022
 		aerr, ok := err.(*AcceptedError)
 		if ok {
-			b, readErr := ioutil.ReadAll(resp.Body)
+			b, readErr := io.ReadAll(resp.Body)
 			if readErr != nil {
 				return response, readErr
 			}
@@ -770,7 +777,7 @@ func (c *Client) checkRateLimitBeforeDo(req *http.Request, rateLimitCategory rat
 			StatusCode: http.StatusForbidden,
 			Request:    req,
 			Header:     make(http.Header),
-			Body:       ioutil.NopCloser(strings.NewReader("")),
+			Body:       io.NopCloser(strings.NewReader("")),
 		}
 		return &RateLimitError{
 			Rate:     rate,
@@ -1032,14 +1039,14 @@ func CheckResponse(r *http.Response) error {
 	}
 
 	errorResponse := &ErrorResponse{Response: r}
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err == nil && data != nil {
 		json.Unmarshal(data, errorResponse)
 	}
 	// Re-populate error response body because GitHub error responses are often
 	// undocumented and inconsistent.
 	// Issue #1136, #540.
-	r.Body = ioutil.NopCloser(bytes.NewBuffer(data))
+	r.Body = io.NopCloser(bytes.NewBuffer(data))
 	switch {
 	case r.StatusCode == http.StatusUnauthorized && strings.HasPrefix(r.Header.Get(headerOTP), "required"):
 		return (*TwoFactorAuthError)(errorResponse)

--- a/vendor/github.com/google/go-github/v48/github/messages.go
+++ b/vendor/github.com/google/go-github/v48/github/messages.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net/http"
 	"net/url"
@@ -68,6 +67,7 @@ var (
 		"marketplace_purchase":           "MarketplacePurchaseEvent",
 		"member":                         "MemberEvent",
 		"membership":                     "MembershipEvent",
+		"merge_group":                    "MergeGroupEvent",
 		"meta":                           "MetaEvent",
 		"milestone":                      "MilestoneEvent",
 		"organization":                   "OrganizationEvent",
@@ -170,7 +170,7 @@ func ValidatePayloadFromBody(contentType string, readable io.Reader, signature s
 	switch contentType {
 	case "application/json":
 		var err error
-		if body, err = ioutil.ReadAll(readable); err != nil {
+		if body, err = io.ReadAll(readable); err != nil {
 			return nil, err
 		}
 
@@ -184,7 +184,7 @@ func ValidatePayloadFromBody(contentType string, readable io.Reader, signature s
 		const payloadFormParam = "payload"
 
 		var err error
-		if body, err = ioutil.ReadAll(readable); err != nil {
+		if body, err = io.ReadAll(readable); err != nil {
 			return nil, err
 		}
 

--- a/vendor/github.com/google/go-github/v48/github/orgs_security_managers.go
+++ b/vendor/github.com/google/go-github/v48/github/orgs_security_managers.go
@@ -1,0 +1,57 @@
+// Copyright 2022 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// ListSecurityManagerTeams lists all security manager teams for an organization.
+//
+// GitHub API docs: https://docs.github.com/en/rest/orgs/security-managers#list-security-manager-teams
+func (s *OrganizationsService) ListSecurityManagerTeams(ctx context.Context, org string) ([]*Team, *Response, error) {
+	u := fmt.Sprintf("orgs/%v/security-managers", org)
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var teams []*Team
+	resp, err := s.client.Do(ctx, req, &teams)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return teams, resp, nil
+}
+
+// AddSecurityManagerTeam adds a team to the list of security managers for an organization.
+//
+// GitHub API docs: https://docs.github.com/en/rest/orgs/security-managers#add-a-security-manager-team
+func (s *OrganizationsService) AddSecurityManagerTeam(ctx context.Context, org, team string) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/security-managers/teams/%v", org, team)
+	req, err := s.client.NewRequest("PUT", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// RemoveSecurityManagerTeam removes a team from the list of security managers for an organization.
+//
+// GitHub API docs: https://docs.github.com/en/rest/orgs/security-managers#remove-a-security-manager-team
+func (s *OrganizationsService) RemoveSecurityManagerTeam(ctx context.Context, org, team string) (*Response, error) {
+	u := fmt.Sprintf("orgs/%v/security-managers/teams/%v", org, team)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}

--- a/vendor/github.com/google/go-github/v48/github/repos.go
+++ b/vendor/github.com/google/go-github/v48/github/repos.go
@@ -1019,7 +1019,7 @@ type RequiredStatusCheck struct {
 type PullRequestReviewsEnforcement struct {
 	// Allow specific users, teams, or apps to bypass pull request requirements.
 	BypassPullRequestAllowances *BypassPullRequestAllowances `json:"bypass_pull_request_allowances,omitempty"`
-	// Specifies which users and teams can dismiss pull request reviews.
+	// Specifies which users, teams and apps can dismiss pull request reviews.
 	DismissalRestrictions *DismissalRestrictions `json:"dismissal_restrictions,omitempty"`
 	// Specifies if approved reviews are dismissed automatically, when a new commit is pushed.
 	DismissStaleReviews bool `json:"dismiss_stale_reviews"`
@@ -1036,8 +1036,8 @@ type PullRequestReviewsEnforcement struct {
 type PullRequestReviewsEnforcementRequest struct {
 	// Allow specific users, teams, or apps to bypass pull request requirements.
 	BypassPullRequestAllowancesRequest *BypassPullRequestAllowancesRequest `json:"bypass_pull_request_allowances,omitempty"`
-	// Specifies which users and teams should be allowed to dismiss pull request reviews.
-	// User and team dismissal restrictions are only available for
+	// Specifies which users, teams and apps should be allowed to dismiss pull request reviews.
+	// User, team and app dismissal restrictions are only available for
 	// organization-owned repositories. Must be nil for personal repositories.
 	DismissalRestrictionsRequest *DismissalRestrictionsRequest `json:"dismissal_restrictions,omitempty"`
 	// Specifies if approved reviews can be dismissed automatically, when a new commit is pushed. (Required)
@@ -1055,7 +1055,7 @@ type PullRequestReviewsEnforcementRequest struct {
 type PullRequestReviewsEnforcementUpdate struct {
 	// Allow specific users, teams, or apps to bypass pull request requirements.
 	BypassPullRequestAllowancesRequest *BypassPullRequestAllowancesRequest `json:"bypass_pull_request_allowances,omitempty"`
-	// Specifies which users and teams can dismiss pull request reviews. Can be omitted.
+	// Specifies which users, teams and apps can dismiss pull request reviews. Can be omitted.
 	DismissalRestrictionsRequest *DismissalRestrictionsRequest `json:"dismissal_restrictions,omitempty"`
 	// Specifies if approved reviews can be dismissed automatically, when a new commit is pushed. Can be omitted.
 	DismissStaleReviews *bool `json:"dismiss_stale_reviews,omitempty"`
@@ -1113,7 +1113,7 @@ type BranchRestrictionsRequest struct {
 	// The list of team slugs with push access. (Required; use []string{} instead of nil for empty list.)
 	Teams []string `json:"teams"`
 	// The list of app slugs with push access.
-	Apps []string `json:"apps,omitempty"`
+	Apps []string `json:"apps"`
 }
 
 // BypassPullRequestAllowances represents the people, teams, or apps who are allowed to bypass required pull requests.
@@ -1145,10 +1145,12 @@ type DismissalRestrictions struct {
 	Users []*User `json:"users"`
 	// The list of teams which can dismiss pull request reviews.
 	Teams []*Team `json:"teams"`
+	// The list of apps which can dismiss pull request reviews.
+	Apps []*App `json:"apps"`
 }
 
 // DismissalRestrictionsRequest represents the request to create/edit the
-// restriction to allows only specific users or teams to dimiss pull request reviews. It is
+// restriction to allows only specific users, teams or apps to dimiss pull request reviews. It is
 // separate from DismissalRestrictions above because the request structure is
 // different from the response structure.
 // Note: Both Users and Teams must be nil, or both must be non-nil.
@@ -1157,6 +1159,8 @@ type DismissalRestrictionsRequest struct {
 	Users *[]string `json:"users,omitempty"`
 	// The list of team slugs which can dismiss pull request reviews. (Required; use nil to disable dismissal_restrictions or &[]string{} otherwise.)
 	Teams *[]string `json:"teams,omitempty"`
+	// The list of apps which can dismiss pull request reviews. (Required; use nil to disable dismissal_restrictions or &[]string{} otherwise.)
+	Apps *[]string `json:"apps,omitempty"`
 }
 
 // SignaturesProtectedBranch represents the protection status of an individual branch.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -240,7 +240,7 @@ github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
-# github.com/google/go-github/v48 v48.0.0
+# github.com/google/go-github/v48 v48.1.0
 ## explicit
 github.com/google/go-github/v48/github
 # github.com/google/go-querystring v1.1.0
@@ -520,8 +520,6 @@ github.com/ulikunitz/xz/lzma
 # github.com/ultraware/funlen v0.0.3
 ## explicit
 github.com/ultraware/funlen
-# github.com/vmihailenco/msgpack v4.0.1+incompatible
-## explicit
 # github.com/vmihailenco/msgpack/v4 v4.3.12
 github.com/vmihailenco/msgpack/v4
 github.com/vmihailenco/msgpack/v4/codes
@@ -582,8 +580,6 @@ golang.org/x/crypto/salsa20/salsa
 golang.org/x/crypto/scrypt
 golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
-# golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
-## explicit
 # golang.org/x/exp/typeparams v0.0.0-20220613132600-b0d781184e0d
 golang.org/x/exp/typeparams
 # golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->

This should unblock #1210.  There were unlying APIs that were just released in go-github that were needed for #1210 

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Before this change go-github was @ v48.0.0

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* After this change go-github is now @ v48.1.0


----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features) - N/A
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features) - N/A
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

