### PR TITLE
bugfix: include empty Checks array on v3 branch protection creation

### DIFF
--- a/github/resource_github_branch_protection_v3_utils.go
+++ b/github/resource_github_branch_protection_v3_utils.go
@@ -193,6 +193,11 @@ func expandRequiredStatusChecks(d *schema.ResourceData) (*github.RequiredStatusC
 
 			contexts := expandNestedSet(m, "contexts")
 			rsc.Contexts = contexts
+
+			// Contexts parameter is deprecated and Checks can not be nil
+			// Bug: https://github.com/google/go-github/issues/2467
+			// RequiredStatusChecksRequest: https://github.com/google/go-github/blob/master/github/repos.go#L992
+			rsc.Checks = []*github.RequiredStatusCheck{}
 		}
 		return rsc, nil
 	}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #1307 #1147

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Branch protections can not be created due to a nil error on the upstream Github API.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The nil value is now passed as an empty array which causes the branch protection to be applied successfully.


### Other information
<!-- Any other information that is important to this PR  -->

* Aims to resolve this issue https://github.com/integrations/terraform-provider-github/issues/1307 by implementing the upstream suggestion for resolution as proposed here https://github.com/google/go-github/issues/2467#issuecomment-1250072559


----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

