### PR TITLE
feat: Add capability to ignore non-existing invitations

### DIFF
--- a/github/resource_github_user_invitation_accepter.go
+++ b/github/resource_github_user_invitation_accepter.go
@@ -26,7 +26,7 @@ func resourceGithubUserInvitationAccepter() *schema.Resource {
 			"ignore_not_found": {
 				Type:     schema.TypeBool,
 				Required: false,
-				ForceNew: false,
+				ForceNew: true,
 			},
 		},
 	}

--- a/website/docs/r/user_invitation_accepter.html.markdown
+++ b/website/docs/r/user_invitation_accepter.html.markdown
@@ -28,9 +28,10 @@ provider "github" {
 }
 
 resource "github_user_invitation_accepter" "example" {
-  provider      = "github.invitee"
-  invitation_id = github_repository_collaborator.example.invitation_id
-} 
+  provider         = "github.invitee"
+  invitation_id    = github_repository_collaborator.example.invitation_id
+  ignore_not_found = true
+}
 ```
 
 ## Argument Reference
@@ -38,3 +39,4 @@ resource "github_user_invitation_accepter" "example" {
 The following arguments are supported:
 
 * `invitation_id` - (Required) ID of the invitation to accept
+* `ignore_not_found` - (Optional) Ignores invitations that are not found. This can be used to not fail when invitations might already have been accepted manually.


### PR DESCRIPTION
Part of #1157 (resolves one of two cases).

----

## Behavior

### Before the change?

`github_user_invitation_accepter` errors when an invite was already accepted or declined.

### After the change?

The behaviour is configurable with the `ignore_not_found` argument. The argument defaults to `false`, which does not change default behaviour.

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes (Please add the `Type: Breaking change` label)
- [X] No

### Pull request type

Please add the corresponding label for change this PR introduces:
- Feature/model/API additions: `Type: Feature`
