### PR TITLE
feat: add parent team attributes to teams datasource

### DIFF
--- a/github/data_source_github_organization_teams.go
+++ b/github/data_source_github_organization_teams.go
@@ -66,6 +66,11 @@ func dataSourceGithubOrganizationTeams() *schema.Resource {
 							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						"parent": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
 					},
 				},
 			},
@@ -135,7 +140,6 @@ func flattenGitHubTeams(tq TeamsQuery) []interface{} {
 		t["name"] = team.Name
 		t["description"] = team.Description
 		t["privacy"] = team.Privacy
-
 		members := team.Members.Nodes
 		flatMembers := make([]string, len(members))
 
@@ -144,6 +148,12 @@ func flattenGitHubTeams(tq TeamsQuery) []interface{} {
 		}
 
 		t["members"] = flatMembers
+
+		parentTeam := make(map[string]interface{})
+		parentTeam["id"] = team.Parent.ID
+		parentTeam["slug"] = team.Parent.Slug
+		parentTeam["name"] = team.Parent.Name
+		t["parent"] = parentTeam
 
 		repositories := team.Repositories.Nodes
 

--- a/github/data_source_github_organization_teams_test.go
+++ b/github/data_source_github_organization_teams_test.go
@@ -57,6 +57,7 @@ func TestAccGithubOrganizationTeamsDataSource(t *testing.T) {
 		check := resource.ComposeAggregateTestCheckFunc(
 			resource.TestCheckResourceAttrSet("data.github_organization_teams.root_teams", "teams.0.id"),
 			resource.TestCheckResourceAttrSet("data.github_organization_teams.root_teams", "teams.0.node_id"),
+			resource.TestCheckResourceAttr("data.github_organization_teams.root_teams", "teams.0.parent.id", ""),
 		)
 
 		testCase := func(t *testing.T, mode string) {

--- a/github/util_v4_teams.go
+++ b/github/util_v4_teams.go
@@ -13,7 +13,12 @@ type TeamsQuery struct {
 				Name        githubv4.String
 				Description githubv4.String
 				Privacy     githubv4.String
-				Members     struct {
+				Parent      struct {
+					ID   githubv4.String
+					Slug githubv4.String
+					Name githubv4.String
+				} `graphql:"parentTeam"`
+				Members struct {
 					Nodes []struct {
 						Login githubv4.String
 					}

--- a/website/docs/d/organization_teams.html.markdown
+++ b/website/docs/d/organization_teams.html.markdown
@@ -44,3 +44,4 @@ The `team` block consists of:
  * `privacy` - the team's privacy type.
  * `members` - List of team members. Not returned if `summary_only = true`
  * `repositories` - List of team repositories. Not returned if `summary_only = true`
+ * `parent` - the parent team.


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Parent team is not returned

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* When getting teams from datasource, return for each team the parent team with the following attributes: ID, slug, name.

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

