### PR TITLE
URL encode environment name in `github_repository_environment`

### DIFF
--- a/github/resource_github_repository_environment.go
+++ b/github/resource_github_repository_environment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"net/http"
+	"net/url"
 
 	"github.com/google/go-github/v48/github"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -81,11 +82,12 @@ func resourceGithubRepositoryEnvironmentCreate(d *schema.ResourceData, meta inte
 	owner := meta.(*Owner).name
 	repoName := d.Get("repository").(string)
 	envName := d.Get("environment").(string)
+	escapedEnvName := url.QueryEscape(envName)
 	updateData := createUpdateEnvironmentData(d, meta)
 
 	ctx := context.Background()
 
-	_, _, err := client.Repositories.CreateUpdateEnvironment(ctx, owner, repoName, envName, &updateData)
+	_, _, err := client.Repositories.CreateUpdateEnvironment(ctx, owner, repoName, escapedEnvName, &updateData)
 
 	if err != nil {
 		return err
@@ -101,13 +103,14 @@ func resourceGithubRepositoryEnvironmentRead(d *schema.ResourceData, meta interf
 
 	owner := meta.(*Owner).name
 	repoName, envName, err := parseTwoPartID(d.Id(), "repository", "environment")
+	escapedEnvName := url.QueryEscape(envName)
 	if err != nil {
 		return err
 	}
 
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
-	env, _, err := client.Repositories.GetEnvironment(ctx, owner, repoName, envName)
+	env, _, err := client.Repositories.GetEnvironment(ctx, owner, repoName, escapedEnvName)
 	if err != nil {
 		if ghErr, ok := err.(*github.ErrorResponse); ok {
 			if ghErr.Response.StatusCode == http.StatusNotFound {
@@ -170,11 +173,12 @@ func resourceGithubRepositoryEnvironmentUpdate(d *schema.ResourceData, meta inte
 	owner := meta.(*Owner).name
 	repoName := d.Get("repository").(string)
 	envName := d.Get("environment").(string)
+	escapedEnvName := url.QueryEscape(envName)
 	updateData := createUpdateEnvironmentData(d, meta)
 
 	ctx := context.Background()
 
-	resultKey, _, err := client.Repositories.CreateUpdateEnvironment(ctx, owner, repoName, envName, &updateData)
+	resultKey, _, err := client.Repositories.CreateUpdateEnvironment(ctx, owner, repoName, escapedEnvName, &updateData)
 	if err != nil {
 		return err
 	}
@@ -189,13 +193,14 @@ func resourceGithubRepositoryEnvironmentDelete(d *schema.ResourceData, meta inte
 
 	owner := meta.(*Owner).name
 	repoName, envName, err := parseTwoPartID(d.Id(), "repository", "environment")
+	escapedEnvName := url.QueryEscape(envName)
 	if err != nil {
 		return err
 	}
 
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
-	_, err = client.Repositories.DeleteEnvironment(ctx, owner, repoName, envName)
+	_, err = client.Repositories.DeleteEnvironment(ctx, owner, repoName, escapedEnvName)
 	return err
 }
 

--- a/github/resource_github_repository_environment_test.go
+++ b/github/resource_github_repository_environment_test.go
@@ -26,7 +26,7 @@ func TestAccGithubRepositoryEnvironment(t *testing.T) {
 
 			resource "github_repository_environment" "test" {
 				repository 	= github_repository.test.name
-				environment	= "test_environment_name"
+				environment	= "environment/test"
 				wait_timer	= 10000
 				reviewers {
 					users = [data.github_user.current.id]
@@ -42,7 +42,7 @@ func TestAccGithubRepositoryEnvironment(t *testing.T) {
 		check := resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(
 				"github_repository_environment.test", "environment",
-				"test_environment_name",
+				"environment/test",
 			),
 		)
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #1389 

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

Any attempt to create, read, update or delete a [repository environment](https://docs.github.com/en/rest/deployments/environments?apiVersion=2022-11-28) with a name that contains a `/` or other special characters would fail.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Attempts to create, read, update or delete a repository environment with a name that contains a `/` or other special characters will succeed.


### Other information
<!-- Any other information that is important to this PR  -->

* Not sure if this should instead be fixed upstream, in https://github.com/google/go-github, or if it is the responsibility of the client to URL encode the input.

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [x] Yes (Please add the `Type: Breaking change` label)
- [ ] No

If `Yes`, what's the impact:  

* Users of this resource may need to update their configuration to make sure that the environment name is not URL encoded twice. In other words, they may need to change e.g.:
```hcl
resource "github_repository_environment" "this" {
  environment = urlencode("environment/test")
  repository  = "my-repo"
}
```
into:
```hcl
resource "github_repository_environment" "this" {
  environment = "environment/test"
  repository  = "my-repo"
}
```
assuming they have environment names that contain special characters.

### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

