### PR TITLE
feat: Adding rename argument to the github_branch_default resource

### DIFF
--- a/github/resource_github_branch_default_test.go
+++ b/github/resource_github_branch_default_test.go
@@ -118,4 +118,54 @@ func TestAccGithubBranchDefault(t *testing.T) {
 		})
 
 	})
+
+	t.Run("replaces the default_branch of a repository without creating a branch resource prior to", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name      = "tf-acc-test-%s"
+				auto_init = true
+			}
+			
+			resource "github_branch_default" "test"{
+				repository = github_repository.test.name
+				branch     = "development"
+				rename     = true
+			}
+
+		`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_branch_default.test", "branch",
+				"development",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
 }

--- a/website/docs/r/branch_default.html.markdown
+++ b/website/docs/r/branch_default.html.markdown
@@ -15,6 +15,8 @@ Note that use of this resource is incompatible with the `default_branch` option 
 
 ## Example Usage
 
+Basic usage:
+
 ```hcl
 resource "github_repository" "example" {
   name        = "example"
@@ -33,12 +35,29 @@ resource "github_branch_default" "default"{
 }
 ```
 
+Renaming to a branch that doesn't exist:
+
+```hcl
+resource "github_repository" "example" {
+  name        = "example"
+  description = "My awesome codebase"
+  auto_init   = true
+}
+
+resource "github_branch_default" "default"{
+  repository = github_repository.example.name
+  branch     = "development"
+  rename     = true
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `repository` - (Required) The GitHub repository
 * `branch` - (Required) The branch (e.g. `main`)
+* `rename` - (Optional) Indicate if it should rename the branch rather than use an existing branch. Defaults to `false`. 
 
 ## Import
 


### PR DESCRIPTION
Resolves #765 

----

## Behavior

### Before the change?
In order to rename the default branch of a given repository, the branch had to be created _prior_ to calling the resource. 

### After the change?
With a new boolean flag, we can simply rename the default branch directly without the need of first calling the `github_branch` resource by setting `rename` to true. For backwards compatibility, we can still call the `github_branch` resource to be called first prior to calling the `github_branch_default` resource by setting `rename` to false (Which is the default).


### Other information


----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [X] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

