### PR TITLE
Fixing team repository permissions

### DIFF
--- a/github/config.go
+++ b/github/config.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/google/go-github/v48/github"
@@ -177,7 +178,7 @@ func newPreviewHeaderInjectorTransport(headers map[string]string, rt http.RoundT
 func (injector *previewHeaderInjectorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	for name, value := range injector.previewHeaders {
 		header := req.Header.Get(name)
-		header += value
+		header = strings.Join([]string{header, value}, ",")
 		req.Header.Set(name, header)
 	}
 	return injector.rt.RoundTrip(req)

--- a/github/config.go
+++ b/github/config.go
@@ -39,6 +39,7 @@ func RateLimitedHTTPClient(client *http.Client, writeDelay time.Duration, readDe
 	client.Transport = NewRateLimitTransport(client.Transport, WithWriteDelay(writeDelay), WithReadDelay(readDelay))
 	client.Transport = logging.NewTransport("Github", client.Transport)
 	client.Transport = newPreviewHeaderInjectorTransport(map[string]string{
+		// TODO: remove when Stone Crop preview is moved to general availability in the GraphQL API
 		"Accept": "application/vnd.github.stone-crop-preview+json",
 	}, client.Transport)
 

--- a/github/config.go
+++ b/github/config.go
@@ -179,7 +179,11 @@ func newPreviewHeaderInjectorTransport(headers map[string]string, rt http.RoundT
 func (injector *previewHeaderInjectorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	for name, value := range injector.previewHeaders {
 		header := req.Header.Get(name)
-		header = strings.Join([]string{header, value}, ",")
+		if header == "" {
+			header = value
+		} else {
+			header = strings.Join([]string{header, value}, ",")
+		}
 		req.Header.Set(name, header)
 	}
 	return injector.rt.RoundTrip(req)

--- a/github/config.go
+++ b/github/config.go
@@ -38,7 +38,6 @@ func RateLimitedHTTPClient(client *http.Client, writeDelay time.Duration, readDe
 	client.Transport = NewRateLimitTransport(client.Transport, WithWriteDelay(writeDelay), WithReadDelay(readDelay))
 	client.Transport = logging.NewTransport("Github", client.Transport)
 	client.Transport = newPreviewHeaderInjectorTransport(map[string]string{
-		// TODO: remove when Stone Crop preview is moved to general availability in the GraphQL API
 		"Accept": "application/vnd.github.stone-crop-preview+json",
 	}, client.Transport)
 
@@ -177,7 +176,9 @@ func newPreviewHeaderInjectorTransport(headers map[string]string, rt http.RoundT
 
 func (injector *previewHeaderInjectorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	for name, value := range injector.previewHeaders {
-		req.Header.Set(name, value)
+		header := req.Header.Get(name)
+		header += value
+		req.Header.Set(name, header)
 	}
 	return injector.rt.RoundTrip(req)
 }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #1373 

----

## Behavior

### Before the change?

* Accept header was overwritten by `previewHeaderInjectorTransport` which caused errors in `github_team_repository` which needs the `vnd.github.v3.repository+json` value to be present in the `Accept` header. 

### After the change?

* `previewHeaderInjectorTransport` appends the preview schema to the existing `Accept` header (Go implementation will return default `""` - empty string - when header not set so logic will work even if `Accept` header not already set) as a comma-separated list 


### Other information

No other info 

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`

----

