### PR TITLE
Updates workflow to use PR targets for RW workflow actions

### DIFF
--- a/.github/workflows/add_to_octokit_project.yml
+++ b/.github/workflows/add_to_octokit_project.yml
@@ -5,6 +5,8 @@ on:
     types: [reopened, opened]
   pull_request:
     types: [reopened, opened]
+  pull_request_target:
+    types: [reopened, opened]
     
 jobs:
   add-to-project:
@@ -15,5 +17,5 @@ jobs:
         with:
           project-url: https://github.com/orgs/octokit/projects/10
           github-token: ${{ secrets.OCTOKITBOT_PROJECT_ACTION_TOKEN }}
-          labeled: 'Status: Stale'
+          labeled: "Status: Stale"
           label-operator: NOT


### PR DESCRIPTION
From: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

> Warning: For workflows that are triggered by the pull_request_target event, the GITHUB_TOKEN is granted read/write repository permission unless the permissions key is specified and the workflow can access secrets, even when it is triggered from a fork. Although the workflow runs in the context of the base of the pull request, you should make sure that you do not check out, build, or run untrusted code from the pull request with this event. Additionally, any caches share the same scope as the base branch. To help prevent cache poisoning, you should not save the cache if there is a possibility that the cache contents were altered. For more information, see "[Keeping your GitHub Actions and workflows secure: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests)" on the GitHub Security Lab website.

We need this action to be read/write.