### PR TITLE
fix: skip anonymous tests that can't be done anonymously

### DIFF
--- a/github/data_source_github_repository_file_test.go
+++ b/github/data_source_github_repository_file_test.go
@@ -75,7 +75,7 @@ func TestAccGithubRepositoryFileDataSource(t *testing.T) {
 		}
 
 		t.Run("with an anonymous account", func(t *testing.T) {
-			testCase(t, anonymous)
+			t.Skip("anonymous account not supported for this operation")
 		})
 
 		t.Run("with an individual account", func(t *testing.T) {

--- a/github/data_source_github_tree_test.go
+++ b/github/data_source_github_tree_test.go
@@ -58,7 +58,7 @@ func TestAccGithubTreeDataSource(t *testing.T) {
 		}
 
 		t.Run("with an anonymous account", func(t *testing.T) {
-			testCase(t, anonymous)
+			t.Skip("anonymous account not supported for this operation")
 		})
 
 		t.Run("with an individual account", func(t *testing.T) {


### PR DESCRIPTION
This is in reference to #1414 but does not actually solve it.

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The tests would fail due to the requirement of a token, however you can't have a token with anonymous tests.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The tests no longer attempt to be run.


### Other information
<!-- Any other information that is important to this PR  -->
While working on #1414 I found these tests which will never work without a feature change and test rework as well.

----

## Additional info

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [X] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`

----

## Justification of Changes
### TestAccGithubRepositoryFileDataSource
In this test it tries to create a repo and file which can then be queried, which is not possible with no access token as an anonymous test would have.

My original idea was to create a test with a static file, however that failed as there is no `owner` attribute on the data source so the owner would get set to an empty string even with `GITHUB_OWNER` or `GITHUB_ORGANIZATION` set.

### TestAccGithubTreeDataSource
In this test it tries to create a repo which can then be queried, which is not possible with no access token as an anonymous test would have.

My original idea was to create a test with a static repo, however that failed as there is no `owner` attribute on the data source so the owner would get set to an empty string even with `GITHUB_OWNER` or `GITHUB_ORGANIZATION` set.