### PR TITLE
Switching from make test to make testacc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,4 @@ jobs:
       - run: make lint
       - run: make website-lint
       - run: make build
-      - run: make test
+      - run: make testacc


### PR DESCRIPTION
make test runs nothing but make testacc runs the actual acceptance tests. Running acceptance tests would have prevented issue https://github.com/integrations/terraform-provider-github/issues/1373

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #1385 

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* CI doesn't run any tests on PRs

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* CI runs acceptance tests on PRs


### Other information
<!-- Any other information that is important to this PR  -->

* 

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Dependencies/code cleanup: `Type: Maintenance`

----

