### PR TITLE
Add links to OpenID Connect subject claim customization template resources and data sources to github.erb

### DIFF
--- a/website/github.erb
+++ b/website/github.erb
@@ -14,6 +14,9 @@
           <a href="#">Data Sources</a>
           <ul class="nav nav-visible">
             <li>
+              <a href="/docs/providers/github/d/actions_organization_oidc_subject_claim_customization_template.html">actions_organization_oidc_subject_claim_customization_template</a>
+            </li>
+            <li>
               <a href="/docs/providers/github/d/actions_organization_registration_token.html">actions_organization_registration_token</a>
             </li>
             <li>
@@ -24,6 +27,9 @@
             </li>
             <li>
               <a href="/docs/providers/github/d/actions_registration_token.html">actions_registration_token</a>
+            </li>
+            <li>
+              <a href="/docs/providers/github/d/actions_repository_oidc_subject_claim_customization_template.html">actions_repository_oidc_subject_claim_customization_template</a>
             </li>
             <li>
               <a href="/docs/providers/github/d/actions_secrets.html">actions_secrets</a>
@@ -122,6 +128,9 @@
               <a href="/docs/providers/github/r/actions_organization_secret.html">github_actions_organization_secret</a>
             </li>
             <li>
+              <a href="/docs/providers/github/r/actions_organization_oidc_subject_claim_customization_template.html">github_actions_organization_oidc_subject_claim_customization_template</a>
+            </li>
+            <li>
               <a href="/docs/providers/github/r/actions_organization_permissions.html">github_actions_organization_permissions</a>
             </li>
             <li>
@@ -129,6 +138,9 @@
             </li>
             <li>
               <a href="/docs/providers/github/r/actions_repository_access_level.html">github_actions_repository_permissions</a>
+            </li>
+            <li>
+              <a href="/docs/providers/github/r/actions_repository_oidc_subject_claim_customization_template.html">github_actions_repository_oidc_subject_claim_customization_template</a>
             </li>
             <li>
               <a href="/docs/providers/github/r/actions_repository_permissions.html">github_actions_repository_permissions</a>


### PR DESCRIPTION
## Behavior

### Before the change?
There were missing links in `github.erb` for #1473.

### After the change?
The correct links have been added.

### Other information
None

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

### Pull request type
- Updates to docs or samples: `Type: Documentation`
