### PR TITLE
updated pull_request_bypassers structs for app, like push actors

### DIFF
--- a/github/util_v4_branch_protection.go
+++ b/github/util_v4_branch_protection.go
@@ -31,6 +31,7 @@ type DismissalActorTypes struct {
 
 type BypassPullRequestActorTypes struct {
 	Actor struct {
+		App  Actor     `graphql:"... on App"`
 		Team Actor     `graphql:"... on Team"`
 		User ActorUser `graphql:"... on User"`
 	}
@@ -329,7 +330,7 @@ func setBypassPullRequestActorIDs(actors []BypassPullRequestActorTypes, data Bra
 	for _, a := range actors {
 		IsID := false
 		for _, v := range data.BypassPullRequestActorIDs {
-			if (a.Actor.Team.ID != nil && a.Actor.Team.ID.(string) == v) || (a.Actor.User.ID != nil && a.Actor.User.ID.(string) == v) {
+			if (a.Actor.Team.ID != nil && a.Actor.Team.ID.(string) == v) || (a.Actor.User.ID != nil && a.Actor.User.ID.(string) == v) || (a.Actor.App.ID != nil && a.Actor.App.ID.(string) == v) {
 				bypassActors = append(bypassActors, v)
 				IsID = true
 				break
@@ -342,6 +343,9 @@ func setBypassPullRequestActorIDs(actors []BypassPullRequestActorTypes, data Bra
 			}
 			if a.Actor.User.Login != "" {
 				bypassActors = append(bypassActors, "/"+string(a.Actor.User.Login))
+			}
+			if a.Actor.App != (Actor{}) {
+				bypassActors = append(bypassActors, a.Actor.App.ID.(string))
 			}
 		}
 	}


### PR DESCRIPTION
Resolves #1367 
----

## Behavior

### Before the change?
* Github apps added to the pull_request_bypassers would add correctly, but each plan/apply would re-add the app ID.


### After the change?

* terraform plan/apply will no longer see the app ID as invalid/missing when it exists (as expected).


### Other information

* Duplicated the logic from push actors

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features) (didn't see tests for push actors)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

### Pull request type

- Bugfix: `Type: Bug`

----