### PR TITLE
Document importance of submodule required_providers block

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -37,6 +37,8 @@ resource "github_membership" "membership_for_user_x" {
 }
 ```
 
+- You **must** add a `required_providers` block to every module that will create resources with this provider. If you do not explicitly require `integrations/github` in a submodule, your terraform run may [break in hard-to-troubleshoot ways](https://github.com/integrations/terraform-provider-github/issues/876#issuecomment-1303790559).
+
 Terraform 0.12 and earlier:
 
 ```terraform


### PR DESCRIPTION
Discussed over in #876, using implicit provider inheritance with this provider does not work, because terraform will prefer the `hashicorp/github` module by default.

Tagging @kfcampbell who requested the PR :)
