### PR TITLE
Fixing `github_repository_file` owner/org handling

### DIFF
--- a/github/data_source_github_repository_file_test.go
+++ b/github/data_source_github_repository_file_test.go
@@ -94,7 +94,7 @@ func TestAccGithubRepositoryFileDataSource(t *testing.T) {
 	})
 }
 
-func Test_dataSourceGithubRepositoryFileRead(t *testing.T) {
+func TestDataSourceGithubRepositoryFileRead(t *testing.T) {
 	// helper function to simplify marshalling.
 	marshal := func(t *testing.T, msg interface{}) string {
 		data, err := json.MarshalIndent(msg, "", "    ")

--- a/github/data_source_github_repository_file_test.go
+++ b/github/data_source_github_repository_file_test.go
@@ -1,19 +1,25 @@
 package github
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
 	"testing"
+
+	"github.com/google/go-github/v49/github"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func TestAccGithubRepositoryFileDataSource(t *testing.T) {
-
 	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
 	t.Run("read files", func(t *testing.T) {
-
 		config := fmt.Sprintf(`
 
 			resource "github_repository" "test" {
@@ -85,6 +91,191 @@ func TestAccGithubRepositoryFileDataSource(t *testing.T) {
 		t.Run("with an organization account", func(t *testing.T) {
 			testCase(t, organization)
 		})
+	})
+}
 
+func Test_dataSourceGithubRepositoryFileRead(t *testing.T) {
+	// helper function to simplify marshalling.
+	marshal := func(t *testing.T, msg interface{}) string {
+		data, err := json.MarshalIndent(msg, "", "    ")
+		if err != nil {
+			t.Fatalf("cant encode to json: %v", err)
+		}
+
+		return string(data)
+	}
+
+	sha := "some-test-sha"
+	committerName := "some-test-user"
+	committerEmail := "some-test-user@github.com"
+	commitMessage := "test commit message"
+
+	enc := "base64"
+	fileContent := "here-goes-content-of-our-glorious-config.json"
+	b64FileContent := base64.StdEncoding.EncodeToString([]byte(fileContent))
+
+	fileName := "test-file.json"
+	branch := "main"
+
+	// setting up some org/owner info
+	owner := "test-owner"
+	org := "test-org"
+	repo := "test-repo"
+
+	// preparing mashalled objects
+	branchRespBody := marshal(t, &github.Branch{Name: &branch})
+	repoContentRespBody := marshal(t, &github.RepositoryContent{
+		Encoding: &enc,
+		Content:  &b64FileContent,
+		SHA:      &sha,
+	})
+	repoCommitRespBody := marshal(t, &github.RepositoryCommit{
+		SHA: &sha,
+		Committer: &github.User{
+			Name:  &committerName,
+			Email: &committerEmail,
+		},
+		Commit: &github.Commit{
+			Message: &commitMessage,
+		},
+	})
+
+	t.Run("extracting org and repo if full_name is passed", func(t *testing.T) {
+		// test setup
+		repositoryFullName := fmt.Sprintf("%s/%s", org, repo)
+		expectedID := fmt.Sprintf("%s/%s", repo, fileName)
+		expectedRepo := "test-repo"
+
+		ts := githubApiMock([]*mockResponse{
+			{
+				ExpectedUri:  fmt.Sprintf("/repos/%s/%s/branches/%s", org, repo, branch),
+				ResponseBody: branchRespBody,
+				StatusCode:   http.StatusOK,
+			},
+			{
+				ExpectedUri:  fmt.Sprintf("/repos/%s/%s/contents/%s?ref=%s", org, repo, fileName, branch),
+				ResponseBody: repoContentRespBody,
+				StatusCode:   http.StatusOK,
+			},
+			{
+				ExpectedUri:  fmt.Sprintf("/repos/%s/%s/commits/%s", org, repo, sha),
+				ResponseBody: repoCommitRespBody,
+				StatusCode:   http.StatusOK,
+			},
+			{
+				ExpectedUri:  fmt.Sprintf("/repos/%s/%s/commits", org, repo),
+				ResponseBody: repoCommitRespBody,
+				StatusCode:   http.StatusOK,
+			},
+		})
+		defer ts.Close()
+
+		httpCl := http.DefaultClient
+		httpCl.Transport = http.DefaultTransport
+
+		client := github.NewClient(httpCl)
+		u, _ := url.Parse(ts.URL + "/")
+		client.BaseURL = u
+
+		meta := &Owner{
+			name:     owner,
+			v3client: client,
+		}
+
+		testSchema := map[string]*schema.Schema{
+			"repository": {Type: schema.TypeString},
+			"file":       {Type: schema.TypeString},
+			"branch":     {Type: schema.TypeString},
+			"commit_sha": {Type: schema.TypeString},
+			"content":    {Type: schema.TypeString},
+			"id":         {Type: schema.TypeString},
+		}
+
+		schema := schema.TestResourceDataRaw(t, testSchema, map[string]interface{}{
+			"repository": repositoryFullName,
+			"file":       fileName,
+			"branch":     branch,
+			"commit_sha": sha,
+			"content":    "",
+			"id":         "",
+		})
+
+		// actual call
+		err := dataSourceGithubRepositoryFileRead(schema, meta)
+
+		// assertions
+		assert.Nil(t, err)
+		assert.Equal(t, expectedRepo, schema.Get("repository"))
+		assert.Equal(t, fileContent, schema.Get("content"))
+		assert.Equal(t, expectedID, schema.Get("id"))
+	})
+	t.Run("using user as owner if just name is passed", func(t *testing.T) {
+		// test setup
+		repositoryFullName := repo
+		expectedID := fmt.Sprintf("%s/%s", repo, fileName)
+		expectedRepo := "test-repo"
+
+		ts := githubApiMock([]*mockResponse{
+			{
+				ExpectedUri:  fmt.Sprintf("/repos/%s/%s/branches/%s", owner, repo, branch),
+				ResponseBody: branchRespBody,
+				StatusCode:   http.StatusOK,
+			},
+			{
+				ExpectedUri:  fmt.Sprintf("/repos/%s/%s/contents/%s?ref=%s", owner, repo, fileName, branch),
+				ResponseBody: repoContentRespBody,
+				StatusCode:   http.StatusOK,
+			},
+			{
+				ExpectedUri:  fmt.Sprintf("/repos/%s/%s/commits/%s", owner, repo, sha),
+				ResponseBody: repoCommitRespBody,
+				StatusCode:   http.StatusOK,
+			},
+			{
+				ExpectedUri:  fmt.Sprintf("/repos/%s/%s/commits", owner, repo),
+				ResponseBody: repoCommitRespBody,
+				StatusCode:   http.StatusOK,
+			},
+		})
+		defer ts.Close()
+
+		httpCl := http.DefaultClient
+		httpCl.Transport = http.DefaultTransport
+
+		client := github.NewClient(httpCl)
+		u, _ := url.Parse(ts.URL + "/")
+		client.BaseURL = u
+
+		meta := &Owner{
+			name:     owner,
+			v3client: client,
+		}
+
+		testSchema := map[string]*schema.Schema{
+			"repository": {Type: schema.TypeString},
+			"file":       {Type: schema.TypeString},
+			"branch":     {Type: schema.TypeString},
+			"commit_sha": {Type: schema.TypeString},
+			"content":    {Type: schema.TypeString},
+			"id":         {Type: schema.TypeString},
+		}
+
+		schema := schema.TestResourceDataRaw(t, testSchema, map[string]interface{}{
+			"repository": repositoryFullName,
+			"file":       fileName,
+			"branch":     branch,
+			"commit_sha": sha,
+			"content":    "",
+			"id":         "",
+		})
+
+		// actual call
+		err := dataSourceGithubRepositoryFileRead(schema, meta)
+
+		// assertions
+		assert.Nil(t, err)
+		assert.Equal(t, expectedRepo, schema.Get("repository"))
+		assert.Equal(t, fileContent, schema.Get("content"))
+		assert.Equal(t, expectedID, schema.Get("id"))
 	})
 }

--- a/website/docs/d/repository_file.html.markdown
+++ b/website/docs/d/repository_file.html.markdown
@@ -31,7 +31,7 @@ The following arguments are supported:
 
 * `file` - (Required) The path of the file to manage.
 
-* `branch` - (Optional) Git branch (defaults to `main`).
+* `branch` - (Optional) Git branch (if omitted, the default repository branch is used, which is usually `main`)
   The branch must already exist; it will not be created if it does not already exist.
 
 ## Attributes Reference

--- a/website/docs/d/repository_file.html.markdown
+++ b/website/docs/d/repository_file.html.markdown
@@ -27,12 +27,12 @@ data "github_repository_file" "foo" {
 
 The following arguments are supported:
 
-* `repository` - (Required) The repository to read the file from. If an unqualified repo name (without an owner) is passed, the owner will be inferred from the owner of the token used to execute the plan. If a name of the type "owner/repo" (with a slash in the middle) is passed, the owner will be as specified and not the owner of the token. 
+* `repository` - (Required) The repository to read the file from. If an unqualified repo name (without an owner) is passed, the owner will be inferred from the owner of the token used to execute the plan. If a name of the type "owner/repo" (with a slash in the middle) is passed, the owner will be as specified and not the owner of the token.
 
 * `file` - (Required) The path of the file to manage.
 
 * `branch` - (Optional) Git branch (defaults to `main`).
-  The branch must already exist, if its not specified then default branch for repo is being used.
+  The branch must already exist; it will not be created if it does not already exist.
 
 ## Attributes Reference
 

--- a/website/docs/d/repository_file.html.markdown
+++ b/website/docs/d/repository_file.html.markdown
@@ -27,9 +27,7 @@ data "github_repository_file" "foo" {
 
 The following arguments are supported:
 
-* `repository` - (Required) The repository to read the file from.  
-  if `full_name` is passed then its being split into `org` and `repo` (e.g. `bar/foo` split to org `bar` and repo `foo` )  
-  if `name` is passed then `owner` is user
+* `repository` - (Required) The repository to read the file from. If an unqualified repo name (without an owner) is passed, the owner will be inferred from the owner of the token used to execute the plan. If a name of the type "owner/repo" (with a slash in the middle) is passed, the owner will be as specified and not the owner of the token. 
 
 * `file` - (Required) The path of the file to manage.
 

--- a/website/docs/d/repository_file.html.markdown
+++ b/website/docs/d/repository_file.html.markdown
@@ -27,12 +27,14 @@ data "github_repository_file" "foo" {
 
 The following arguments are supported:
 
-* `repository` - (Required) The repository to create the file in.
+* `repository` - (Required) The repository to read the file from.  
+  if `full_name` is passed then its being split into `org` and `repo` (e.g. `bar/foo` split to org `bar` and repo `foo` )  
+  if `name` is passed then `owner` is user
 
 * `file` - (Required) The path of the file to manage.
 
 * `branch` - (Optional) Git branch (defaults to `main`).
-  The branch must already exist, it will not be created if it does not already exist.
+  The branch must already exist, if its not specified then default branch for repo is being used.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixing `github_repository_file` owner handling, if `full_name` ispassed, split it into `owner` and `repo`, use user as an `owner` otherwise

Signed-off-by: Valery Masiutsin <val.masiutsin@gmail.com>

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #942 

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

*  owner account was used as an `org`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

*  if `full_name` is passed then its being split into `org` and `repo`


### Other information
<!-- Any other information that is important to this PR  -->

* 

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->
No
Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

