### PR TITLE
feat: adds new branch protection options for last reviewer and locking branch

### DIFF
--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -63,6 +63,11 @@ func resourceGithubBranchProtection() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			PROTECTION_LOCK_BRANCH: {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			PROTECTION_REQUIRES_APPROVING_REVIEWS: {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -95,6 +100,11 @@ func resourceGithubBranchProtection() *schema.Resource {
 							Type:     schema.TypeSet,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						PROTECTION_REQUIRES_LAST_PUSH_APPROVAL: {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
 						},
 					},
 				},
@@ -197,6 +207,8 @@ func resourceGithubBranchProtectionCreate(d *schema.ResourceData, meta interface
 		RestrictsPushes:                githubv4.NewBoolean(githubv4.Boolean(data.RestrictsPushes)),
 		RestrictsReviewDismissals:      githubv4.NewBoolean(githubv4.Boolean(data.RestrictsReviewDismissals)),
 		ReviewDismissalActorIDs:        githubv4NewIDSlice(githubv4IDSlice(data.ReviewDismissalActorIDs)),
+		LockBranch:                     githubv4.NewBoolean(githubv4.Boolean(data.LockBranch)),
+		RequireLastPushApproval:        githubv4.NewBoolean(githubv4.Boolean(data.RequireLastPushApproval)),
 	}
 
 	ctx := context.Background()
@@ -299,6 +311,16 @@ func resourceGithubBranchProtectionRead(d *schema.ResourceData, meta interface{}
 		log.Printf("[DEBUG] Problem setting '%s' in %s %s branch protection (%s)", PROTECTION_RESTRICTS_PUSHES, protection.Repository.Name, protection.Pattern, d.Id())
 	}
 
+	err = d.Set(PROTECTION_REQUIRES_LAST_PUSH_APPROVAL, protection.RequireLastPushApproval)
+	if err != nil {
+		log.Printf("[DEBUG] Problem setting '%s' in %s %s branch protection (%s)", PROTECTION_REQUIRES_LAST_PUSH_APPROVAL, protection.Repository.Name, protection.Pattern, d.Id())
+	}
+
+	err = d.Set(PROTECTION_LOCK_BRANCH, protection.LockBranch)
+	if err != nil {
+		log.Printf("[DEBUG] Problem setting '%s' in %s %s branch protection (%s)", PROTECTION_LOCK_BRANCH, protection.Repository.Name, protection.Pattern, d.Id())
+	}
+
 	return nil
 }
 
@@ -357,6 +379,8 @@ func resourceGithubBranchProtectionUpdate(d *schema.ResourceData, meta interface
 		RestrictsPushes:                githubv4.NewBoolean(githubv4.Boolean(data.RestrictsPushes)),
 		RestrictsReviewDismissals:      githubv4.NewBoolean(githubv4.Boolean(data.RestrictsReviewDismissals)),
 		ReviewDismissalActorIDs:        githubv4NewIDSlice(githubv4IDSlice(data.ReviewDismissalActorIDs)),
+		LockBranch:                     githubv4.NewBoolean(githubv4.Boolean(data.LockBranch)),
+		RequireLastPushApproval:        githubv4.NewBoolean(githubv4.Boolean(data.RequireLastPushApproval)),
 	}
 
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())

--- a/github/resource_github_branch_protection_test.go
+++ b/github/resource_github_branch_protection_test.go
@@ -51,6 +51,9 @@ func TestAccGithubBranchProtection(t *testing.T) {
 			resource.TestCheckResourceAttr(
 				"github_branch_protection.test", "push_restrictions.#", "0",
 			),
+			resource.TestCheckResourceAttr(
+				"github_branch_protection.test", "lock_branch", "false",
+			),
 		)
 
 		testCase := func(t *testing.T, mode string) {
@@ -138,6 +141,9 @@ func TestAccGithubBranchProtection(t *testing.T) {
 			),
 			resource.TestCheckResourceAttr(
 				"github_branch_protection.test", "push_restrictions.#", "0",
+			),
+			resource.TestCheckResourceAttr(
+				"github_branch_protection.test", "lock_branch", "false",
 			),
 		)
 
@@ -275,6 +281,7 @@ func TestAccGithubBranchProtection(t *testing.T) {
 				required_pull_request_reviews {
 						dismiss_stale_reviews      = true
 						require_code_owner_reviews = true
+						require_last_push_approval = true
 				}
 
 			}
@@ -293,6 +300,9 @@ func TestAccGithubBranchProtection(t *testing.T) {
 			),
 			resource.TestCheckResourceAttr(
 				"github_branch_protection.test", "required_pull_request_reviews.0.required_approving_review_count", "1",
+			),
+			resource.TestCheckResourceAttr(
+				"github_branch_protection.test", "required_pull_request_reviews.0.require_last_push_approval", "true",
 			),
 		)
 

--- a/github/util_v4_branch_protection.go
+++ b/github/util_v4_branch_protection.go
@@ -76,6 +76,8 @@ type BranchProtectionRule struct {
 	RequiresStrictStatusChecks     githubv4.Boolean
 	RestrictsPushes                githubv4.Boolean
 	RestrictsReviewDismissals      githubv4.Boolean
+	RequireLastPushApproval        githubv4.Boolean
+	LockBranch                     githubv4.Boolean
 }
 
 type BranchProtectionResourceData struct {
@@ -101,6 +103,8 @@ type BranchProtectionResourceData struct {
 	RestrictsPushes                bool
 	RestrictsReviewDismissals      bool
 	ReviewDismissalActorIDs        []string
+	RequireLastPushApproval        bool
+	LockBranch                     bool
 }
 
 func branchProtectionResourceData(d *schema.ResourceData, meta interface{}) (BranchProtectionResourceData, error) {
@@ -193,6 +197,9 @@ func branchProtectionResourceData(d *schema.ResourceData, meta interface{}) (Bra
 					data.BypassPullRequestActorIDs = bypassPullRequestActorIDs
 				}
 			}
+			if v, ok := m[PROTECTION_REQUIRES_LAST_PUSH_APPROVAL]; ok {
+				data.RequireLastPushApproval = v.(bool)
+			}
 		}
 	}
 
@@ -227,6 +234,10 @@ func branchProtectionResourceData(d *schema.ResourceData, meta interface{}) (Bra
 			data.PushActorIDs = pushActorIDs
 			data.RestrictsPushes = true
 		}
+	}
+
+	if v, ok := d.GetOk(PROTECTION_LOCK_BRANCH); ok {
+		data.LockBranch = v.(bool)
 	}
 
 	return data, nil
@@ -387,6 +398,7 @@ func setApprovingReviews(protection BranchProtectionRule, data BranchProtectionR
 			PROTECTION_RESTRICTS_REVIEW_DISMISSALS:     protection.RestrictsReviewDismissals,
 			PROTECTION_RESTRICTS_REVIEW_DISMISSERS:     dismissalActors,
 			PROTECTION_PULL_REQUESTS_BYPASSERS:         bypassPullRequestActors,
+			PROTECTION_REQUIRES_LAST_PUSH_APPROVAL:     protection.RequireLastPushApproval,
 		},
 	}
 

--- a/github/util_v4_consts.go
+++ b/github/util_v4_consts.go
@@ -20,6 +20,8 @@ const (
 	PROTECTION_RESTRICTS_REVIEW_DISMISSALS      = "restrict_dismissals"
 	PROTECTION_RESTRICTS_REVIEW_DISMISSERS      = "dismissal_restrictions"
 	PROTECTION_PULL_REQUESTS_BYPASSERS          = "pull_request_bypassers"
+	PROTECTION_LOCK_BRANCH                      = "lock_branch"
+	PROTECTION_REQUIRES_LAST_PUSH_APPROVAL      = "require_last_push_approval"
 
 	REPOSITORY_ID = "repository_id"
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golangci/golangci-lint v1.41.1
 	github.com/google/go-github/v48 v48.1.0
 	github.com/hashicorp/terraform-plugin-sdk v1.17.2
-	github.com/shurcooL/githubv4 v0.0.0-20220520033151-0b4e3294ff00
+	github.com/shurcooL/githubv4 v0.0.0-20221126192849-0b5c4c7994eb
 	golang.org/x/crypto v0.3.0
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
 	gopkg.in/square/go-jose.v2 v2.6.0

--- a/go.sum
+++ b/go.sum
@@ -891,6 +891,8 @@ github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c/go.mod h1:/PevMnwAx
 github.com/shirou/gopsutil/v3 v3.21.5/go.mod h1:ghfMypLDrFSWN2c9cDYFLHyynQ+QUht0cv/18ZqVczw=
 github.com/shurcooL/githubv4 v0.0.0-20220520033151-0b4e3294ff00 h1:fiFvD4lT0aWjuuAb64LlZ/67v87m+Kc9Qsu5cMFNK0w=
 github.com/shurcooL/githubv4 v0.0.0-20220520033151-0b4e3294ff00/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
+github.com/shurcooL/githubv4 v0.0.0-20221126192849-0b5c4c7994eb h1:foJysa74+t41fG7adnt+TkfcNxQUWid8R/HlXe+Mmbw=
+github.com/shurcooL/githubv4 v0.0.0-20221126192849-0b5c4c7994eb/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 h1:B1PEwpArrNp4dkQrfxh/abbBAOZBVp0ds+fBEOUOqOc=

--- a/vendor/github.com/shurcooL/githubv4/enum.go
+++ b/vendor/github.com/shurcooL/githubv4/enum.go
@@ -45,6 +45,27 @@ const (
 	CheckConclusionStateStale          CheckConclusionState = "STALE"           // The check suite or run was marked stale by GitHub. Only GitHub can use this conclusion.
 )
 
+// CheckRunState represents the possible states of a check run in a status rollup.
+type CheckRunState string
+
+// The possible states of a check run in a status rollup.
+const (
+	CheckRunStateActionRequired CheckRunState = "ACTION_REQUIRED" // The check run requires action.
+	CheckRunStateCancelled      CheckRunState = "CANCELLED"       // The check run has been cancelled.
+	CheckRunStateCompleted      CheckRunState = "COMPLETED"       // The check run has been completed.
+	CheckRunStateFailure        CheckRunState = "FAILURE"         // The check run has failed.
+	CheckRunStateInProgress     CheckRunState = "IN_PROGRESS"     // The check run is in progress.
+	CheckRunStateNeutral        CheckRunState = "NEUTRAL"         // The check run was neutral.
+	CheckRunStatePending        CheckRunState = "PENDING"         // The check run is in pending state.
+	CheckRunStateQueued         CheckRunState = "QUEUED"          // The check run has been queued.
+	CheckRunStateSkipped        CheckRunState = "SKIPPED"         // The check run was skipped.
+	CheckRunStateStale          CheckRunState = "STALE"           // The check run was marked stale by GitHub. Only GitHub can use this conclusion.
+	CheckRunStateStartupFailure CheckRunState = "STARTUP_FAILURE" // The check run has failed at startup.
+	CheckRunStateSuccess        CheckRunState = "SUCCESS"         // The check run has succeeded.
+	CheckRunStateTimedOut       CheckRunState = "TIMED_OUT"       // The check run has timed out.
+	CheckRunStateWaiting        CheckRunState = "WAITING"         // The check run is in waiting state.
+)
+
 // CheckRunType represents the possible types of check runs.
 type CheckRunType string
 
@@ -115,6 +136,17 @@ const (
 	CommitContributionOrderFieldCommitCount CommitContributionOrderField = "COMMIT_COUNT" // Order commit contributions by how many commits they represent.
 )
 
+// ComparisonStatus represents the status of a git comparison between two refs.
+type ComparisonStatus string
+
+// The status of a git comparison between two refs.
+const (
+	ComparisonStatusDiverged  ComparisonStatus = "DIVERGED"  // The head ref is both ahead and behind of the base ref, indicating git history has diverged.
+	ComparisonStatusAhead     ComparisonStatus = "AHEAD"     // The head ref is ahead of the base ref.
+	ComparisonStatusBehind    ComparisonStatus = "BEHIND"    // The head ref is behind the base ref.
+	ComparisonStatusIdentical ComparisonStatus = "IDENTICAL" // The head ref and base ref are identical.
+)
+
 // ContributionLevel represents varying levels of contributions from none to many.
 type ContributionLevel string
 
@@ -151,6 +183,8 @@ const (
 	DependencyGraphEcosystemComposer DependencyGraphEcosystem = "COMPOSER" // PHP packages hosted at packagist.org.
 	DependencyGraphEcosystemGo       DependencyGraphEcosystem = "GO"       // Go modules.
 	DependencyGraphEcosystemActions  DependencyGraphEcosystem = "ACTIONS"  // GitHub Actions.
+	DependencyGraphEcosystemRust     DependencyGraphEcosystem = "RUST"     // Rust crates.
+	DependencyGraphEcosystemPub      DependencyGraphEcosystem = "PUB"      // Dart packages hosted at pub.dev.
 )
 
 // DeploymentOrderField represents properties by which deployment connections can be ordered.
@@ -229,6 +263,15 @@ const (
 	DiscussionOrderFieldUpdatedAt DiscussionOrderField = "UPDATED_AT" // Order discussions by most recent modification time.
 )
 
+// DiscussionPollOptionOrderField represents properties by which discussion poll option connections can be ordered.
+type DiscussionPollOptionOrderField string
+
+// Properties by which discussion poll option connections can be ordered.
+const (
+	DiscussionPollOptionOrderFieldAuthoredOrder DiscussionPollOptionOrderField = "AUTHORED_ORDER" // Order poll options by the order that the poll author specified when creating the poll.
+	DiscussionPollOptionOrderFieldVoteCount     DiscussionPollOptionOrderField = "VOTE_COUNT"     // Order poll options by the number of votes it has.
+)
+
 // DismissReason represents the possible reasons that a Dependabot alert was dismissed.
 type DismissReason string
 
@@ -256,6 +299,19 @@ type EnterpriseAdministratorRole string
 const (
 	EnterpriseAdministratorRoleOwner          EnterpriseAdministratorRole = "OWNER"           // Represents an owner of the enterprise account.
 	EnterpriseAdministratorRoleBillingManager EnterpriseAdministratorRole = "BILLING_MANAGER" // Represents a billing manager of the enterprise account.
+)
+
+// EnterpriseAllowPrivateRepositoryForkingPolicyValue represents the possible values for the enterprise allow private repository forking policy value.
+type EnterpriseAllowPrivateRepositoryForkingPolicyValue string
+
+// The possible values for the enterprise allow private repository forking policy value.
+const (
+	EnterpriseAllowPrivateRepositoryForkingPolicyValueEnterpriseOrganizations             EnterpriseAllowPrivateRepositoryForkingPolicyValue = "ENTERPRISE_ORGANIZATIONS"               // Members can fork a repository to an organization within this enterprise.
+	EnterpriseAllowPrivateRepositoryForkingPolicyValueSameOrganization                    EnterpriseAllowPrivateRepositoryForkingPolicyValue = "SAME_ORGANIZATION"                      // Members can fork a repository only within the same organization (intra-org).
+	EnterpriseAllowPrivateRepositoryForkingPolicyValueSameOrganizationUserAccounts        EnterpriseAllowPrivateRepositoryForkingPolicyValue = "SAME_ORGANIZATION_USER_ACCOUNTS"        // Members can fork a repository to their user account or within the same organization.
+	EnterpriseAllowPrivateRepositoryForkingPolicyValueEnterpriseOrganizationsUserAccounts EnterpriseAllowPrivateRepositoryForkingPolicyValue = "ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS" // Members can fork a repository to their enterprise-managed user account or an organization inside this enterprise.
+	EnterpriseAllowPrivateRepositoryForkingPolicyValueUserAccounts                        EnterpriseAllowPrivateRepositoryForkingPolicyValue = "USER_ACCOUNTS"                          // Members can fork a repository to their user account.
+	EnterpriseAllowPrivateRepositoryForkingPolicyValueEverywhere                          EnterpriseAllowPrivateRepositoryForkingPolicyValue = "EVERYWHERE"                             // Members can fork a repository to their user account or an organization, either inside or outside of this enterprise.
 )
 
 // EnterpriseDefaultRepositoryPermissionSettingValue represents the possible values for the enterprise base repository permission setting.
@@ -369,8 +425,9 @@ type EnterpriseUserAccountMembershipRole string
 
 // The possible roles for enterprise membership.
 const (
-	EnterpriseUserAccountMembershipRoleMember EnterpriseUserAccountMembershipRole = "MEMBER" // The user is a member of the enterprise membership.
-	EnterpriseUserAccountMembershipRoleOwner  EnterpriseUserAccountMembershipRole = "OWNER"  // The user is an owner of the enterprise membership.
+	EnterpriseUserAccountMembershipRoleMember       EnterpriseUserAccountMembershipRole = "MEMBER"       // The user is a member of an organization in the enterprise.
+	EnterpriseUserAccountMembershipRoleOwner        EnterpriseUserAccountMembershipRole = "OWNER"        // The user is an owner of an organization in the enterprise.
+	EnterpriseUserAccountMembershipRoleUnaffiliated EnterpriseUserAccountMembershipRole = "UNAFFILIATED" // The user is not an owner of the enterprise, and not a member or owner of any organizations in the enterprise; only for EMU-enabled enterprises.
 )
 
 // EnterpriseUserDeployment represents the possible GitHub Enterprise deployments where this user can exist.
@@ -491,6 +548,15 @@ const (
 	IpAllowListForInstalledAppsEnabledSettingValueDisabled IpAllowListForInstalledAppsEnabledSettingValue = "DISABLED" // The setting is disabled for the owner.
 )
 
+// IssueClosedStateReason represents the possible state reasons of a closed issue.
+type IssueClosedStateReason string
+
+// The possible state reasons of a closed issue.
+const (
+	IssueClosedStateReasonCompleted  IssueClosedStateReason = "COMPLETED"   // An issue that has been closed as completed.
+	IssueClosedStateReasonNotPlanned IssueClosedStateReason = "NOT_PLANNED" // An issue that has been closed as not planned.
+)
+
 // IssueCommentOrderField represents properties by which issue comment connections can be ordered.
 type IssueCommentOrderField string
 
@@ -516,6 +582,16 @@ type IssueState string
 const (
 	IssueStateOpen   IssueState = "OPEN"   // An issue that is still open.
 	IssueStateClosed IssueState = "CLOSED" // An issue that has been closed.
+)
+
+// IssueStateReason represents the possible state reasons of an issue.
+type IssueStateReason string
+
+// The possible state reasons of an issue.
+const (
+	IssueStateReasonReopened   IssueStateReason = "REOPENED"    // An issue that has been reopened.
+	IssueStateReasonNotPlanned IssueStateReason = "NOT_PLANNED" // An issue that has been closed as not planned.
+	IssueStateReasonCompleted  IssueStateReason = "COMPLETED"   // An issue that has been closed as completed.
 )
 
 // IssueTimelineItemsItemType represents the possible item types found in a timeline.
@@ -584,6 +660,25 @@ const (
 	LockReasonSpam      LockReason = "SPAM"       // The issue or pull request was locked because the conversation was spam.
 )
 
+// MergeCommitMessage represents the possible default commit messages for merges.
+type MergeCommitMessage string
+
+// The possible default commit messages for merges.
+const (
+	MergeCommitMessagePrTitle MergeCommitMessage = "PR_TITLE" // Default to the pull request's title.
+	MergeCommitMessagePrBody  MergeCommitMessage = "PR_BODY"  // Default to the pull request's body.
+	MergeCommitMessageBlank   MergeCommitMessage = "BLANK"    // Default to a blank commit message.
+)
+
+// MergeCommitTitle represents the possible default commit titles for merges.
+type MergeCommitTitle string
+
+// The possible default commit titles for merges.
+const (
+	MergeCommitTitlePrTitle      MergeCommitTitle = "PR_TITLE"      // Default to the pull request's title.
+	MergeCommitTitleMergeMessage MergeCommitTitle = "MERGE_MESSAGE" // Default to the classic title for a merge message (e.g., Merge pull request #123 from branch-name).
+)
+
 // MergeableState represents whether or not a PullRequest can be merged.
 type MergeableState string
 
@@ -599,10 +694,8 @@ type MigrationSourceType string
 
 // Represents the different Octoshift migration sources.
 const (
-	MigrationSourceTypeGitLab          MigrationSourceType = "GITLAB"           // A GitLab migration source.
 	MigrationSourceTypeAzureDevOps     MigrationSourceType = "AZURE_DEVOPS"     // An Azure DevOps migration source.
 	MigrationSourceTypeBitbucketServer MigrationSourceType = "BITBUCKET_SERVER" // A Bitbucket Server migration source.
-	MigrationSourceTypeGitHub          MigrationSourceType = "GITHUB"           // A GitHub migration source.
 	MigrationSourceTypeGitHubArchive   MigrationSourceType = "GITHUB_ARCHIVE"   // A GitHub Migration API source.
 )
 
@@ -611,11 +704,13 @@ type MigrationState string
 
 // The Octoshift migration state.
 const (
-	MigrationStateNotStarted MigrationState = "NOT_STARTED" // The Octoshift migration has not started.
-	MigrationStateQueued     MigrationState = "QUEUED"      // The Octoshift migration has been queued.
-	MigrationStateInProgress MigrationState = "IN_PROGRESS" // The Octoshift migration is in progress.
-	MigrationStateSucceeded  MigrationState = "SUCCEEDED"   // The Octoshift migration has succeeded.
-	MigrationStateFailed     MigrationState = "FAILED"      // The Octoshift migration has failed.
+	MigrationStateNotStarted        MigrationState = "NOT_STARTED"        // The Octoshift migration has not started.
+	MigrationStateQueued            MigrationState = "QUEUED"             // The Octoshift migration has been queued.
+	MigrationStateInProgress        MigrationState = "IN_PROGRESS"        // The Octoshift migration is in progress.
+	MigrationStateSucceeded         MigrationState = "SUCCEEDED"          // The Octoshift migration has succeeded.
+	MigrationStateFailed            MigrationState = "FAILED"             // The Octoshift migration has failed.
+	MigrationStatePendingValidation MigrationState = "PENDING_VALIDATION" // The Octoshift migration needs to have its credentials validated.
+	MigrationStateFailedValidation  MigrationState = "FAILED_VALIDATION"  // The Octoshift migration has invalid credentials.
 )
 
 // MilestoneOrderField represents properties by which milestone connections can be ordered.
@@ -732,6 +827,7 @@ type OrgRemoveMemberAuditEntryMembershipType string
 
 // The type of membership a user has with an Organization.
 const (
+	OrgRemoveMemberAuditEntryMembershipTypeSuspended           OrgRemoveMemberAuditEntryMembershipType = "SUSPENDED"            // A suspended member.
 	OrgRemoveMemberAuditEntryMembershipTypeDirectMember        OrgRemoveMemberAuditEntryMembershipType = "DIRECT_MEMBER"        // A direct member is a user that is a member of the Organization.
 	OrgRemoveMemberAuditEntryMembershipTypeAdmin               OrgRemoveMemberAuditEntryMembershipType = "ADMIN"                // Organization administrators have full access and can change several settings, including the names of repositories that belong to the Organization and Owners team membership. In addition, organization admins can delete the organization and all of its repositories.
 	OrgRemoveMemberAuditEntryMembershipTypeBillingManager      OrgRemoveMemberAuditEntryMembershipType = "BILLING_MANAGER"      // A billing manager is a user who manages the billing settings for the Organization, such as updating payment information.
@@ -1003,6 +1099,7 @@ const (
 	ProjectNextFieldTypeDate               ProjectNextFieldType = "DATE"                 // Date.
 	ProjectNextFieldTypeIteration          ProjectNextFieldType = "ITERATION"            // Iteration.
 	ProjectNextFieldTypeTracks             ProjectNextFieldType = "TRACKS"               // Tracks.
+	ProjectNextFieldTypeTrackedBy          ProjectNextFieldType = "TRACKED_BY"           // Tracked by.
 )
 
 // ProjectNextOrderField represents properties by which the return project can be ordered.
@@ -1044,6 +1141,103 @@ const (
 	ProjectTemplateAutomatedKanbanV2      ProjectTemplate = "AUTOMATED_KANBAN_V2"      // Create a board with v2 triggers to automatically move cards across To do, In progress and Done columns.
 	ProjectTemplateAutomatedReviewsKanban ProjectTemplate = "AUTOMATED_REVIEWS_KANBAN" // Create a board with triggers to automatically move cards across columns with review automation.
 	ProjectTemplateBugTriage              ProjectTemplate = "BUG_TRIAGE"               // Create a board to triage and prioritize bugs with To do, priority, and Done columns.
+)
+
+// ProjectV2FieldOrderField represents properties by which project v2 field connections can be ordered.
+type ProjectV2FieldOrderField string
+
+// Properties by which project v2 field connections can be ordered.
+const (
+	ProjectV2FieldOrderFieldPosition  ProjectV2FieldOrderField = "POSITION"   // Order project v2 fields by position.
+	ProjectV2FieldOrderFieldCreatedAt ProjectV2FieldOrderField = "CREATED_AT" // Order project v2 fields by creation time.
+	ProjectV2FieldOrderFieldName      ProjectV2FieldOrderField = "NAME"       // Order project v2 fields by name.
+)
+
+// ProjectV2FieldType represents the type of a project field.
+type ProjectV2FieldType string
+
+// The type of a project field.
+const (
+	ProjectV2FieldTypeAssignees          ProjectV2FieldType = "ASSIGNEES"            // Assignees.
+	ProjectV2FieldTypeLinkedPullRequests ProjectV2FieldType = "LINKED_PULL_REQUESTS" // Linked Pull Requests.
+	ProjectV2FieldTypeReviewers          ProjectV2FieldType = "REVIEWERS"            // Reviewers.
+	ProjectV2FieldTypeLabels             ProjectV2FieldType = "LABELS"               // Labels.
+	ProjectV2FieldTypeMilestone          ProjectV2FieldType = "MILESTONE"            // Milestone.
+	ProjectV2FieldTypeRepository         ProjectV2FieldType = "REPOSITORY"           // Repository.
+	ProjectV2FieldTypeTitle              ProjectV2FieldType = "TITLE"                // Title.
+	ProjectV2FieldTypeText               ProjectV2FieldType = "TEXT"                 // Text.
+	ProjectV2FieldTypeSingleSelect       ProjectV2FieldType = "SINGLE_SELECT"        // Single Select.
+	ProjectV2FieldTypeNumber             ProjectV2FieldType = "NUMBER"               // Number.
+	ProjectV2FieldTypeDate               ProjectV2FieldType = "DATE"                 // Date.
+	ProjectV2FieldTypeIteration          ProjectV2FieldType = "ITERATION"            // Iteration.
+	ProjectV2FieldTypeTracks             ProjectV2FieldType = "TRACKS"               // Tracks.
+	ProjectV2FieldTypeTrackedBy          ProjectV2FieldType = "TRACKED_BY"           // Tracked by.
+)
+
+// ProjectV2ItemFieldValueOrderField represents properties by which project v2 item field value connections can be ordered.
+type ProjectV2ItemFieldValueOrderField string
+
+// Properties by which project v2 item field value connections can be ordered.
+const (
+	ProjectV2ItemFieldValueOrderFieldPosition ProjectV2ItemFieldValueOrderField = "POSITION" // Order project v2 item field values by the their position in the project.
+)
+
+// ProjectV2ItemOrderField represents properties by which project v2 item connections can be ordered.
+type ProjectV2ItemOrderField string
+
+// Properties by which project v2 item connections can be ordered.
+const (
+	ProjectV2ItemOrderFieldPosition ProjectV2ItemOrderField = "POSITION" // Order project v2 items by the their position in the project.
+)
+
+// ProjectV2ItemType represents the type of a project item.
+type ProjectV2ItemType string
+
+// The type of a project item.
+const (
+	ProjectV2ItemTypeIssue       ProjectV2ItemType = "ISSUE"        // Issue.
+	ProjectV2ItemTypePullRequest ProjectV2ItemType = "PULL_REQUEST" // Pull Request.
+	ProjectV2ItemTypeDraftIssue  ProjectV2ItemType = "DRAFT_ISSUE"  // Draft Issue.
+	ProjectV2ItemTypeRedacted    ProjectV2ItemType = "REDACTED"     // Redacted Item.
+)
+
+// ProjectV2OrderField represents properties by which projects can be ordered.
+type ProjectV2OrderField string
+
+// Properties by which projects can be ordered.
+const (
+	ProjectV2OrderFieldTitle     ProjectV2OrderField = "TITLE"      // The project's title.
+	ProjectV2OrderFieldNumber    ProjectV2OrderField = "NUMBER"     // The project's number.
+	ProjectV2OrderFieldUpdatedAt ProjectV2OrderField = "UPDATED_AT" // The project's date and time of update.
+	ProjectV2OrderFieldCreatedAt ProjectV2OrderField = "CREATED_AT" // The project's date and time of creation.
+)
+
+// ProjectV2State represents the possible states of a project v2.
+type ProjectV2State string
+
+// The possible states of a project v2.
+const (
+	ProjectV2StateOpen   ProjectV2State = "OPEN"   // A project v2 that is still open.
+	ProjectV2StateClosed ProjectV2State = "CLOSED" // A project v2 that has been closed.
+)
+
+// ProjectV2ViewLayout represents the layout of a project v2 view.
+type ProjectV2ViewLayout string
+
+// The layout of a project v2 view.
+const (
+	ProjectV2ViewLayoutBoardLayout ProjectV2ViewLayout = "BOARD_LAYOUT" // Board layout.
+	ProjectV2ViewLayoutTableLayout ProjectV2ViewLayout = "TABLE_LAYOUT" // Table layout.
+)
+
+// ProjectV2ViewOrderField represents properties by which project v2 view connections can be ordered.
+type ProjectV2ViewOrderField string
+
+// Properties by which project v2 view connections can be ordered.
+const (
+	ProjectV2ViewOrderFieldPosition  ProjectV2ViewOrderField = "POSITION"   // Order project v2 views by position.
+	ProjectV2ViewOrderFieldCreatedAt ProjectV2ViewOrderField = "CREATED_AT" // Order project v2 views by creation time.
+	ProjectV2ViewOrderFieldName      ProjectV2ViewOrderField = "NAME"       // Order project v2 views by name.
 )
 
 // ProjectViewLayout represents the layout of a project view.
@@ -1458,6 +1652,15 @@ const (
 	RepositoryVisibilityInternal RepositoryVisibility = "INTERNAL" // The repository is visible only to users in the same business.
 )
 
+// RepositoryVulnerabilityAlertDependencyScope represents the possible scopes of an alert's dependency.
+type RepositoryVulnerabilityAlertDependencyScope string
+
+// The possible scopes of an alert's dependency.
+const (
+	RepositoryVulnerabilityAlertDependencyScopeRuntime     RepositoryVulnerabilityAlertDependencyScope = "RUNTIME"     // A dependency that is leveraged during application runtime.
+	RepositoryVulnerabilityAlertDependencyScopeDevelopment RepositoryVulnerabilityAlertDependencyScope = "DEVELOPMENT" // A dependency that is only used in development.
+)
+
 // RepositoryVulnerabilityAlertState represents the possible states of an alert.
 type RepositoryVulnerabilityAlertState string
 
@@ -1531,17 +1734,29 @@ const (
 	SearchTypeDiscussion SearchType = "DISCUSSION" // Returns matching discussions in repositories.
 )
 
+// SecurityAdvisoryClassification represents classification of the advisory.
+type SecurityAdvisoryClassification string
+
+// Classification of the advisory.
+const (
+	SecurityAdvisoryClassificationGeneral SecurityAdvisoryClassification = "GENERAL" // Classification of general advisories.
+	SecurityAdvisoryClassificationMalware SecurityAdvisoryClassification = "MALWARE" // Classification of malware advisories.
+)
+
 // SecurityAdvisoryEcosystem represents the possible ecosystems of a security vulnerability's package.
 type SecurityAdvisoryEcosystem string
 
 // The possible ecosystems of a security vulnerability's package.
 const (
 	SecurityAdvisoryEcosystemComposer SecurityAdvisoryEcosystem = "COMPOSER" // PHP packages hosted at packagist.org.
+	SecurityAdvisoryEcosystemErlang   SecurityAdvisoryEcosystem = "ERLANG"   // Erlang/Elixir packages hosted at hex.pm.
+	SecurityAdvisoryEcosystemActions  SecurityAdvisoryEcosystem = "ACTIONS"  // GitHub Actions.
 	SecurityAdvisoryEcosystemGo       SecurityAdvisoryEcosystem = "GO"       // Go modules.
 	SecurityAdvisoryEcosystemMaven    SecurityAdvisoryEcosystem = "MAVEN"    // Java artifacts hosted at the Maven central repository.
 	SecurityAdvisoryEcosystemNpm      SecurityAdvisoryEcosystem = "NPM"      // JavaScript packages hosted at npmjs.com.
 	SecurityAdvisoryEcosystemNuget    SecurityAdvisoryEcosystem = "NUGET"    // .NET packages hosted at the NuGet Gallery.
 	SecurityAdvisoryEcosystemPip      SecurityAdvisoryEcosystem = "PIP"      // Python packages hosted at PyPI.org.
+	SecurityAdvisoryEcosystemPub      SecurityAdvisoryEcosystem = "PUB"      // Dart packages hosted at pub.dev.
 	SecurityAdvisoryEcosystemRubygems SecurityAdvisoryEcosystem = "RUBYGEMS" // Ruby gems hosted at RubyGems.org.
 	SecurityAdvisoryEcosystemRust     SecurityAdvisoryEcosystem = "RUST"     // Rust crates.
 )
@@ -1641,6 +1856,15 @@ const (
 	SponsorsGoalKindMonthlySponsorshipAmount SponsorsGoalKind = "MONTHLY_SPONSORSHIP_AMOUNT" // The goal is about getting a certain amount in USD from sponsorships each month.
 )
 
+// SponsorsListingFeaturedItemFeatureableType represents the different kinds of records that can be featured on a GitHub Sponsors profile page.
+type SponsorsListingFeaturedItemFeatureableType string
+
+// The different kinds of records that can be featured on a GitHub Sponsors profile page.
+const (
+	SponsorsListingFeaturedItemFeatureableTypeRepository SponsorsListingFeaturedItemFeatureableType = "REPOSITORY" // A repository owned by the user or organization with the GitHub Sponsors profile.
+	SponsorsListingFeaturedItemFeatureableTypeUser       SponsorsListingFeaturedItemFeatureableType = "USER"       // A user who belongs to the organization with the GitHub Sponsors profile.
+)
+
 // SponsorsTierOrderField represents properties by which Sponsors tiers connections can be ordered.
 type SponsorsTierOrderField string
 
@@ -1673,6 +1897,25 @@ type SponsorshipPrivacy string
 const (
 	SponsorshipPrivacyPublic  SponsorshipPrivacy = "PUBLIC"  // Public.
 	SponsorshipPrivacyPrivate SponsorshipPrivacy = "PRIVATE" // Private.
+)
+
+// SquashMergeCommitMessage represents the possible default commit messages for squash merges.
+type SquashMergeCommitMessage string
+
+// The possible default commit messages for squash merges.
+const (
+	SquashMergeCommitMessagePrBody         SquashMergeCommitMessage = "PR_BODY"         // Default to the pull request's body.
+	SquashMergeCommitMessageCommitMessages SquashMergeCommitMessage = "COMMIT_MESSAGES" // Default to the branch's commit messages.
+	SquashMergeCommitMessageBlank          SquashMergeCommitMessage = "BLANK"           // Default to a blank commit message.
+)
+
+// SquashMergeCommitTitle represents the possible default commit titles for squash merges.
+type SquashMergeCommitTitle string
+
+// The possible default commit titles for squash merges.
+const (
+	SquashMergeCommitTitlePrTitle         SquashMergeCommitTitle = "PR_TITLE"           // Default to the pull request's title.
+	SquashMergeCommitTitleCommitOrPrTitle SquashMergeCommitTitle = "COMMIT_OR_PR_TITLE" // Default to the commit's title (if only one commit) or the pull request's title (when more than one commit).
 )
 
 // StarOrderField represents properties by which star connections can be ordered.
@@ -1835,4 +2078,12 @@ type VerifiableDomainOrderField string
 const (
 	VerifiableDomainOrderFieldDomain    VerifiableDomainOrderField = "DOMAIN"     // Order verifiable domains by the domain name.
 	VerifiableDomainOrderFieldCreatedAt VerifiableDomainOrderField = "CREATED_AT" // Order verifiable domains by their creation date.
+)
+
+// WorkflowRunOrderField represents properties by which workflow run connections can be ordered.
+type WorkflowRunOrderField string
+
+// Properties by which workflow run connections can be ordered.
+const (
+	WorkflowRunOrderFieldCreatedAt WorkflowRunOrderField = "CREATED_AT" // Order workflow runs by most recently created.
 )

--- a/vendor/github.com/shurcooL/githubv4/input.go
+++ b/vendor/github.com/shurcooL/githubv4/input.go
@@ -4,7 +4,7 @@ package githubv4
 
 // Input represents one of the Input structs:
 //
-// AbortQueuedMigrationsInput, AcceptEnterpriseAdministratorInvitationInput, AcceptTopicSuggestionInput, AddAssigneesToAssignableInput, AddCommentInput, AddDiscussionCommentInput, AddEnterpriseSupportEntitlementInput, AddLabelsToLabelableInput, AddProjectCardInput, AddProjectColumnInput, AddProjectDraftIssueInput, AddProjectNextItemInput, AddPullRequestReviewCommentInput, AddPullRequestReviewInput, AddPullRequestReviewThreadInput, AddReactionInput, AddStarInput, AddUpvoteInput, AddVerifiableDomainInput, ApproveDeploymentsInput, ApproveVerifiableDomainInput, ArchiveRepositoryInput, AuditLogOrder, CancelEnterpriseAdminInvitationInput, CancelSponsorshipInput, ChangeUserStatusInput, CheckAnnotationData, CheckAnnotationRange, CheckRunAction, CheckRunFilter, CheckRunOutput, CheckRunOutputImage, CheckSuiteAutoTriggerPreference, CheckSuiteFilter, ClearLabelsFromLabelableInput, CloneProjectInput, CloneTemplateRepositoryInput, CloseIssueInput, ClosePullRequestInput, CommitAuthor, CommitContributionOrder, CommitMessage, CommittableBranch, ContributionOrder, ConvertProjectCardNoteToIssueInput, ConvertPullRequestToDraftInput, CreateBranchProtectionRuleInput, CreateCheckRunInput, CreateCheckSuiteInput, CreateCommitOnBranchInput, CreateDiscussionInput, CreateEnterpriseOrganizationInput, CreateEnvironmentInput, CreateIpAllowListEntryInput, CreateIssueInput, CreateMigrationSourceInput, CreateProjectInput, CreatePullRequestInput, CreateRefInput, CreateRepositoryInput, CreateSponsorsTierInput, CreateSponsorshipInput, CreateTeamDiscussionCommentInput, CreateTeamDiscussionInput, DeclineTopicSuggestionInput, DeleteBranchProtectionRuleInput, DeleteDeploymentInput, DeleteDiscussionCommentInput, DeleteDiscussionInput, DeleteEnvironmentInput, DeleteIpAllowListEntryInput, DeleteIssueCommentInput, DeleteIssueInput, DeleteProjectCardInput, DeleteProjectColumnInput, DeleteProjectInput, DeleteProjectNextItemInput, DeletePullRequestReviewCommentInput, DeletePullRequestReviewInput, DeleteRefInput, DeleteTeamDiscussionCommentInput, DeleteTeamDiscussionInput, DeleteVerifiableDomainInput, DeploymentOrder, DisablePullRequestAutoMergeInput, DiscussionOrder, DismissPullRequestReviewInput, DismissRepositoryVulnerabilityAlertInput, DraftPullRequestReviewComment, DraftPullRequestReviewThread, EnablePullRequestAutoMergeInput, EnterpriseAdministratorInvitationOrder, EnterpriseMemberOrder, EnterpriseServerInstallationOrder, EnterpriseServerUserAccountEmailOrder, EnterpriseServerUserAccountOrder, EnterpriseServerUserAccountsUploadOrder, FileAddition, FileChanges, FileDeletion, FollowOrganizationInput, FollowUserInput, GistOrder, GrantEnterpriseOrganizationsMigratorRoleInput, GrantMigratorRoleInput, InviteEnterpriseAdminInput, IpAllowListEntryOrder, IssueCommentOrder, IssueFilters, IssueOrder, LabelOrder, LanguageOrder, LinkRepositoryToProjectInput, LockLockableInput, MarkDiscussionCommentAsAnswerInput, MarkFileAsViewedInput, MarkPullRequestReadyForReviewInput, MergeBranchInput, MergePullRequestInput, MilestoneOrder, MinimizeCommentInput, MoveProjectCardInput, MoveProjectColumnInput, OrgEnterpriseOwnerOrder, OrganizationOrder, PackageFileOrder, PackageOrder, PackageVersionOrder, PinIssueInput, ProjectOrder, PullRequestOrder, ReactionOrder, RefOrder, RegenerateEnterpriseIdentityProviderRecoveryCodesInput, RegenerateVerifiableDomainTokenInput, RejectDeploymentsInput, ReleaseOrder, RemoveAssigneesFromAssignableInput, RemoveEnterpriseAdminInput, RemoveEnterpriseIdentityProviderInput, RemoveEnterpriseOrganizationInput, RemoveEnterpriseSupportEntitlementInput, RemoveLabelsFromLabelableInput, RemoveOutsideCollaboratorInput, RemoveReactionInput, RemoveStarInput, RemoveUpvoteInput, ReopenIssueInput, ReopenPullRequestInput, RepositoryInvitationOrder, RepositoryMigrationOrder, RepositoryOrder, RequestReviewsInput, RequiredStatusCheckInput, RerequestCheckSuiteInput, ResolveReviewThreadInput, RevokeEnterpriseOrganizationsMigratorRoleInput, RevokeMigratorRoleInput, SavedReplyOrder, SecurityAdvisoryIdentifierFilter, SecurityAdvisoryOrder, SecurityVulnerabilityOrder, SetEnterpriseIdentityProviderInput, SetOrganizationInteractionLimitInput, SetRepositoryInteractionLimitInput, SetUserInteractionLimitInput, SponsorOrder, SponsorableOrder, SponsorsActivityOrder, SponsorsTierOrder, SponsorshipNewsletterOrder, SponsorshipOrder, StarOrder, StartRepositoryMigrationInput, SubmitPullRequestReviewInput, TeamDiscussionCommentOrder, TeamDiscussionOrder, TeamMemberOrder, TeamOrder, TeamRepositoryOrder, TransferIssueInput, UnarchiveRepositoryInput, UnfollowOrganizationInput, UnfollowUserInput, UnlinkRepositoryFromProjectInput, UnlockLockableInput, UnmarkDiscussionCommentAsAnswerInput, UnmarkFileAsViewedInput, UnmarkIssueAsDuplicateInput, UnminimizeCommentInput, UnpinIssueInput, UnresolveReviewThreadInput, UpdateBranchProtectionRuleInput, UpdateCheckRunInput, UpdateCheckSuitePreferencesInput, UpdateDiscussionCommentInput, UpdateDiscussionInput, UpdateEnterpriseAdministratorRoleInput, UpdateEnterpriseAllowPrivateRepositoryForkingSettingInput, UpdateEnterpriseDefaultRepositoryPermissionSettingInput, UpdateEnterpriseMembersCanChangeRepositoryVisibilitySettingInput, UpdateEnterpriseMembersCanCreateRepositoriesSettingInput, UpdateEnterpriseMembersCanDeleteIssuesSettingInput, UpdateEnterpriseMembersCanDeleteRepositoriesSettingInput, UpdateEnterpriseMembersCanInviteCollaboratorsSettingInput, UpdateEnterpriseMembersCanMakePurchasesSettingInput, UpdateEnterpriseMembersCanUpdateProtectedBranchesSettingInput, UpdateEnterpriseMembersCanViewDependencyInsightsSettingInput, UpdateEnterpriseOrganizationProjectsSettingInput, UpdateEnterpriseOwnerOrganizationRoleInput, UpdateEnterpriseProfileInput, UpdateEnterpriseRepositoryProjectsSettingInput, UpdateEnterpriseTeamDiscussionsSettingInput, UpdateEnterpriseTwoFactorAuthenticationRequiredSettingInput, UpdateEnvironmentInput, UpdateIpAllowListEnabledSettingInput, UpdateIpAllowListEntryInput, UpdateIpAllowListForInstalledAppsEnabledSettingInput, UpdateIssueCommentInput, UpdateIssueInput, UpdateNotificationRestrictionSettingInput, UpdateOrganizationAllowPrivateRepositoryForkingSettingInput, UpdateProjectCardInput, UpdateProjectColumnInput, UpdateProjectDraftIssueInput, UpdateProjectInput, UpdateProjectNextInput, UpdateProjectNextItemFieldInput, UpdatePullRequestBranchInput, UpdatePullRequestInput, UpdatePullRequestReviewCommentInput, UpdatePullRequestReviewInput, UpdateRefInput, UpdateRepositoryInput, UpdateSponsorshipPreferencesInput, UpdateSubscriptionInput, UpdateTeamDiscussionCommentInput, UpdateTeamDiscussionInput, UpdateTeamsRepositoryInput, UpdateTopicsInput, UserStatusOrder, VerifiableDomainOrder, VerifyVerifiableDomainInput.
+// AbortQueuedMigrationsInput, AcceptEnterpriseAdministratorInvitationInput, AcceptTopicSuggestionInput, AddAssigneesToAssignableInput, AddCommentInput, AddDiscussionCommentInput, AddDiscussionPollVoteInput, AddEnterpriseOrganizationMemberInput, AddEnterpriseSupportEntitlementInput, AddLabelsToLabelableInput, AddProjectCardInput, AddProjectColumnInput, AddProjectDraftIssueInput, AddProjectNextItemInput, AddProjectV2DraftIssueInput, AddProjectV2ItemByIdInput, AddPullRequestReviewCommentInput, AddPullRequestReviewInput, AddPullRequestReviewThreadInput, AddReactionInput, AddStarInput, AddUpvoteInput, AddVerifiableDomainInput, ApproveDeploymentsInput, ApproveVerifiableDomainInput, ArchiveProjectV2ItemInput, ArchiveRepositoryInput, AuditLogOrder, CancelEnterpriseAdminInvitationInput, CancelSponsorshipInput, ChangeUserStatusInput, CheckAnnotationData, CheckAnnotationRange, CheckRunAction, CheckRunFilter, CheckRunOutput, CheckRunOutputImage, CheckSuiteAutoTriggerPreference, CheckSuiteFilter, ClearLabelsFromLabelableInput, ClearProjectV2ItemFieldValueInput, CloneProjectInput, CloneTemplateRepositoryInput, CloseIssueInput, ClosePullRequestInput, CommitAuthor, CommitContributionOrder, CommitMessage, CommittableBranch, ContributionOrder, ConvertProjectCardNoteToIssueInput, ConvertPullRequestToDraftInput, CreateBranchProtectionRuleInput, CreateCheckRunInput, CreateCheckSuiteInput, CreateCommitOnBranchInput, CreateDiscussionInput, CreateEnterpriseOrganizationInput, CreateEnvironmentInput, CreateIpAllowListEntryInput, CreateIssueInput, CreateLinkedBranchInput, CreateMigrationSourceInput, CreateProjectInput, CreateProjectV2Input, CreatePullRequestInput, CreateRefInput, CreateRepositoryInput, CreateSponsorsTierInput, CreateSponsorshipInput, CreateTeamDiscussionCommentInput, CreateTeamDiscussionInput, DeclineTopicSuggestionInput, DeleteBranchProtectionRuleInput, DeleteDeploymentInput, DeleteDiscussionCommentInput, DeleteDiscussionInput, DeleteEnvironmentInput, DeleteIpAllowListEntryInput, DeleteIssueCommentInput, DeleteIssueInput, DeleteLinkedBranchInput, DeleteProjectCardInput, DeleteProjectColumnInput, DeleteProjectInput, DeleteProjectNextItemInput, DeleteProjectV2ItemInput, DeletePullRequestReviewCommentInput, DeletePullRequestReviewInput, DeleteRefInput, DeleteTeamDiscussionCommentInput, DeleteTeamDiscussionInput, DeleteVerifiableDomainInput, DeploymentOrder, DisablePullRequestAutoMergeInput, DiscussionOrder, DiscussionPollOptionOrder, DismissPullRequestReviewInput, DismissRepositoryVulnerabilityAlertInput, DraftPullRequestReviewComment, DraftPullRequestReviewThread, EnablePullRequestAutoMergeInput, EnterpriseAdministratorInvitationOrder, EnterpriseMemberOrder, EnterpriseServerInstallationOrder, EnterpriseServerUserAccountEmailOrder, EnterpriseServerUserAccountOrder, EnterpriseServerUserAccountsUploadOrder, FileAddition, FileChanges, FileDeletion, FollowOrganizationInput, FollowUserInput, GistOrder, GrantEnterpriseOrganizationsMigratorRoleInput, GrantMigratorRoleInput, InviteEnterpriseAdminInput, IpAllowListEntryOrder, IssueCommentOrder, IssueFilters, IssueOrder, LabelOrder, LanguageOrder, LinkProjectV2ToRepositoryInput, LinkProjectV2ToTeamInput, LinkRepositoryToProjectInput, LockLockableInput, MarkDiscussionCommentAsAnswerInput, MarkFileAsViewedInput, MarkPullRequestReadyForReviewInput, MergeBranchInput, MergePullRequestInput, MilestoneOrder, MinimizeCommentInput, MoveProjectCardInput, MoveProjectColumnInput, OrgEnterpriseOwnerOrder, OrganizationOrder, PackageFileOrder, PackageOrder, PackageVersionOrder, PinIssueInput, ProjectOrder, ProjectV2FieldOrder, ProjectV2FieldValue, ProjectV2Filters, ProjectV2ItemFieldValueOrder, ProjectV2ItemOrder, ProjectV2Order, ProjectV2ViewOrder, PullRequestOrder, ReactionOrder, RefOrder, RegenerateEnterpriseIdentityProviderRecoveryCodesInput, RegenerateVerifiableDomainTokenInput, RejectDeploymentsInput, ReleaseOrder, RemoveAssigneesFromAssignableInput, RemoveEnterpriseAdminInput, RemoveEnterpriseIdentityProviderInput, RemoveEnterpriseOrganizationInput, RemoveEnterpriseSupportEntitlementInput, RemoveLabelsFromLabelableInput, RemoveOutsideCollaboratorInput, RemoveReactionInput, RemoveStarInput, RemoveUpvoteInput, ReopenIssueInput, ReopenPullRequestInput, RepositoryInvitationOrder, RepositoryMigrationOrder, RepositoryOrder, RequestReviewsInput, RequiredStatusCheckInput, RerequestCheckSuiteInput, ResolveReviewThreadInput, RevokeEnterpriseOrganizationsMigratorRoleInput, RevokeMigratorRoleInput, SavedReplyOrder, SecurityAdvisoryIdentifierFilter, SecurityAdvisoryOrder, SecurityVulnerabilityOrder, SetEnterpriseIdentityProviderInput, SetOrganizationInteractionLimitInput, SetRepositoryInteractionLimitInput, SetUserInteractionLimitInput, SponsorOrder, SponsorableOrder, SponsorsActivityOrder, SponsorsTierOrder, SponsorshipNewsletterOrder, SponsorshipOrder, StarOrder, StartRepositoryMigrationInput, SubmitPullRequestReviewInput, TeamDiscussionCommentOrder, TeamDiscussionOrder, TeamMemberOrder, TeamOrder, TeamRepositoryOrder, TransferEnterpriseOrganizationInput, TransferIssueInput, UnarchiveProjectV2ItemInput, UnarchiveRepositoryInput, UnfollowOrganizationInput, UnfollowUserInput, UnlinkProjectV2FromRepositoryInput, UnlinkProjectV2FromTeamInput, UnlinkRepositoryFromProjectInput, UnlockLockableInput, UnmarkDiscussionCommentAsAnswerInput, UnmarkFileAsViewedInput, UnmarkIssueAsDuplicateInput, UnminimizeCommentInput, UnpinIssueInput, UnresolveReviewThreadInput, UpdateBranchProtectionRuleInput, UpdateCheckRunInput, UpdateCheckSuitePreferencesInput, UpdateDiscussionCommentInput, UpdateDiscussionInput, UpdateEnterpriseAdministratorRoleInput, UpdateEnterpriseAllowPrivateRepositoryForkingSettingInput, UpdateEnterpriseDefaultRepositoryPermissionSettingInput, UpdateEnterpriseMembersCanChangeRepositoryVisibilitySettingInput, UpdateEnterpriseMembersCanCreateRepositoriesSettingInput, UpdateEnterpriseMembersCanDeleteIssuesSettingInput, UpdateEnterpriseMembersCanDeleteRepositoriesSettingInput, UpdateEnterpriseMembersCanInviteCollaboratorsSettingInput, UpdateEnterpriseMembersCanMakePurchasesSettingInput, UpdateEnterpriseMembersCanUpdateProtectedBranchesSettingInput, UpdateEnterpriseMembersCanViewDependencyInsightsSettingInput, UpdateEnterpriseOrganizationProjectsSettingInput, UpdateEnterpriseOwnerOrganizationRoleInput, UpdateEnterpriseProfileInput, UpdateEnterpriseRepositoryProjectsSettingInput, UpdateEnterpriseTeamDiscussionsSettingInput, UpdateEnterpriseTwoFactorAuthenticationRequiredSettingInput, UpdateEnvironmentInput, UpdateIpAllowListEnabledSettingInput, UpdateIpAllowListEntryInput, UpdateIpAllowListForInstalledAppsEnabledSettingInput, UpdateIssueCommentInput, UpdateIssueInput, UpdateNotificationRestrictionSettingInput, UpdateOrganizationAllowPrivateRepositoryForkingSettingInput, UpdateOrganizationWebCommitSignoffSettingInput, UpdateProjectCardInput, UpdateProjectColumnInput, UpdateProjectDraftIssueInput, UpdateProjectInput, UpdateProjectNextInput, UpdateProjectNextItemFieldInput, UpdateProjectV2DraftIssueInput, UpdateProjectV2Input, UpdateProjectV2ItemFieldValueInput, UpdateProjectV2ItemPositionInput, UpdatePullRequestBranchInput, UpdatePullRequestInput, UpdatePullRequestReviewCommentInput, UpdatePullRequestReviewInput, UpdateRefInput, UpdateRepositoryInput, UpdateRepositoryWebCommitSignoffSettingInput, UpdateSponsorshipPreferencesInput, UpdateSubscriptionInput, UpdateTeamDiscussionCommentInput, UpdateTeamDiscussionInput, UpdateTeamsRepositoryInput, UpdateTopicsInput, UserStatusOrder, VerifiableDomainOrder, VerifyVerifiableDomainInput, WorkflowRunOrder.
 type Input interface{}
 
 // AbortQueuedMigrationsInput is an autogenerated input type of AbortQueuedMigrations.
@@ -71,6 +71,30 @@ type AddDiscussionCommentInput struct {
 	ClientMutationID *String `json:"clientMutationId,omitempty"`
 }
 
+// AddDiscussionPollVoteInput is an autogenerated input type of AddDiscussionPollVote.
+type AddDiscussionPollVoteInput struct {
+	// The Node ID of the discussion poll option to vote for. (Required.)
+	PollOptionID ID `json:"pollOptionId"`
+
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
+// AddEnterpriseOrganizationMemberInput is an autogenerated input type of AddEnterpriseOrganizationMember.
+type AddEnterpriseOrganizationMemberInput struct {
+	// The ID of the enterprise which owns the organization. (Required.)
+	EnterpriseID ID `json:"enterpriseId"`
+	// The ID of the organization the users will be added to. (Required.)
+	OrganizationID ID `json:"organizationId"`
+	// The IDs of the enterprise members to add. (Required.)
+	UserIDs []ID `json:"userIds"`
+
+	// The role to assign the users in the organization. (Optional.)
+	Role *OrganizationMemberRole `json:"role,omitempty"`
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
 // AddEnterpriseSupportEntitlementInput is an autogenerated input type of AddEnterpriseSupportEntitlement.
 type AddEnterpriseSupportEntitlementInput struct {
 	// The ID of the Enterprise which the admin belongs to. (Required.)
@@ -119,6 +143,32 @@ type AddProjectColumnInput struct {
 
 // AddProjectDraftIssueInput is an autogenerated input type of AddProjectDraftIssue.
 type AddProjectDraftIssueInput struct {
+
+	// The ID of the Project to add the draft issue to. This field is required. **Upcoming Change on 2023-01-01 UTC** **Description:** `projectId` will be removed. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement. **Reason:** The `ProjectNext` API is deprecated in favour of the more capable `ProjectV2` API. (Optional.)
+	ProjectID *ID `json:"projectId,omitempty"`
+	// The title of the draft issue. This field is required. **Upcoming Change on 2023-01-01 UTC** **Description:** `title` will be removed. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement. **Reason:** The `ProjectNext` API is deprecated in favour of the more capable `ProjectV2` API. (Optional.)
+	Title *String `json:"title,omitempty"`
+	// The body of the draft issue. **Upcoming Change on 2023-01-01 UTC** **Description:** `body` will be removed. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement. **Reason:** The `ProjectNext` API is deprecated in favour of the more capable `ProjectV2` API. (Optional.)
+	Body *String `json:"body,omitempty"`
+	// The IDs of the assignees of the draft issue. **Upcoming Change on 2023-01-01 UTC** **Description:** `assigneeIds` will be removed. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement. **Reason:** The `ProjectNext` API is deprecated in favour of the more capable `ProjectV2` API. (Optional.)
+	AssigneeIDs *[]ID `json:"assigneeIds,omitempty"`
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
+// AddProjectNextItemInput is an autogenerated input type of AddProjectNextItem.
+type AddProjectNextItemInput struct {
+
+	// The ID of the Project to add the item to. This field is required. **Upcoming Change on 2023-01-01 UTC** **Description:** `projectId` will be removed. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement. **Reason:** The `ProjectNext` API is deprecated in favour of the more capable `ProjectV2` API. (Optional.)
+	ProjectID *ID `json:"projectId,omitempty"`
+	// The content id of the item (Issue or PullRequest). This field is required. **Upcoming Change on 2023-01-01 UTC** **Description:** `contentId` will be removed. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement. **Reason:** The `ProjectNext` API is deprecated in favour of the more capable `ProjectV2` API. (Optional.)
+	ContentID *ID `json:"contentId,omitempty"`
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
+// AddProjectV2DraftIssueInput is an autogenerated input type of AddProjectV2DraftIssue.
+type AddProjectV2DraftIssueInput struct {
 	// The ID of the Project to add the draft issue to. (Required.)
 	ProjectID ID `json:"projectId"`
 	// The title of the draft issue. (Required.)
@@ -132,11 +182,11 @@ type AddProjectDraftIssueInput struct {
 	ClientMutationID *String `json:"clientMutationId,omitempty"`
 }
 
-// AddProjectNextItemInput is an autogenerated input type of AddProjectNextItem.
-type AddProjectNextItemInput struct {
+// AddProjectV2ItemByIdInput is an autogenerated input type of AddProjectV2ItemById.
+type AddProjectV2ItemByIdInput struct {
 	// The ID of the Project to add the item to. (Required.)
 	ProjectID ID `json:"projectId"`
-	// The content id of the item (Issue or PullRequest). (Required.)
+	// The id of the Issue or Pull Request to add. (Required.)
 	ContentID ID `json:"contentId"`
 
 	// A unique identifier for the client performing the mutation. (Optional.)
@@ -268,6 +318,17 @@ type ApproveVerifiableDomainInput struct {
 	ClientMutationID *String `json:"clientMutationId,omitempty"`
 }
 
+// ArchiveProjectV2ItemInput is an autogenerated input type of ArchiveProjectV2Item.
+type ArchiveProjectV2ItemInput struct {
+	// The ID of the Project to archive the item from. (Required.)
+	ProjectID ID `json:"projectId"`
+	// The ID of the ProjectV2Item to archive. (Required.)
+	ItemID ID `json:"itemId"`
+
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
 // ArchiveRepositoryInput is an autogenerated input type of ArchiveRepository.
 type ArchiveRepositoryInput struct {
 	// The ID of the repository to mark as archived. (Required.)
@@ -376,8 +437,12 @@ type CheckRunFilter struct {
 	AppID *Int `json:"appId,omitempty"`
 	// Filters the check runs by this name. (Optional.)
 	CheckName *String `json:"checkName,omitempty"`
-	// Filters the check runs by this status. (Optional.)
+	// Filters the check runs by this status. Superceded by statuses. (Optional.)
 	Status *CheckStatusState `json:"status,omitempty"`
+	// Filters the check runs by this status. Overrides status. (Optional.)
+	Statuses *[]CheckStatusState `json:"statuses,omitempty"`
+	// Filters the check runs by these conclusions. (Optional.)
+	Conclusions *[]CheckConclusionState `json:"conclusions,omitempty"`
 }
 
 // CheckRunOutput represents descriptive details about the check run.
@@ -432,6 +497,19 @@ type ClearLabelsFromLabelableInput struct {
 	ClientMutationID *String `json:"clientMutationId,omitempty"`
 }
 
+// ClearProjectV2ItemFieldValueInput is an autogenerated input type of ClearProjectV2ItemFieldValue.
+type ClearProjectV2ItemFieldValueInput struct {
+	// The ID of the Project. (Required.)
+	ProjectID ID `json:"projectId"`
+	// The ID of the item to be cleared. (Required.)
+	ItemID ID `json:"itemId"`
+	// The ID of the field to be cleared. (Required.)
+	FieldID ID `json:"fieldId"`
+
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
 // CloneProjectInput is an autogenerated input type of CloneProject.
 type CloneProjectInput struct {
 	// The owner ID to create the project under. (Required.)
@@ -475,6 +553,8 @@ type CloseIssueInput struct {
 	// ID of the issue to be closed. (Required.)
 	IssueID ID `json:"issueId"`
 
+	// The reason the issue is to be closed. (Optional.)
+	StateReason *IssueClosedStateReason `json:"stateReason,omitempty"`
 	// A unique identifier for the client performing the mutation. (Optional.)
 	ClientMutationID *String `json:"clientMutationId,omitempty"`
 }
@@ -514,7 +594,7 @@ type CommitMessage struct {
 	Body *String `json:"body,omitempty"`
 }
 
-// CommittableBranch represents a git ref for a commit to be appended to. The ref must be a branch, i.e. its fully qualified name must start with `refs/heads/` (although the input is not required to be fully qualified). The Ref may be specified by its global node ID or by the repository nameWithOwner and branch name. ### Examples Specify a branch using a global node ID: { "id": "MDM6UmVmMTpyZWZzL2hlYWRzL21haW4=" } Specify a branch using nameWithOwner and branch name: { "nameWithOwner": "github/graphql-client", "branchName": "main" }.
+// CommittableBranch represents a git ref for a commit to be appended to. The ref must be a branch, i.e. its fully qualified name must start with `refs/heads/` (although the input is not required to be fully qualified). The Ref may be specified by its global node ID or by the `repositoryNameWithOwner` and `branchName`. ### Examples Specify a branch using a global node ID: { "id": "MDM6UmVmMTpyZWZzL2hlYWRzL21haW4=" } Specify a branch using `repositoryNameWithOwner` and `branchName`: { "repositoryNameWithOwner": "github/graphql-client", "branchName": "main" }.
 type CommittableBranch struct {
 
 	// The Node ID of the Ref to be updated. (Optional.)
@@ -588,11 +668,11 @@ type CreateBranchProtectionRuleInput struct {
 	DismissesStaleReviews *Boolean `json:"dismissesStaleReviews,omitempty"`
 	// Is dismissal of pull request reviews restricted. (Optional.)
 	RestrictsReviewDismissals *Boolean `json:"restrictsReviewDismissals,omitempty"`
-	// A list of User or Team IDs allowed to dismiss reviews on pull requests targeting matching branches. (Optional.)
+	// A list of User, Team, or App IDs allowed to dismiss reviews on pull requests targeting matching branches. (Optional.)
 	ReviewDismissalActorIDs *[]ID `json:"reviewDismissalActorIds,omitempty"`
-	// A list of User or Team IDs allowed to bypass pull requests targeting matching branches. (Optional.)
+	// A list of User, Team, or App IDs allowed to bypass pull requests targeting matching branches. (Optional.)
 	BypassPullRequestActorIDs *[]ID `json:"bypassPullRequestActorIds,omitempty"`
-	// A list of User or Team IDs allowed to bypass force push targeting matching branches. (Optional.)
+	// A list of User, Team, or App IDs allowed to bypass force push targeting matching branches. (Optional.)
 	BypassForcePushActorIDs *[]ID `json:"bypassForcePushActorIds,omitempty"`
 	// Is pushing to matching branches restricted. (Optional.)
 	RestrictsPushes *Boolean `json:"restrictsPushes,omitempty"`
@@ -604,6 +684,12 @@ type CreateBranchProtectionRuleInput struct {
 	RequiredStatusChecks *[]RequiredStatusCheckInput `json:"requiredStatusChecks,omitempty"`
 	// Are conversations required to be resolved before merging. (Optional.)
 	RequiresConversationResolution *Boolean `json:"requiresConversationResolution,omitempty"`
+	// Whether the most recent push must be approved by someone other than the person who pushed it. (Optional.)
+	RequireLastPushApproval *Boolean `json:"requireLastPushApproval,omitempty"`
+	// Whether to set the branch as read-only. If this is true, users will not be able to push to the branch. (Optional.)
+	LockBranch *Boolean `json:"lockBranch,omitempty"`
+	// Whether users can pull changes from upstream when the branch is locked. Set to `true` to allow fork syncing. Set to `false` to prevent fork syncing. (Optional.)
+	LockAllowsFetchAndMerge *Boolean `json:"lockAllowsFetchAndMerge,omitempty"`
 	// A unique identifier for the client performing the mutation. (Optional.)
 	ClientMutationID *String `json:"clientMutationId,omitempty"`
 }
@@ -744,6 +830,21 @@ type CreateIssueInput struct {
 	ClientMutationID *String `json:"clientMutationId,omitempty"`
 }
 
+// CreateLinkedBranchInput is an autogenerated input type of CreateLinkedBranch.
+type CreateLinkedBranchInput struct {
+	// ID of the issue to link to. (Required.)
+	IssueID ID `json:"issueId"`
+	// The commit SHA to base the new branch on. (Required.)
+	Oid GitObjectID `json:"oid"`
+
+	// The name of the new branch. Defaults to issue number and title. (Optional.)
+	Name *String `json:"name,omitempty"`
+	// ID of the repository to create the branch in. Defaults to the issue repository. (Optional.)
+	RepositoryID *ID `json:"repositoryId,omitempty"`
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
 // CreateMigrationSourceInput is an autogenerated input type of CreateMigrationSource.
 type CreateMigrationSourceInput struct {
 	// The Octoshift migration source name. (Required.)
@@ -776,6 +877,21 @@ type CreateProjectInput struct {
 	Template *ProjectTemplate `json:"template,omitempty"`
 	// A list of repository IDs to create as linked repositories for the project. (Optional.)
 	RepositoryIDs *[]ID `json:"repositoryIds,omitempty"`
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
+// CreateProjectV2Input is an autogenerated input type of CreateProjectV2.
+type CreateProjectV2Input struct {
+	// The owner ID to create the project under. (Required.)
+	OwnerID ID `json:"ownerId"`
+	// The title of the project. (Required.)
+	Title String `json:"title"`
+
+	// The repository to link the project to. (Optional.)
+	RepositoryID *ID `json:"repositoryId,omitempty"`
+	// The team to link the project to. The team will be granted read permissions. (Optional.)
+	TeamID *ID `json:"teamId,omitempty"`
 	// A unique identifier for the client performing the mutation. (Optional.)
 	ClientMutationID *String `json:"clientMutationId,omitempty"`
 }
@@ -1002,6 +1118,15 @@ type DeleteIssueInput struct {
 	ClientMutationID *String `json:"clientMutationId,omitempty"`
 }
 
+// DeleteLinkedBranchInput is an autogenerated input type of DeleteLinkedBranch.
+type DeleteLinkedBranchInput struct {
+	// The ID of the linked branch. (Required.)
+	LinkedBranchID ID `json:"linkedBranchId"`
+
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
 // DeleteProjectCardInput is an autogenerated input type of DeleteProjectCard.
 type DeleteProjectCardInput struct {
 	// The id of the card to delete. (Required.)
@@ -1031,6 +1156,17 @@ type DeleteProjectInput struct {
 
 // DeleteProjectNextItemInput is an autogenerated input type of DeleteProjectNextItem.
 type DeleteProjectNextItemInput struct {
+
+	// The ID of the Project from which the item should be removed. This field is required. **Upcoming Change on 2023-01-01 UTC** **Description:** `projectId` will be removed. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement. **Reason:** The `ProjectNext` API is deprecated in favour of the more capable `ProjectV2` API. (Optional.)
+	ProjectID *ID `json:"projectId,omitempty"`
+	// The ID of the item to be removed. This field is required. **Upcoming Change on 2023-01-01 UTC** **Description:** `itemId` will be removed. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement. **Reason:** The `ProjectNext` API is deprecated in favour of the more capable `ProjectV2` API. (Optional.)
+	ItemID *ID `json:"itemId,omitempty"`
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
+// DeleteProjectV2ItemInput is an autogenerated input type of DeleteProjectV2Item.
+type DeleteProjectV2ItemInput struct {
 	// The ID of the Project from which the item should be removed. (Required.)
 	ProjectID ID `json:"projectId"`
 	// The ID of the item to be removed. (Required.)
@@ -1119,6 +1255,14 @@ type DiscussionOrder struct {
 	Direction OrderDirection `json:"direction"`
 }
 
+// DiscussionPollOptionOrder represents ordering options for discussion poll option connections.
+type DiscussionPollOptionOrder struct {
+	// The field to order poll options by. (Required.)
+	Field DiscussionPollOptionOrderField `json:"field"`
+	// The ordering direction. (Required.)
+	Direction OrderDirection `json:"direction"`
+}
+
 // DismissPullRequestReviewInput is an autogenerated input type of DismissPullRequestReview.
 type DismissPullRequestReviewInput struct {
 	// The Node ID of the pull request review to modify. (Required.)
@@ -1173,11 +1317,11 @@ type EnablePullRequestAutoMergeInput struct {
 	// ID of the pull request to enable auto-merge on. (Required.)
 	PullRequestID ID `json:"pullRequestId"`
 
-	// Commit headline to use for the commit when the PR is mergable; if omitted, a default message will be used. (Optional.)
+	// Commit headline to use for the commit when the PR is mergable; if omitted, a default message will be used. NOTE: when merging with a merge queue any input value for commit headline is ignored. (Optional.)
 	CommitHeadline *String `json:"commitHeadline,omitempty"`
-	// Commit body to use for the commit when the PR is mergable; if omitted, a default message will be used. (Optional.)
+	// Commit body to use for the commit when the PR is mergable; if omitted, a default message will be used. NOTE: when merging with a merge queue any input value for commit message is ignored. (Optional.)
 	CommitBody *String `json:"commitBody,omitempty"`
-	// The merge method to use. If omitted, defaults to 'MERGE'. (Optional.)
+	// The merge method to use. If omitted, defaults to `MERGE`. NOTE: when merging with a merge queue any input value for merge method is ignored. (Optional.)
 	MergeMethod *PullRequestMergeMethod `json:"mergeMethod,omitempty"`
 	// The email address to associate with this merge. (Optional.)
 	AuthorEmail *String `json:"authorEmail,omitempty"`
@@ -1384,6 +1528,28 @@ type LanguageOrder struct {
 	Direction OrderDirection `json:"direction"`
 }
 
+// LinkProjectV2ToRepositoryInput is an autogenerated input type of LinkProjectV2ToRepository.
+type LinkProjectV2ToRepositoryInput struct {
+	// The ID of the project to link to the repository. (Required.)
+	ProjectID ID `json:"projectId"`
+	// The ID of the repository to link to the project. (Required.)
+	RepositoryID ID `json:"repositoryId"`
+
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
+// LinkProjectV2ToTeamInput is an autogenerated input type of LinkProjectV2ToTeam.
+type LinkProjectV2ToTeamInput struct {
+	// The ID of the project to link to the team. (Required.)
+	ProjectID ID `json:"projectId"`
+	// The ID of the team to link to the project. (Required.)
+	TeamID ID `json:"teamId"`
+
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
 // LinkRepositoryToProjectInput is an autogenerated input type of LinkRepositoryToProject.
 type LinkRepositoryToProjectInput struct {
 	// The ID of the Project to link to a Repository. (Required.)
@@ -1571,6 +1737,68 @@ type ProjectOrder struct {
 	// The field in which to order projects by. (Required.)
 	Field ProjectOrderField `json:"field"`
 	// The direction in which to order projects by the specified field. (Required.)
+	Direction OrderDirection `json:"direction"`
+}
+
+// ProjectV2FieldOrder represents ordering options for project v2 field connections.
+type ProjectV2FieldOrder struct {
+	// The field to order the project v2 fields by. (Required.)
+	Field ProjectV2FieldOrderField `json:"field"`
+	// The ordering direction. (Required.)
+	Direction OrderDirection `json:"direction"`
+}
+
+// ProjectV2FieldValue represents the values that can be used to update a field of an item inside a Project. Only 1 value can be updated at a time.
+type ProjectV2FieldValue struct {
+
+	// The text to set on the field. (Optional.)
+	Text *String `json:"text,omitempty"`
+	// The number to set on the field. (Optional.)
+	Number *Float `json:"number,omitempty"`
+	// The ISO 8601 date to set on the field. (Optional.)
+	Date *Date `json:"date,omitempty"`
+	// The id of the single select option to set on the field. (Optional.)
+	SingleSelectOptionID *String `json:"singleSelectOptionId,omitempty"`
+	// The id of the iteration to set on the field. (Optional.)
+	IterationID *String `json:"iterationId,omitempty"`
+}
+
+// ProjectV2Filters represents ways in which to filter lists of projects.
+type ProjectV2Filters struct {
+
+	// List project v2 filtered by the state given. (Optional.)
+	State *ProjectV2State `json:"state,omitempty"`
+}
+
+// ProjectV2ItemFieldValueOrder represents ordering options for project v2 item field value connections.
+type ProjectV2ItemFieldValueOrder struct {
+	// The field to order the project v2 item field values by. (Required.)
+	Field ProjectV2ItemFieldValueOrderField `json:"field"`
+	// The ordering direction. (Required.)
+	Direction OrderDirection `json:"direction"`
+}
+
+// ProjectV2ItemOrder represents ordering options for project v2 item connections.
+type ProjectV2ItemOrder struct {
+	// The field to order the project v2 items by. (Required.)
+	Field ProjectV2ItemOrderField `json:"field"`
+	// The ordering direction. (Required.)
+	Direction OrderDirection `json:"direction"`
+}
+
+// ProjectV2Order represents ways in which lists of projects can be ordered upon return.
+type ProjectV2Order struct {
+	// The field in which to order projects by. (Required.)
+	Field ProjectV2OrderField `json:"field"`
+	// The direction in which to order projects by the specified field. (Required.)
+	Direction OrderDirection `json:"direction"`
+}
+
+// ProjectV2ViewOrder represents ordering options for project v2 view connections.
+type ProjectV2ViewOrder struct {
+	// The field to order the project v2 views by. (Required.)
+	Field ProjectV2ViewOrderField `json:"field"`
+	// The ordering direction. (Required.)
 	Direction OrderDirection `json:"direction"`
 }
 
@@ -2007,6 +2235,8 @@ type StartRepositoryMigrationInput struct {
 	SourceRepositoryURL URI `json:"sourceRepositoryUrl"`
 	// The name of the imported repository. (Required.)
 	RepositoryName String `json:"repositoryName"`
+	// The Octoshift migration source access token. (Required.)
+	AccessToken String `json:"accessToken"`
 
 	// Whether to continue the migration on error. (Optional.)
 	ContinueOnError *Boolean `json:"continueOnError,omitempty"`
@@ -2014,12 +2244,14 @@ type StartRepositoryMigrationInput struct {
 	GitArchiveURL *String `json:"gitArchiveUrl,omitempty"`
 	// The signed URL to access the user-uploaded metadata archive. (Optional.)
 	MetadataArchiveURL *String `json:"metadataArchiveUrl,omitempty"`
-	// The Octoshift migration source access token. (Optional.)
-	AccessToken *String `json:"accessToken,omitempty"`
 	// The GitHub personal access token of the user importing to the target repository. (Optional.)
 	GitHubPat *String `json:"githubPat,omitempty"`
 	// Whether to skip migrating releases for the repository. (Optional.)
 	SkipReleases *Boolean `json:"skipReleases,omitempty"`
+	// The visibility of the imported repository. (Optional.)
+	TargetRepoVisibility *String `json:"targetRepoVisibility,omitempty"`
+	// Whether to lock the source repository. (Optional.)
+	LockSource *Boolean `json:"lockSource,omitempty"`
 	// A unique identifier for the client performing the mutation. (Optional.)
 	ClientMutationID *String `json:"clientMutationId,omitempty"`
 }
@@ -2079,12 +2311,36 @@ type TeamRepositoryOrder struct {
 	Direction OrderDirection `json:"direction"`
 }
 
+// TransferEnterpriseOrganizationInput is an autogenerated input type of TransferEnterpriseOrganization.
+type TransferEnterpriseOrganizationInput struct {
+	// The ID of the organization to transfer. (Required.)
+	OrganizationID ID `json:"organizationId"`
+	// The ID of the enterprise where the organization should be transferred. (Required.)
+	DestinationEnterpriseID ID `json:"destinationEnterpriseId"`
+
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
 // TransferIssueInput is an autogenerated input type of TransferIssue.
 type TransferIssueInput struct {
 	// The Node ID of the issue to be transferred. (Required.)
 	IssueID ID `json:"issueId"`
 	// The Node ID of the repository the issue should be transferred to. (Required.)
 	RepositoryID ID `json:"repositoryId"`
+
+	// Whether to create labels if they don't exist in the target repository (matched by name). (Optional.)
+	CreateLabelsIfMissing *Boolean `json:"createLabelsIfMissing,omitempty"`
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
+// UnarchiveProjectV2ItemInput is an autogenerated input type of UnarchiveProjectV2Item.
+type UnarchiveProjectV2ItemInput struct {
+	// The ID of the Project to archive the item from. (Required.)
+	ProjectID ID `json:"projectId"`
+	// The ID of the ProjectV2Item to unarchive. (Required.)
+	ItemID ID `json:"itemId"`
 
 	// A unique identifier for the client performing the mutation. (Optional.)
 	ClientMutationID *String `json:"clientMutationId,omitempty"`
@@ -2112,6 +2368,28 @@ type UnfollowOrganizationInput struct {
 type UnfollowUserInput struct {
 	// ID of the user to unfollow. (Required.)
 	UserID ID `json:"userId"`
+
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
+// UnlinkProjectV2FromRepositoryInput is an autogenerated input type of UnlinkProjectV2FromRepository.
+type UnlinkProjectV2FromRepositoryInput struct {
+	// The ID of the project to unlink from the repository. (Required.)
+	ProjectID ID `json:"projectId"`
+	// The ID of the repository to unlink from the project. (Required.)
+	RepositoryID ID `json:"repositoryId"`
+
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
+// UnlinkProjectV2FromTeamInput is an autogenerated input type of UnlinkProjectV2FromTeam.
+type UnlinkProjectV2FromTeamInput struct {
+	// The ID of the project to unlink from the team. (Required.)
+	ProjectID ID `json:"projectId"`
+	// The ID of the team to unlink from the project. (Required.)
+	TeamID ID `json:"teamId"`
 
 	// A unique identifier for the client performing the mutation. (Optional.)
 	ClientMutationID *String `json:"clientMutationId,omitempty"`
@@ -2228,11 +2506,11 @@ type UpdateBranchProtectionRuleInput struct {
 	DismissesStaleReviews *Boolean `json:"dismissesStaleReviews,omitempty"`
 	// Is dismissal of pull request reviews restricted. (Optional.)
 	RestrictsReviewDismissals *Boolean `json:"restrictsReviewDismissals,omitempty"`
-	// A list of User or Team IDs allowed to dismiss reviews on pull requests targeting matching branches. (Optional.)
+	// A list of User, Team, or App IDs allowed to dismiss reviews on pull requests targeting matching branches. (Optional.)
 	ReviewDismissalActorIDs *[]ID `json:"reviewDismissalActorIds,omitempty"`
-	// A list of User or Team IDs allowed to bypass pull requests targeting matching branches. (Optional.)
+	// A list of User, Team, or App IDs allowed to bypass pull requests targeting matching branches. (Optional.)
 	BypassPullRequestActorIDs *[]ID `json:"bypassPullRequestActorIds,omitempty"`
-	// A list of User or Team IDs allowed to bypass force push targeting matching branches. (Optional.)
+	// A list of User, Team, or App IDs allowed to bypass force push targeting matching branches. (Optional.)
 	BypassForcePushActorIDs *[]ID `json:"bypassForcePushActorIds,omitempty"`
 	// Is pushing to matching branches restricted. (Optional.)
 	RestrictsPushes *Boolean `json:"restrictsPushes,omitempty"`
@@ -2244,6 +2522,12 @@ type UpdateBranchProtectionRuleInput struct {
 	RequiredStatusChecks *[]RequiredStatusCheckInput `json:"requiredStatusChecks,omitempty"`
 	// Are conversations required to be resolved before merging. (Optional.)
 	RequiresConversationResolution *Boolean `json:"requiresConversationResolution,omitempty"`
+	// Whether the most recent push must be approved by someone other than the person who pushed it. (Optional.)
+	RequireLastPushApproval *Boolean `json:"requireLastPushApproval,omitempty"`
+	// Whether to set the branch as read-only. If this is true, users will not be able to push to the branch. (Optional.)
+	LockBranch *Boolean `json:"lockBranch,omitempty"`
+	// Whether users can pull changes from upstream when the branch is locked. Set to `true` to allow fork syncing. Set to `false` to prevent fork syncing. (Optional.)
+	LockAllowsFetchAndMerge *Boolean `json:"lockAllowsFetchAndMerge,omitempty"`
 	// A unique identifier for the client performing the mutation. (Optional.)
 	ClientMutationID *String `json:"clientMutationId,omitempty"`
 }
@@ -2334,6 +2618,8 @@ type UpdateEnterpriseAllowPrivateRepositoryForkingSettingInput struct {
 	// The value for the allow private repository forking setting on the enterprise. (Required.)
 	SettingValue EnterpriseEnabledDisabledSettingValue `json:"settingValue"`
 
+	// The value for the allow private repository forking policy on the enterprise. (Optional.)
+	PolicyValue *EnterpriseAllowPrivateRepositoryForkingPolicyValue `json:"policyValue,omitempty"`
 	// A unique identifier for the client performing the mutation. (Optional.)
 	ClientMutationID *String `json:"clientMutationId,omitempty"`
 }
@@ -2625,6 +2911,17 @@ type UpdateOrganizationAllowPrivateRepositoryForkingSettingInput struct {
 	ClientMutationID *String `json:"clientMutationId,omitempty"`
 }
 
+// UpdateOrganizationWebCommitSignoffSettingInput is an autogenerated input type of UpdateOrganizationWebCommitSignoffSetting.
+type UpdateOrganizationWebCommitSignoffSettingInput struct {
+	// The ID of the organization on which to set the web commit signoff setting. (Required.)
+	OrganizationID ID `json:"organizationId"`
+	// Enable signoff on web-based commits for repositories in the organization?. (Required.)
+	WebCommitSignoffRequired Boolean `json:"webCommitSignoffRequired"`
+
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
 // UpdateProjectCardInput is an autogenerated input type of UpdateProjectCard.
 type UpdateProjectCardInput struct {
 	// The ProjectCard ID to update. (Required.)
@@ -2683,15 +2980,64 @@ type UpdateProjectInput struct {
 
 // UpdateProjectNextInput is an autogenerated input type of UpdateProjectNext.
 type UpdateProjectNextInput struct {
+
+	// The ID of the Project to update. This field is required. **Upcoming Change on 2023-01-01 UTC** **Description:** `projectId` will be removed. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement. **Reason:** The `ProjectNext` API is deprecated in favour of the more capable `ProjectV2` API. (Optional.)
+	ProjectID *ID `json:"projectId,omitempty"`
+	// Set the title of the project. **Upcoming Change on 2023-01-01 UTC** **Description:** `title` will be removed. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement. **Reason:** The `ProjectNext` API is deprecated in favour of the more capable `ProjectV2` API. (Optional.)
+	Title *String `json:"title,omitempty"`
+	// Set the readme description of the project. **Upcoming Change on 2023-01-01 UTC** **Description:** `description` will be removed. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement. **Reason:** The `ProjectNext` API is deprecated in favour of the more capable `ProjectV2` API. (Optional.)
+	Description *String `json:"description,omitempty"`
+	// Set the short description of the project. **Upcoming Change on 2023-01-01 UTC** **Description:** `shortDescription` will be removed. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement. **Reason:** The `ProjectNext` API is deprecated in favour of the more capable `ProjectV2` API. (Optional.)
+	ShortDescription *String `json:"shortDescription,omitempty"`
+	// Set the project to closed or open. **Upcoming Change on 2023-01-01 UTC** **Description:** `closed` will be removed. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement. **Reason:** The `ProjectNext` API is deprecated in favour of the more capable `ProjectV2` API. (Optional.)
+	Closed *Boolean `json:"closed,omitempty"`
+	// Set the project to public or private. **Upcoming Change on 2023-01-01 UTC** **Description:** `public` will be removed. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement. **Reason:** The `ProjectNext` API is deprecated in favour of the more capable `ProjectV2` API. (Optional.)
+	Public *Boolean `json:"public,omitempty"`
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
+// UpdateProjectNextItemFieldInput is an autogenerated input type of UpdateProjectNextItemField.
+type UpdateProjectNextItemFieldInput struct {
+
+	// The ID of the Project. This field is required. (Optional.)
+	ProjectID *ID `json:"projectId,omitempty"`
+	// The id of the item to be updated. This field is required. **Upcoming Change on 2023-01-01 UTC** **Description:** `itemId` will be removed. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement. **Reason:** The `ProjectNext` API is deprecated in favour of the more capable `ProjectV2` API. (Optional.)
+	ItemID *ID `json:"itemId,omitempty"`
+	// The id of the field to be updated. **Upcoming Change on 2023-01-01 UTC** **Description:** `fieldId` will be removed. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement. **Reason:** The `ProjectNext` API is deprecated in favour of the more capable `ProjectV2` API. (Optional.)
+	FieldID *ID `json:"fieldId,omitempty"`
+	// The value which will be set on the field. This field is required. **Upcoming Change on 2023-01-01 UTC** **Description:** `value` will be removed. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement. **Reason:** The `ProjectNext` API is deprecated in favour of the more capable `ProjectV2` API. (Optional.)
+	Value *String `json:"value,omitempty"`
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
+// UpdateProjectV2DraftIssueInput is an autogenerated input type of UpdateProjectV2DraftIssue.
+type UpdateProjectV2DraftIssueInput struct {
+	// The ID of the draft issue to update. (Required.)
+	DraftIssueID ID `json:"draftIssueId"`
+
+	// The title of the draft issue. (Optional.)
+	Title *String `json:"title,omitempty"`
+	// The body of the draft issue. (Optional.)
+	Body *String `json:"body,omitempty"`
+	// The IDs of the assignees of the draft issue. (Optional.)
+	AssigneeIDs *[]ID `json:"assigneeIds,omitempty"`
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
+// UpdateProjectV2Input is an autogenerated input type of UpdateProjectV2.
+type UpdateProjectV2Input struct {
 	// The ID of the Project to update. (Required.)
 	ProjectID ID `json:"projectId"`
 
 	// Set the title of the project. (Optional.)
 	Title *String `json:"title,omitempty"`
-	// Set the readme description of the project. (Optional.)
-	Description *String `json:"description,omitempty"`
 	// Set the short description of the project. (Optional.)
 	ShortDescription *String `json:"shortDescription,omitempty"`
+	// Set the readme description of the project. (Optional.)
+	Readme *String `json:"readme,omitempty"`
 	// Set the project to closed or open. (Optional.)
 	Closed *Boolean `json:"closed,omitempty"`
 	// Set the project to public or private. (Optional.)
@@ -2700,17 +3046,30 @@ type UpdateProjectNextInput struct {
 	ClientMutationID *String `json:"clientMutationId,omitempty"`
 }
 
-// UpdateProjectNextItemFieldInput is an autogenerated input type of UpdateProjectNextItemField.
-type UpdateProjectNextItemFieldInput struct {
+// UpdateProjectV2ItemFieldValueInput is an autogenerated input type of UpdateProjectV2ItemFieldValue.
+type UpdateProjectV2ItemFieldValueInput struct {
 	// The ID of the Project. (Required.)
 	ProjectID ID `json:"projectId"`
-	// The id of the item to be updated. (Required.)
+	// The ID of the item to be updated. (Required.)
 	ItemID ID `json:"itemId"`
+	// The ID of the field to be updated. (Required.)
+	FieldID ID `json:"fieldId"`
 	// The value which will be set on the field. (Required.)
-	Value String `json:"value"`
+	Value ProjectV2FieldValue `json:"value"`
 
-	// The id of the field to be updated. (Optional.)
-	FieldID *ID `json:"fieldId,omitempty"`
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
+// UpdateProjectV2ItemPositionInput is an autogenerated input type of UpdateProjectV2ItemPosition.
+type UpdateProjectV2ItemPositionInput struct {
+	// The ID of the Project. (Required.)
+	ProjectID ID `json:"projectId"`
+	// The ID of the item to be moved. (Required.)
+	ItemID ID `json:"itemId"`
+
+	// The ID of the item to position this item after. If omitted or set to null the item will be moved to top. (Optional.)
+	AfterID *ID `json:"afterId,omitempty"`
 	// A unique identifier for the client performing the mutation. (Optional.)
 	ClientMutationID *String `json:"clientMutationId,omitempty"`
 }
@@ -2807,6 +3166,19 @@ type UpdateRepositoryInput struct {
 	HasIssuesEnabled *Boolean `json:"hasIssuesEnabled,omitempty"`
 	// Indicates if the repository should have the project boards feature enabled. (Optional.)
 	HasProjectsEnabled *Boolean `json:"hasProjectsEnabled,omitempty"`
+	// Indicates if the repository should have the discussions feature enabled. (Optional.)
+	HasDiscussionsEnabled *Boolean `json:"hasDiscussionsEnabled,omitempty"`
+	// A unique identifier for the client performing the mutation. (Optional.)
+	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
+// UpdateRepositoryWebCommitSignoffSettingInput is an autogenerated input type of UpdateRepositoryWebCommitSignoffSetting.
+type UpdateRepositoryWebCommitSignoffSettingInput struct {
+	// The ID of the repository to update. (Required.)
+	RepositoryID ID `json:"repositoryId"`
+	// Indicates if the repository should require signoff on web-based commits. (Required.)
+	WebCommitSignoffRequired Boolean `json:"webCommitSignoffRequired"`
+
 	// A unique identifier for the client performing the mutation. (Optional.)
 	ClientMutationID *String `json:"clientMutationId,omitempty"`
 }
@@ -2918,4 +3290,12 @@ type VerifyVerifiableDomainInput struct {
 
 	// A unique identifier for the client performing the mutation. (Optional.)
 	ClientMutationID *String `json:"clientMutationId,omitempty"`
+}
+
+// WorkflowRunOrder represents ways in which lists of workflow runs can be ordered upon return.
+type WorkflowRunOrder struct {
+	// The field by which to order workflows. (Required.)
+	Field WorkflowRunOrderField `json:"field"`
+	// The direction in which to order workflow runs by the specified field. (Required.)
+	Direction OrderDirection `json:"direction"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -682,7 +682,7 @@ github.com/securego/gosec/v2/rules
 # github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c
 ## explicit
 github.com/shazow/go-diff/difflib
-# github.com/shurcooL/githubv4 v0.0.0-20220520033151-0b4e3294ff00
+# github.com/shurcooL/githubv4 v0.0.0-20221126192849-0b5c4c7994eb
 ## explicit
 github.com/shurcooL/githubv4
 # github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29

--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -88,6 +88,7 @@ The following arguments are supported:
 * `allows_deletions` - (Optional) Boolean, setting this to `true` to allow the branch to be deleted.
 * `allows_force_pushes` - (Optional) Boolean, setting this to `true` to allow force pushes on the branch.
 * `blocks_creations` - (Optional) Boolean, setting this to `true` to block creating the branch.
+* `lock_branch` - (Optional) Boolean, Setting this to `true` will make the branch read-only and preventing any pushes to it. Defaults to `false`
 
 ### Required Status Checks
 
@@ -106,7 +107,8 @@ The following arguments are supported:
 * `pull_request_bypassers`: (Optional) The list of actor Names/IDs that are allowed to bypass pull request requirements. Actor names must either begin with a "/" for users or the organization name followed by a "/" for teams.
 * `require_code_owner_reviews`: (Optional) Require an approved review in pull requests including files with a designated code owner. Defaults to `false`.
 * `required_approving_review_count`: (Optional) Require x number of approvals to satisfy branch protection requirements. If this is specified it must be a number between 0-6. This requirement matches GitHub's API, see the upstream [documentation](https://developer.github.com/v3/repos/branches/#parameters-1) for more information.
-
+  (https://developer.github.com/v3/repos/branches/#parameters-1) for more information.
+* `require_last_push_approval`: (Optional) Require that The most recent push must be approved by someone other than the last pusher.  Defaults to `false`
 
 ## Import
 


### PR DESCRIPTION
<!-- Issues are required for both bug fixes and features. -->
Resolves #1352 (at least for the v4 version of branch protection)
Resolves #1341 (at least for the v4 version of branch protection)
----

## Behavior
This enables two new options [introduced in October](https://github.blog/changelog/2022-10-20-new-branch-protections-last-pusher-and-locked-branch/) around branch protections, specifically, the ability to require the last approval be from someone besides the last person to push to the branch (for the case that multiple people are working on the same branch), as well as the ability to lock branches.

The new option did require upgrading shurcooL/githubv4.

### Before the change?
* This can't be changed via terraform

### After the change?
* These options are available for managing the state of these branch protection options


### Other information
* N/A

----

## Additional info

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [X] No

If `Yes`, what's the impact:  

* N/A


### Pull request type
`Type: Feature`

----

### Manual Testing:

Overrode terraform to use by locally built version via dev.tfrc, and these were the results (with repo/org names redacted):

`main.tf`:
```terraform
terraform {
  required_providers {
    github = {
      source  = "integrations/github"
      version = "~> 5.0"
    }
  }
}

data "github_repository" "test" {
  full_name = "REDACTED/REDACTED"
}

resource "github_branch_protection" "example" {
  repository_id = data.github_repository.test.node_id
  pattern = "test"

  required_pull_request_reviews {
    require_last_push_approval = true
  }

  lock_branch = true
}
```

<img width="1154" alt="Screenshot 2022-12-02 at 1 35 34 PM" src="https://user-images.githubusercontent.com/839261/205394150-9b0cdeee-e1bb-42cb-82cb-f55c9e9591ec.png">

Branch protection rules created (in two screenshots because of the size of the page)
<img width="795" alt="Screenshot 2022-12-02 at 1 35 55 PM" src="https://user-images.githubusercontent.com/839261/205394261-ac8e2be0-9bb1-47e2-a6f6-9bf2237050d9.png">
<img width="796" alt="Screenshot 2022-12-02 at 1 36 01 PM" src="https://user-images.githubusercontent.com/839261/205394277-97dae20f-5b55-4db6-a069-1a6e5b7b524b.png">
