### PR TITLE
feat: Add the ability to set the action and reusable workflow access level

### DIFF
--- a/website/docs/r/actions_repository_permissions.html.markdown
+++ b/website/docs/r/actions_repository_permissions.html.markdown
@@ -8,7 +8,7 @@ description: |-
 # github_actions_repository_permissions
 
 This resource allows you to enable and manage GitHub Actions permissions for a given repository.
-You must have admin access to an repository to use this resource.
+You must have admin access to a repository to use this resource.
 
 ## Example Usage
 
@@ -18,6 +18,7 @@ resource "github_repository" "example" {
 }
 
 resource "github_actions_repository_permissions" "test" {
+  access_level    = "user"
   allowed_actions = "selected"
   allowed_actions_config {
     github_owned_allowed = true
@@ -36,6 +37,7 @@ The following arguments are supported:
 * `allowed_actions`        - (Optional) The permissions policy that controls the actions that are allowed to run. Can be one of: `all`, `local_only`, or `selected`.
 * `enabled`                - (Optional) Should GitHub actions be enabled on this repository?
 * `allowed_actions_config` - (Optional) Sets the actions that are allowed in an repository. Only available when `allowed_actions` = `selected`. See [Allowed Actions Config](#allowed-actions-config) below for details.
+* `access_level`           - (Optional) Sets the level of access that workflows outside of this repository have to actions and resuable workflows in this repository.  Can be one of: `none`, `user`, `organization`, or `enterprise`.
 
 ### Allowed Actions Config
 

--- a/website/docs/r/actions_repository_permissions.html.markdown
+++ b/website/docs/r/actions_repository_permissions.html.markdown
@@ -36,8 +36,8 @@ The following arguments are supported:
 * `repository`             - (Required) The GitHub repository
 * `allowed_actions`        - (Optional) The permissions policy that controls the actions that are allowed to run. Can be one of: `all`, `local_only`, or `selected`.
 * `enabled`                - (Optional) Should GitHub actions be enabled on this repository?
-* `allowed_actions_config` - (Optional) Sets the actions that are allowed in an repository. Only available when `allowed_actions` = `selected`. See [Allowed Actions Config](#allowed-actions-config) below for details.
-* `access_level`           - (Optional) Sets the level of access that workflows outside of this repository have to actions and resuable workflows in this repository.  Can be one of: `none`, `user`, `organization`, or `enterprise`.
+* `allowed_actions_config` - (Optional) Sets the actions that are allowed in a repository. Only available when `allowed_actions` = `selected`. See [Allowed Actions Config](#allowed-actions-config) below for details.
+* `access_level`           - (Optional) Sets the level of access that workflows outside of this repository have to actions and reusable workflows in this repository.  Can be one of: `none`, `user`, `organization`, or `enterprise`.
 
 ### Allowed Actions Config
 


### PR DESCRIPTION
Resolves #1418 

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->
* There was no way to specify the action access setting to allow other repositories to use your private/internal repositories actions and reusable workflows in their own.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
* This allows you to set whether or not another repository in within your user, organization, or enterprise can use this repositories actions and reusable workflows.


### Other information
<!-- Any other information that is important to this PR  -->

* Tested via unit tests for both user and organization, see screenshots below
* I did find that `allowed_actions` needed to be set when using this, so there may need to be some additional logic to allow this setting alone.  But if that is considered acceptable I will leave it.

----

## Additional info

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [X] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Feature/model/API additions: `Type: Feature`

----

![Screen Shot 2022-12-17 at 2 17 48 PM](https://user-images.githubusercontent.com/839261/208268690-25b89255-43da-4e5d-9893-c0affff5f7db.png)
![Screen Shot 2022-12-17 at 2 44 35 PM](https://user-images.githubusercontent.com/839261/208268691-3e741ab0-54aa-4ed8-9089-c4458f651004.png)
