### PR TITLE
feat: add repo action access level resource

### DIFF
--- a/github/provider.go
+++ b/github/provider.go
@@ -93,6 +93,7 @@ func Provider() terraform.ResourceProvider {
 			"github_actions_organization_permissions":            resourceGithubActionsOrganizationPermissions(),
 			"github_actions_organization_secret":                 resourceGithubActionsOrganizationSecret(),
 			"github_actions_organization_secret_repositories":    resourceGithubActionsOrganizationSecretRepositories(),
+			"github_actions_repository_access_level":             resourceGithubActionsRepositoryAccessLevel(),
 			"github_actions_repository_permissions":              resourceGithubActionsRepositoryPermissions(),
 			"github_actions_runner_group":                        resourceGithubActionsRunnerGroup(),
 			"github_actions_secret":                              resourceGithubActionsSecret(),

--- a/github/resource_github_actions_repository_access_level.go
+++ b/github/resource_github_actions_repository_access_level.go
@@ -1,0 +1,86 @@
+package github
+
+import (
+	"context"
+	"github.com/google/go-github/v48/github"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceGithubActionsRepositoryAccessLevel() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGithubActionsRepositoryAccessLevelCreateOrUpdate,
+		Read:   resourceGithubActionsRepositoryAccessLevelRead,
+		Update: resourceGithubActionsRepositoryAccessLevelCreateOrUpdate,
+		Delete: resourceGithubActionsRepositoryAccessLevelDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"access_level": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"none", "user", "organization", "enterprise"}, false),
+			},
+			"repository": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, 100),
+			},
+		},
+	}
+}
+
+func resourceGithubActionsRepositoryAccessLevelCreateOrUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
+	repoName := d.Get("repository").(string)
+	ctx := context.Background()
+	if !d.IsNewResource() {
+		ctx = context.WithValue(ctx, ctxId, d.Id())
+	}
+
+	accessLevel := d.Get("access_level").(string)
+	actionAccessLevel := github.RepositoryActionsAccessLevel{
+		AccessLevel: github.String(accessLevel),
+	}
+
+	_, err := client.Repositories.EditActionsAccessLevel(ctx, owner, repoName, actionAccessLevel)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(repoName)
+	return resourceGithubActionsRepositoryAccessLevelRead(d, meta)
+}
+
+func resourceGithubActionsRepositoryAccessLevelRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
+	repoName := d.Id()
+	ctx := context.WithValue(context.Background(), ctxId, repoName)
+
+	actionAccessLevel, _, err := client.Repositories.GetActionsAccessLevel(ctx, owner, repoName)
+	if err != nil {
+		return err
+	}
+
+	_ = d.Set("access_level", actionAccessLevel.GetAccessLevel())
+
+	return nil
+}
+
+func resourceGithubActionsRepositoryAccessLevelDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
+	repoName := d.Id()
+	ctx := context.WithValue(context.Background(), ctxId, repoName)
+
+	actionAccessLevel := github.RepositoryActionsAccessLevel{
+		AccessLevel: github.String("none"),
+	}
+	_, err := client.Repositories.EditActionsAccessLevel(ctx, owner, repoName, actionAccessLevel)
+
+	return err
+}

--- a/github/resource_github_actions_repository_access_level_test.go
+++ b/github/resource_github_actions_repository_access_level_test.go
@@ -1,0 +1,108 @@
+package github
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"testing"
+)
+
+func TestAccGithubActionsRepositoryAccessLevel(t *testing.T) {
+	t.Run("test setting of user action access level", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		accessLevel := "user"
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name        = "tf-acc-test-topic-%[1]s"
+				description = "Terraform acceptance tests %[1]s"
+				topics		= ["terraform", "testing"]
+				visibility  = "private"
+			}
+
+			resource "github_actions_repository_access_level" "test" {
+				access_level = "%s"
+				repository   = github_repository.test.name
+			}
+		`, randomID, accessLevel)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_actions_repository_access_level.test", "access_level", accessLevel,
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			t.Skip("organization account not supported for this input")
+		})
+	})
+
+	t.Run("test setting of organization action access level", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		accessLevel := "organization"
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name        = "tf-acc-test-topic-%[1]s"
+				description = "Terraform acceptance tests %[1]s"
+				topics		= ["terraform", "testing"]
+				visibility  = "private"
+			}
+
+			resource "github_actions_repository_access_level" "test" {
+				access_level = "%s"
+				repository   = github_repository.test.name
+			}
+		`, randomID, accessLevel)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_actions_repository_access_level.test", "access_level", accessLevel,
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			t.Skip("individual account not supported for this input")
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+}

--- a/website/docs/r/actions_repository_access_level.html.markdown
+++ b/website/docs/r/actions_repository_access_level.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "github"
+page_title: "GitHub: github_actions_repository_access_level"
+description: |-
+  Manages Actions and Reusable Workflow access for a GitHub repository
+---
+
+# github_actions_repository_access_level
+
+This resource allows you to set the access level of a non-public repositories actions and reusable workflows for use in other repositories.
+You must have admin access to a repository to use this resource.
+
+## Example Usage
+
+```hcl
+resource "github_repository" "example" {
+  name       = "my-repository"
+  visibility = "private"
+}
+
+resource "github_actions_repository_access_level" "test" {
+  access_level = "user"
+  repository   = github_repository.example.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `repository`   - (Required) The GitHub repository
+* `access_level` - (Required) Where the actions or reusable workflows of the repository may be used. Possible values are `none`, `user`, `organization`, or `enterprise`. 
+
+## Import
+
+This resource can be imported using the name of the GitHub repository:
+
+```
+$ terraform import github_actions_repository_access_level.test <github_repository_name>
+```

--- a/website/github.erb
+++ b/website/github.erb
@@ -125,6 +125,9 @@
               <a href="/docs/providers/github/r/actions_organization_secret_repositories.html">github_actions_organization_secret_repositories</a>
             </li>
             <li>
+              <a href="/docs/providers/github/r/actions_repository_access_level.html">github_actions_repository_permissions</a>
+            </li>
+            <li>
               <a href="/docs/providers/github/r/actions_repository_permissions.html">github_actions_repository_permissions</a>
             </li>
             <li>


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #1418 

----

## Behavior

### Before the change?
* There was no way to specify the action access setting to allow other repositories to use your private/internal repositories actions and reusable workflows in their own.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* This allows you to set whether or not another repository in within your user, organization, or enterprise can use this repositories actions and reusable workflows.


### Other information
<!-- Any other information that is important to this PR  -->

* I was having trouble getting the website testing to work, so while the docs change should work, I can't say for sure.

----

## Additional info

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [X] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Feature/model/API additions: `Type: Feature`
----

### Automated Testing
The tests are broken up by individual and organization as they have a different set of inputs that are valid.

Organization Test:
![Screenshot 2022-12-20 192658](https://user-images.githubusercontent.com/839261/208819817-5438b79a-f317-42fb-89e8-0c144c556bd1.png)

Individual Test:
![Screenshot 2022-12-20 192711](https://user-images.githubusercontent.com/839261/208819822-88d2811d-ad8b-4367-895d-0f7c36439c51.png)

### Manual Testing
#### Individual User
```terraform
terraform {
  required_providers {
    github = {
      source = "integrations/github"
      version = "5.12.0"
    }
  }
}

provider "github" {
  owner = "wwsean08"
}

resource "github_actions_repository_access_level" "test" {
  access_level = "user"
  repository   = "test"
}
```
<img width="657" alt="Screen Shot 2022-12-21 at 10 39 10 AM" src="https://user-images.githubusercontent.com/839261/208979321-5e8893af-6786-4e7a-95c9-424e5ae05a92.png">

<img width="813" alt="Screen Shot 2022-12-21 at 10 31 17 AM" src="https://user-images.githubusercontent.com/839261/208978085-56ee0c2a-0660-4233-9084-63ab0f98d6b1.png">

#### Organization
```terraform
terraform {
  required_providers {
    github = {
      source = "integrations/github"
      version = "5.12.0"
    }
  }
}

provider "github" {
  owner = "test-organization-wwsean08"
}

resource "github_actions_repository_access_level" "test" {
  access_level = "organization"
  repository   = "test2"
}
```
<img width="665" alt="Screen Shot 2022-12-21 at 10 46 34 AM" src="https://user-images.githubusercontent.com/839261/208980831-45690220-5475-4af0-b359-f13368a1baba.png">
<img width="783" alt="Screen Shot 2022-12-21 at 10 46 53 AM" src="https://user-images.githubusercontent.com/839261/208980834-56192fda-a88c-4a70-a8e6-61a8af4e919f.png">


#### Enterprise
```terraform
terraform {
  required_providers {
    github = {
      source = "integrations/github"
      version = "5.12.0"
    }
  }
}

provider "github" {
  owner = "REDACTED"
}

resource "github_actions_repository_access_level" "test" {
  access_level = "enterprise"
  repository   = "sean-smith-test"
}
```

<img width="746" alt="Screen Shot 2022-12-21 at 10 36 36 AM" src="https://user-images.githubusercontent.com/839261/208978959-3ab837c2-f553-4655-a360-3c3eadf2bbd6.png">

<img width="812" alt="Screen Shot 2022-12-21 at 10 38 10 AM" src="https://user-images.githubusercontent.com/839261/208979350-f6ceb81c-0d05-47dd-8a4d-7d99b128ca4a.png">

#### Destroy
<img width="609" alt="Screen Shot 2022-12-21 at 10 47 19 AM" src="https://user-images.githubusercontent.com/839261/208980963-937569d3-96cd-4ef3-891e-a8f028347f5c.png">

<img width="800" alt="Screen Shot 2022-12-21 at 10 48 36 AM" src="https://user-images.githubusercontent.com/839261/208981047-585a389c-1d71-4576-895d-cb0087932280.png">
