### PR TITLE
fix: Add github_repository migration to remove `branches`

### DIFF
--- a/github/migrate_github_repository.go
+++ b/github/migrate_github_repository.go
@@ -1,0 +1,39 @@
+package github
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"log"
+	"strings"
+)
+
+func resourceGithubRepositoryMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Printf("[INFO] Found GitHub Repository State v0; migrating to v1")
+		return migrateGithubRepositoryStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("unexpected schema version: %d", v)
+	}
+}
+
+func migrateGithubRepositoryStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Printf("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] GitHub Repository Attributes before migration: %#v", is.Attributes)
+
+	prefix := "branches."
+
+	for k := range is.Attributes {
+		if strings.HasPrefix(k, prefix) {
+			delete(is.Attributes, k)
+		}
+	}
+
+	log.Printf("[DEBUG] GitHub Repository Attributes after State Migration: %#v", is.Attributes)
+
+	return is, nil
+}

--- a/github/migrate_github_repository_test.go
+++ b/github/migrate_github_repository_test.go
@@ -1,0 +1,30 @@
+package github
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestMigrateGithubRepositoryStateV0toV1(t *testing.T) {
+	oldAttributes := map[string]string{
+		"branches.#":           "1",
+		"branches.0.name":      "foobar",
+		"branches.0.protected": "false",
+	}
+
+	newState, err := migrateGithubRepositoryStateV0toV1(&terraform.InstanceState{
+		ID:         "nonempty",
+		Attributes: oldAttributes,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedAttributes := map[string]string{}
+	if !reflect.DeepEqual(newState.Attributes, expectedAttributes) {
+		t.Fatalf("Expected attributes:\n%#v\n\nGiven:\n%#v\n",
+			expectedAttributes, newState.Attributes)
+	}
+}

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -27,6 +27,9 @@ func resourceGithubRepository() *schema.Resource {
 			},
 		},
 
+		SchemaVersion: 1,
+		MigrateState:  resourceGithubRepositoryMigrateState,
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
Resolves https://github.com/integrations/terraform-provider-github/issues/1343

----

## Behavior

### Before the change?
* Users with state files before v5 were unable to upgrade to v5 without removing `branches` from the state

### After the change?
* The schema migration will automatically remove `branches` from pre-v5 states


----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

