### PR TITLE
feat: Add ability to enable GitHub Discussions on repositories

### DIFF
--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -50,6 +50,10 @@ func dataSourceGithubRepository() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"has_discussions": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"has_projects": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -244,6 +248,7 @@ func dataSourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("private", repo.GetPrivate())
 	d.Set("visibility", repo.GetVisibility())
 	d.Set("has_issues", repo.GetHasIssues())
+	d.Set("has_discussions", repo.GetHasDiscussions())
 	d.Set("has_wiki", repo.GetHasWiki())
 	d.Set("is_template", repo.GetIsTemplate())
 	d.Set("allow_merge_commit", repo.GetAllowMergeCommit())

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -113,6 +113,10 @@ func resourceGithubRepository() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"has_discussions": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"has_projects": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -356,6 +360,7 @@ func resourceGithubRepositoryObject(d *schema.ResourceData) *github.Repository {
 		Visibility:               github.String(calculateVisibility(d)),
 		HasDownloads:             github.Bool(d.Get("has_downloads").(bool)),
 		HasIssues:                github.Bool(d.Get("has_issues").(bool)),
+		HasDiscussions:           github.Bool(d.Get("has_discussions").(bool)),
 		HasProjects:              github.Bool(d.Get("has_projects").(bool)),
 		HasWiki:                  github.Bool(d.Get("has_wiki").(bool)),
 		IsTemplate:               github.Bool(d.Get("is_template").(bool)),
@@ -516,6 +521,7 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("private", repo.GetPrivate())
 	d.Set("visibility", repo.GetVisibility())
 	d.Set("has_issues", repo.GetHasIssues())
+	d.Set("has_discussions", repo.GetHasDiscussions())
 	d.Set("has_projects", repo.GetHasProjects())
 	d.Set("has_wiki", repo.GetHasWiki())
 	d.Set("is_template", repo.GetIsTemplate())

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -24,7 +24,7 @@ func TestAccGithubRepositories(t *testing.T) {
 
 			  name         = "tf-acc-test-create-%[1]s"
 			  description  = "Terraform acceptance tests %[1]s"
-
+			  has_discussions      = true
 			  has_issues           = true
 			  has_wiki             = true
 			  has_downloads        = true
@@ -42,6 +42,10 @@ func TestAccGithubRepositories(t *testing.T) {
 		check := resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(
 				"github_repository.test", "has_issues",
+				"true",
+			),
+			resource.TestCheckResourceAttr(
+				"github_repository.test", "has_discussions",
 				"true",
 			),
 			resource.TestCheckResourceAttr(

--- a/website/docs/d/repository.html.markdown
+++ b/website/docs/d/repository.html.markdown
@@ -39,6 +39,8 @@ The following arguments are supported:
 
 * `has_issues` - Whether the repository has GitHub Issues enabled.
 
+* `has_discussions` - Whether the repository has GitHub Discussions enabled.
+
 * `has_projects` - Whether the repository has the GitHub Projects enabled.
 
 * `has_wiki` - Whether the repository has the GitHub Wiki enabled.

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -63,7 +63,7 @@ The following arguments are supported:
 * `has_issues` - (Optional) Set to `true` to enable the GitHub Issues features
   on the repository.
 
-* `has_discussions` - (Optional) Set to `true` to enable GitHub Discussions on the repository.
+* `has_discussions` - (Optional) Set to `true` to enable GitHub Discussions on the repository. Defaults to `false`.
 
 * `has_projects` - (Optional) Set to `true` to enable the GitHub Projects features on the repository. Per the GitHub [documentation](https://developer.github.com/v3/repos/#create) when in an organization that has disabled repository projects it will default to `false` and will otherwise default to `true`. If you specify `true` when it has been disabled it will return an error.
 

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -63,6 +63,8 @@ The following arguments are supported:
 * `has_issues` - (Optional) Set to `true` to enable the GitHub Issues features
   on the repository.
 
+* `has_discussions` - (Optional) Set to `true` to enable GitHub Discussions on the repository.
+
 * `has_projects` - (Optional) Set to `true` to enable the GitHub Projects features on the repository. Per the GitHub [documentation](https://developer.github.com/v3/repos/#create) when in an organization that has disabled repository projects it will default to `false` and will otherwise default to `true`. If you specify `true` when it has been disabled it will return an error.
 
 * `has_wiki` - (Optional) Set to `true` to enable the GitHub Wiki features on


### PR DESCRIPTION
Resolves:
*  #1442 

----

## Behavior

### Before the change?
The `has_discussions` value from the repositories API is already available though the existing accessors but is not exposed though the `github_repository` resource and cannot be viewed or changed though Terraform.

### After the change?
* Exposed `has_discussions` as a boolean argument into `github_repository`
```hcl
resource "github_repository" "discussions-true" {
  name        = "discussions-true"
  visibility  = "private"
  has_issues = true
  has_discussions = true
}
```
* Preserved default behavior of `false` if not present
* Added `has_discussions` to the `github_repository` datasource
* Updated documentation


### Other information


----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  


### Pull request type

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

