### PR TITLE
fix: Actually populate the visibility within the resulting object.

### DIFF
--- a/github/data_source_github_actions_organization_secrets.go
+++ b/github/data_source_github_actions_organization_secrets.go
@@ -60,6 +60,7 @@ func dataSourceGithubActionsOrganizationSecretsRead(d *schema.ResourceData, meta
 				"name":       secret.Name,
 				"created_at": secret.CreatedAt.String(),
 				"updated_at": secret.UpdatedAt.String(),
+				"visibility": secret.Visibility,
 			}
 			all_secrets = append(all_secrets, new_secret)
 

--- a/github/data_source_github_actions_organization_secrets_test.go
+++ b/github/data_source_github_actions_organization_secrets_test.go
@@ -18,7 +18,7 @@ func TestAccGithubActionsOrganizationSecretsDataSource(t *testing.T) {
 			resource "github_actions_organization_secret" "test" {
 				secret_name 		= "org_secret_1_%s"
 				plaintext_value = "foo"
-				visibility      = "private"
+				visibility      = "all" # going with all as it does not require a paid subscrption
 			}
 	`, randomID)
 
@@ -30,7 +30,7 @@ func TestAccGithubActionsOrganizationSecretsDataSource(t *testing.T) {
 		check := resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr("data.github_actions_organization_secrets.test", "secrets.#", "1"),
 			resource.TestCheckResourceAttr("data.github_actions_organization_secrets.test", "secrets.0.name", strings.ToUpper(fmt.Sprintf("ORG_SECRET_1_%s", randomID))),
-			resource.TestCheckResourceAttr("data.github_actions_organization_secrets.test", "secrets.0.visibility", "private"),
+			resource.TestCheckResourceAttr("data.github_actions_organization_secrets.test", "secrets.0.visibility", "all"),
 			resource.TestCheckResourceAttrSet("data.github_actions_organization_secrets.test", "secrets.0.created_at"),
 			resource.TestCheckResourceAttrSet("data.github_actions_organization_secrets.test", "secrets.0.updated_at"),
 		)


### PR DESCRIPTION
Found while working on #1414, however it doesn't resolve the issue.  I did a quick search and it doesn't look like anybody has reported this issue yet.

----

## Behavior

### Before the change?
* Currently `github_actions_organization_secrets` does not fill in the visibility field, leaving it blank on all requests

### After the change?
* The `github_actions_organization_secrets` field is filled in with the proper value


### Other information
* I change the test to create a secret with the `all` visibility, as `private` requires a paid subscription which many folks may not have, allowing for more people to work on this and be able to run the tests.

----

## Additional info

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [X] No

If `Yes`, what's the impact:  

* N/A


### Pull request type
Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`

----

## Testing
Tests were performed by running the acceptance test where I found this issue

### Before Change
<img width="1440" alt="Screenshot 2023-01-14 at 1 44 55 PM" src="https://user-images.githubusercontent.com/839261/212498505-a8ef9f71-8dbd-4fef-82ff-d10bb90e47dd.png">

### After Change
<img width="1430" alt="Screenshot 2023-01-14 at 1 44 14 PM" src="https://user-images.githubusercontent.com/839261/212498500-ec8f33f7-2d84-43b0-982c-be2be0a768ce.png">

