### PR TITLE
Create stale action for PRs and Issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: 'Close stale issues and PRs'
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-message: >
+            👋 Hey Friends, this issue has been automatically marked as `stale` because it has no recent activity.
+            It will be closed if no further activity occurs.
+            Please add the `Status: Pinned` label if you feel that this issue needs to remain open/active.
+            Thank you for your contributions and help in keeping things tidy!
+          stale-pr-message: >
+            👋 Hey Friends, this pull request has been automatically marked as `stale` because it has no recent activity.
+            It will be closed if no further activity occurs.
+            Please add the `Status: Pinned` label if you feel that this issue needs to remain open/active.
+            Thank you for your contributions and help in keeping things tidy!
+          days-before-stale: 270
+          days-before-close: 7
+          exempt-issue-labels: 'Status: Pinned'
+          exempt-pr-labels: 'Status: Pinned'


### PR DESCRIPTION
## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

PRs and Issues were allowed to languish and go out of date, 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR implements a stale action that will evaluate PRs and issues on a regular cadence and notify (posting a comment on the item if it's older than 270 days - roughly 9 months) and close the item if the pinned label has not been applied within 7 days following that.

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features) - N/A
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features) - N/A
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

----

