### PR TITLE
Add github_actions_repository_variable

### DIFF
--- a/github/provider.go
+++ b/github/provider.go
@@ -96,6 +96,7 @@ func Provider() terraform.ResourceProvider {
 			"github_actions_repository_access_level":                                resourceGithubActionsRepositoryAccessLevel(),
 			"github_actions_repository_oidc_subject_claim_customization_template":   resourceGithubActionsRepositoryOIDCSubjectClaimCustomizationTemplate(),
 			"github_actions_repository_permissions":                                 resourceGithubActionsRepositoryPermissions(),
+			"github_actions_repository_variable":                                    resourceGithubActionsRepositoryVariable(),
 			"github_actions_runner_group":                                           resourceGithubActionsRunnerGroup(),
 			"github_actions_secret":                                                 resourceGithubActionsSecret(),
 			"github_app_installation_repositories":                                  resourceGithubAppInstallationRepositories(),

--- a/github/resource_github_actions_repository_variable.go
+++ b/github/resource_github_actions_repository_variable.go
@@ -1,0 +1,157 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/google/go-github/v50/github"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceGithubActionsRepositoryVariable() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGithubActionsRepositoryVariableCreate,
+		Read:   resourceGithubActionsRepositoryVariableRead,
+		Update: resourceGithubActionsRepositoryVariableUpdate,
+		Delete: resourceGithubActionsRepositoryVariableDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"repository": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Name of the repository in which to create the variable.",
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "Name of the repository variable.",
+				ValidateFunc: validateVariableName,
+				StateFunc: func(in interface{}) string {
+					// Names are always stored as upper case.
+					return strings.ToUpper(in.(string))
+				},
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Value of the repository variable.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Timestamp of when the repository variable was created.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Timestamp of when the repository variable was last updated.",
+			},
+		},
+	}
+}
+
+func resourceGithubActionsRepositoryVariableCreate(d *schema.ResourceData, meta interface{}) error {
+	ctx := context.Background()
+
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
+
+	repo := d.Get("repository").(string)
+	name := d.Get("name").(string)
+	value := d.Get("value").(string)
+
+	if _, err := client.Actions.CreateRepoVariable(ctx, owner, repo, &github.ActionsVariable{
+		Name:  name,
+		Value: value,
+	}); err != nil {
+		return fmt.Errorf("failed to create repository variable %s: %w", name, err)
+	}
+
+	d.SetId(buildTwoPartID(repo, name))
+	return resourceGithubActionsRepositoryVariableRead(d, meta)
+}
+
+func resourceGithubActionsRepositoryVariableRead(d *schema.ResourceData, meta interface{}) error {
+	ctx := context.Background()
+
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
+
+	repo, name, err := parseTwoPartID(d.Id(), "repository", "name")
+	if err != nil {
+		return err
+	}
+
+	variable, _, err := client.Actions.GetRepoVariable(ctx, owner, repo, name)
+
+	if err != nil {
+		if ghErr, ok := err.(*github.ErrorResponse); ok {
+			if ghErr.Response.StatusCode == http.StatusNotFound {
+				log.Printf("[INFO] Removing actions variable %q from state because it no longer exists on GitHub",
+					d.Id())
+				d.SetId("")
+				return nil
+			}
+		}
+		return fmt.Errorf("failed to lookup repo variable %s: %w", name, err)
+	}
+
+	d.Set("repository", repo)
+	d.Set("name", variable.Name)
+	d.Set("value", variable.Value)
+	d.Set("created_at", variable.CreatedAt.String())
+	d.Set("updated_at", variable.UpdatedAt.String())
+
+	return nil
+}
+
+func resourceGithubActionsRepositoryVariableUpdate(d *schema.ResourceData, meta interface{}) error {
+	ctx := context.Background()
+
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
+
+	repo := d.Get("repository").(string)
+	name := d.Get("name").(string)
+	value := d.Get("value").(string)
+
+	if d.HasChange("repository") || d.HasChange("name") || d.HasChange("value") {
+		if _, err := client.Actions.UpdateRepoVariable(ctx, owner, repo, &github.ActionsVariable{
+			Name:  name,
+			Value: value,
+		}); err != nil {
+			return fmt.Errorf("failed to update repository variable %s: %w", name, err)
+		}
+
+		d.SetId(buildTwoPartID(repo, name))
+	}
+
+	return resourceGithubActionsRepositoryVariableRead(d, meta)
+}
+
+func resourceGithubActionsRepositoryVariableDelete(d *schema.ResourceData, meta interface{}) error {
+	ctx := context.WithValue(context.Background(), ctxId, d.Id())
+
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
+
+	repo, name, err := parseTwoPartID(d.Id(), "repository", "name")
+	if err != nil {
+		return err
+	}
+
+	if _, err := client.Actions.DeleteRepoVariable(ctx, owner, repo, name); err != nil {
+		return fmt.Errorf("failed to delete repo variable %s: %w", name, err)
+	}
+	return nil
+}

--- a/github/resource_github_actions_repository_variable_test.go
+++ b/github/resource_github_actions_repository_variable_test.go
@@ -1,0 +1,154 @@
+package github
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccGithubActionsRepositoryVariable(t *testing.T) {
+	t.Run("creates_updates_and_deletes", func(t *testing.T) {
+		repoName := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		variableName := "a" + acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: fmt.Sprintf(`
+							resource "github_repository" "test" {
+								name = "tf-acc-test-%s"
+							}
+
+							resource "github_actions_repository_variable" "test" {
+								repository = github_repository.test.name
+								name       = "%s"
+								value      = "testing_value"
+							}
+						`, repoName, variableName),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckResourceAttr(
+								"github_actions_repository_variable.test", "name",
+								strings.ToUpper(variableName),
+							),
+							resource.TestCheckResourceAttr(
+								"github_actions_repository_variable.test", "value",
+								"testing_value",
+							),
+							resource.TestCheckResourceAttrSet(
+								"github_actions_repository_variable.test", "created_at",
+							),
+							resource.TestCheckResourceAttrSet(
+								"github_actions_repository_variable.test", "updated_at",
+							),
+						),
+					},
+
+					// Update name
+					{
+						Config: fmt.Sprintf(`
+							resource "github_repository" "test" {
+								name = "tf-acc-test-%s"
+							}
+
+							resource "github_actions_repository_variable" "test" {
+								repository = github_repository.test.name
+								name       = "%s_2"
+								value      = "testing_value"
+							}
+						`, repoName, variableName),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckResourceAttr(
+								"github_actions_repository_variable.test", "name",
+								strings.ToUpper(variableName+"_2"),
+							),
+						),
+					},
+
+					// Update value
+					{
+						Config: fmt.Sprintf(`
+							resource "github_repository" "test" {
+								name = "tf-acc-test-%s"
+							}
+
+							resource "github_actions_repository_variable" "test" {
+								repository = github_repository.test.name
+								name       = "%s_2"
+								value      = "testing_value_2"
+							}
+						`, repoName, variableName),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckResourceAttr(
+								"github_actions_repository_variable.test", "value",
+								"testing_value_2",
+							),
+						),
+					},
+				},
+			})
+		}
+
+		t.Run("with_an_individual_account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with_an_organization_account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+
+	t.Run("imports", func(t *testing.T) {
+		repoName := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		variableName := "a" + acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					// Create
+					{
+						Config: fmt.Sprintf(`
+							resource "github_repository" "test" {
+								name = "tf-acc-test-%s"
+							}
+
+							resource "github_actions_repository_variable" "test" {
+								repository = github_repository.test.name
+								name       = "%s"
+								value      = "testing_value"
+							}
+						`, repoName, variableName),
+					},
+
+					// Import
+					{
+						ResourceName:      "github_actions_repository_variable.test",
+						ImportStateId:     fmt.Sprintf("tf-acc-test-%s:%s", repoName, variableName),
+						ImportState:       true,
+						ImportStateVerify: true,
+						ImportStateVerifyIgnore: []string{
+							"created_at",
+							"updated_at",
+						},
+					},
+				},
+			})
+		}
+
+		t.Run("with_an_individual_account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with_an_organization_account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.41.1
-	github.com/google/go-github/v50 v50.0.0
+	github.com/google/go-github/v50 v50.1.0
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk v1.17.2
 	github.com/shurcooL/githubv4 v0.0.0-20221126192849-0b5c4c7994eb

--- a/go.sum
+++ b/go.sum
@@ -516,8 +516,8 @@ github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v50 v50.0.0 h1:gdO1AeuSZZK4iYWwVbjni7zg8PIQhp7QfmPunr016Jk=
-github.com/google/go-github/v50 v50.0.0/go.mod h1:Ev4Tre8QoKiolvbpOSG3FIi4Mlon3S2Nt9W5JYqKiwA=
+github.com/google/go-github/v50 v50.1.0 h1:hMUpkZjklC5GJ+c3GquSqOP/T4BNsB7XohaPhtMOzRk=
+github.com/google/go-github/v50 v50.1.0/go.mod h1:Ev4Tre8QoKiolvbpOSG3FIi4Mlon3S2Nt9W5JYqKiwA=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/vendor/github.com/google/go-github/v50/github/actions_artifacts.go
+++ b/vendor/github.com/google/go-github/v50/github/actions_artifacts.go
@@ -12,20 +12,34 @@ import (
 	"net/url"
 )
 
-// Artifact reprents a GitHub artifact.  Artifacts allow sharing
+// ArtifactWorkflowRun represents a GitHub artifact's workflow run.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/artifacts
+type ArtifactWorkflowRun struct {
+	ID               *int64  `json:"id,omitempty"`
+	RepositoryID     *int64  `json:"repository_id,omitempty"`
+	HeadRepositoryID *int64  `json:"head_repository_id,omitempty"`
+	HeadBranch       *string `json:"head_branch,omitempty"`
+	HeadSHA          *string `json:"head_sha,omitempty"`
+}
+
+// Artifact represents a GitHub artifact.  Artifacts allow sharing
 // data between jobs in a workflow and provide storage for data
 // once a workflow is complete.
 //
 // GitHub API docs: https://docs.github.com/en/rest/actions/artifacts
 type Artifact struct {
-	ID                 *int64     `json:"id,omitempty"`
-	NodeID             *string    `json:"node_id,omitempty"`
-	Name               *string    `json:"name,omitempty"`
-	SizeInBytes        *int64     `json:"size_in_bytes,omitempty"`
-	ArchiveDownloadURL *string    `json:"archive_download_url,omitempty"`
-	Expired            *bool      `json:"expired,omitempty"`
-	CreatedAt          *Timestamp `json:"created_at,omitempty"`
-	ExpiresAt          *Timestamp `json:"expires_at,omitempty"`
+	ID                 *int64               `json:"id,omitempty"`
+	NodeID             *string              `json:"node_id,omitempty"`
+	Name               *string              `json:"name,omitempty"`
+	SizeInBytes        *int64               `json:"size_in_bytes,omitempty"`
+	URL                *string              `json:"url,omitempty"`
+	ArchiveDownloadURL *string              `json:"archive_download_url,omitempty"`
+	Expired            *bool                `json:"expired,omitempty"`
+	CreatedAt          *Timestamp           `json:"created_at,omitempty"`
+	UpdatedAt          *Timestamp           `json:"updated_at,omitempty"`
+	ExpiresAt          *Timestamp           `json:"expires_at,omitempty"`
+	WorkflowRun        *ArtifactWorkflowRun `json:"workflow_run,omitempty"`
 }
 
 // ArtifactList represents a list of GitHub artifacts.

--- a/vendor/github.com/google/go-github/v50/github/actions_variables.go
+++ b/vendor/github.com/google/go-github/v50/github/actions_variables.go
@@ -1,0 +1,293 @@
+// Copyright 2023 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// ActionsVariable represents a repository action variable.
+type ActionsVariable struct {
+	Name       string     `json:"name"`
+	Value      string     `json:"value"`
+	CreatedAt  *Timestamp `json:"created_at,omitempty"`
+	UpdatedAt  *Timestamp `json:"updated_at,omitempty"`
+	Visibility *string    `json:"visibility,omitempty"`
+	// Used by ListOrgVariables and GetOrgVariables
+	SelectedRepositoriesURL *string `json:"selected_repositories_url,omitempty"`
+	// Used by UpdateOrgVariable and CreateOrgVariable
+	SelectedRepositoryIDs *SelectedRepoIDs `json:"selected_repository_ids,omitempty"`
+}
+
+// ActionsVariables represents one item from the ListVariables response.
+type ActionsVariables struct {
+	TotalCount int                `json:"total_count"`
+	Variables  []*ActionsVariable `json:"variables"`
+}
+
+func (s *ActionsService) listVariables(ctx context.Context, url string, opts *ListOptions) (*ActionsVariables, *Response, error) {
+	u, err := addOptions(url, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	variables := new(ActionsVariables)
+	resp, err := s.client.Do(ctx, req, &variables)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return variables, resp, nil
+}
+
+// ListRepoVariables lists all variables available in a repository.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/variables#list-repository-variables
+func (s *ActionsService) ListRepoVariables(ctx context.Context, owner, repo string, opts *ListOptions) (*ActionsVariables, *Response, error) {
+	url := fmt.Sprintf("repos/%v/%v/actions/variables", owner, repo)
+	return s.listVariables(ctx, url, opts)
+}
+
+// ListOrgVariables lists all variables available in an organization.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/variables#list-organization-variables
+func (s *ActionsService) ListOrgVariables(ctx context.Context, org string, opts *ListOptions) (*ActionsVariables, *Response, error) {
+	url := fmt.Sprintf("orgs/%v/actions/variables", org)
+	return s.listVariables(ctx, url, opts)
+}
+
+// ListEnvVariables lists all variables available in an environment.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/variables#list-environment-variables
+func (s *ActionsService) ListEnvVariables(ctx context.Context, repoID int, env string, opts *ListOptions) (*ActionsVariables, *Response, error) {
+	url := fmt.Sprintf("repositories/%v/environments/%v/variables", repoID, env)
+	return s.listVariables(ctx, url, opts)
+}
+
+func (s *ActionsService) getVariable(ctx context.Context, url string) (*ActionsVariable, *Response, error) {
+	req, err := s.client.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	variable := new(ActionsVariable)
+	resp, err := s.client.Do(ctx, req, variable)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return variable, resp, nil
+}
+
+// GetRepoVariable gets a single repository variable.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/variables#get-a-repository-variable
+func (s *ActionsService) GetRepoVariable(ctx context.Context, owner, repo, name string) (*ActionsVariable, *Response, error) {
+	url := fmt.Sprintf("repos/%v/%v/actions/variables/%v", owner, repo, name)
+	return s.getVariable(ctx, url)
+}
+
+// GetOrgVariable gets a single organization variable.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/variables#get-an-organization-variable
+func (s *ActionsService) GetOrgVariable(ctx context.Context, org, name string) (*ActionsVariable, *Response, error) {
+	url := fmt.Sprintf("orgs/%v/actions/variables/%v", org, name)
+	return s.getVariable(ctx, url)
+}
+
+// GetEnvVariable gets a single environment variable.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/variables#get-an-environment-variable
+func (s *ActionsService) GetEnvVariable(ctx context.Context, repoID int, env, variableName string) (*ActionsVariable, *Response, error) {
+	url := fmt.Sprintf("repositories/%v/environments/%v/variables/%v", repoID, env, variableName)
+	return s.getVariable(ctx, url)
+}
+
+func (s *ActionsService) postVariable(ctx context.Context, url string, variable *ActionsVariable) (*Response, error) {
+	req, err := s.client.NewRequest("POST", url, variable)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(ctx, req, nil)
+}
+
+// CreateRepoVariable creates a repository variable.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/variables#create-a-repository-variable
+func (s *ActionsService) CreateRepoVariable(ctx context.Context, owner, repo string, variable *ActionsVariable) (*Response, error) {
+	url := fmt.Sprintf("repos/%v/%v/actions/variables", owner, repo)
+	return s.postVariable(ctx, url, variable)
+}
+
+// CreateOrgVariable creates an organization variable.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/variables#create-an-organization-variable
+func (s *ActionsService) CreateOrgVariable(ctx context.Context, org string, variable *ActionsVariable) (*Response, error) {
+	url := fmt.Sprintf("orgs/%v/actions/variables", org)
+	return s.postVariable(ctx, url, variable)
+}
+
+// CreateEnvVariable creates an environment variable.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/variables#create-an-environment-variable
+func (s *ActionsService) CreateEnvVariable(ctx context.Context, repoID int, env string, variable *ActionsVariable) (*Response, error) {
+	url := fmt.Sprintf("repositories/%v/environments/%v/variables", repoID, env)
+	return s.postVariable(ctx, url, variable)
+}
+
+func (s *ActionsService) patchVariable(ctx context.Context, url string, variable *ActionsVariable) (*Response, error) {
+	req, err := s.client.NewRequest("PATCH", url, variable)
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(ctx, req, nil)
+}
+
+// UpdateRepoVariable updates a repository variable.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/variables#update-a-repository-variable
+func (s *ActionsService) UpdateRepoVariable(ctx context.Context, owner, repo string, variable *ActionsVariable) (*Response, error) {
+	url := fmt.Sprintf("repos/%v/%v/actions/variables/%v", owner, repo, variable.Name)
+	return s.patchVariable(ctx, url, variable)
+}
+
+// UpdateOrgVariable updates an organization variable.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/variables#update-an-organization-variable
+func (s *ActionsService) UpdateOrgVariable(ctx context.Context, org string, variable *ActionsVariable) (*Response, error) {
+	url := fmt.Sprintf("orgs/%v/actions/variables/%v", org, variable.Name)
+	return s.patchVariable(ctx, url, variable)
+}
+
+// UpdateEnvVariable updates an environment variable.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/variables#create-an-environment-variable
+func (s *ActionsService) UpdateEnvVariable(ctx context.Context, repoID int, env string, variable *ActionsVariable) (*Response, error) {
+	url := fmt.Sprintf("repositories/%v/environments/%v/variables/%v", repoID, env, variable.Name)
+	return s.patchVariable(ctx, url, variable)
+}
+
+func (s *ActionsService) deleteVariable(ctx context.Context, url string) (*Response, error) {
+	req, err := s.client.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// DeleteRepoVariable deletes a variable in a repository.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/variables#delete-a-repository-variable
+func (s *ActionsService) DeleteRepoVariable(ctx context.Context, owner, repo, name string) (*Response, error) {
+	url := fmt.Sprintf("repos/%v/%v/actions/variables/%v", owner, repo, name)
+	return s.deleteVariable(ctx, url)
+}
+
+// DeleteOrgVariable deletes a variable in an organization.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/variables#delete-an-organization-variable
+func (s *ActionsService) DeleteOrgVariable(ctx context.Context, org, name string) (*Response, error) {
+	url := fmt.Sprintf("orgs/%v/actions/variables/%v", org, name)
+	return s.deleteVariable(ctx, url)
+}
+
+// DeleteEnvVariable deletes a variable in an environment.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/variables#delete-an-environment-variable
+func (s *ActionsService) DeleteEnvVariable(ctx context.Context, repoID int, env, variableName string) (*Response, error) {
+	url := fmt.Sprintf("repositories/%v/environments/%v/variables/%v", repoID, env, variableName)
+	return s.deleteVariable(ctx, url)
+}
+
+func (s *ActionsService) listSelectedReposForVariable(ctx context.Context, url string, opts *ListOptions) (*SelectedReposList, *Response, error) {
+	u, err := addOptions(url, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := new(SelectedReposList)
+	resp, err := s.client.Do(ctx, req, result)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return result, resp, nil
+}
+
+// ListSelectedReposForOrgVariable lists all repositories that have access to a variable.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/variables#list-selected-repositories-for-an-organization-variable
+func (s *ActionsService) ListSelectedReposForOrgVariable(ctx context.Context, org, name string, opts *ListOptions) (*SelectedReposList, *Response, error) {
+	url := fmt.Sprintf("orgs/%v/actions/variables/%v/repositories", org, name)
+	return s.listSelectedReposForVariable(ctx, url, opts)
+}
+
+func (s *ActionsService) setSelectedReposForVariable(ctx context.Context, url string, ids SelectedRepoIDs) (*Response, error) {
+	type repoIDs struct {
+		SelectedIDs SelectedRepoIDs `json:"selected_repository_ids"`
+	}
+
+	req, err := s.client.NewRequest("PUT", url, repoIDs{SelectedIDs: ids})
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// SetSelectedReposForOrgVariable sets the repositories that have access to a variable.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/variables#set-selected-repositories-for-an-organization-variable
+func (s *ActionsService) SetSelectedReposForOrgVariable(ctx context.Context, org, name string, ids SelectedRepoIDs) (*Response, error) {
+	url := fmt.Sprintf("orgs/%v/actions/variables/%v/repositories", org, name)
+	return s.setSelectedReposForVariable(ctx, url, ids)
+}
+
+func (s *ActionsService) addSelectedRepoToVariable(ctx context.Context, url string) (*Response, error) {
+	req, err := s.client.NewRequest("PUT", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// AddSelectedRepoToOrgVariable adds a repository to an organization variable.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/variables#add-selected-repository-to-an-organization-variable
+func (s *ActionsService) AddSelectedRepoToOrgVariable(ctx context.Context, org, name string, repo *Repository) (*Response, error) {
+	url := fmt.Sprintf("orgs/%v/actions/variables/%v/repositories/%v", org, name, *repo.ID)
+	return s.addSelectedRepoToVariable(ctx, url)
+}
+
+func (s *ActionsService) removeSelectedRepoFromVariable(ctx context.Context, url string) (*Response, error) {
+	req, err := s.client.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(ctx, req, nil)
+}
+
+// RemoveSelectedRepoFromOrgVariable removes a repository from an organization variable.
+//
+// GitHub API docs: https://docs.github.com/en/rest/actions/variables#remove-selected-repository-from-an-organization-variable
+func (s *ActionsService) RemoveSelectedRepoFromOrgVariable(ctx context.Context, org, name string, repo *Repository) (*Response, error) {
+	url := fmt.Sprintf("orgs/%v/actions/variables/%v/repositories/%v", org, name, *repo.ID)
+	return s.removeSelectedRepoFromVariable(ctx, url)
+}

--- a/vendor/github.com/google/go-github/v50/github/actions_workflow_jobs.go
+++ b/vendor/github.com/google/go-github/v50/github/actions_workflow_jobs.go
@@ -33,6 +33,7 @@ type WorkflowJob struct {
 	HTMLURL     *string     `json:"html_url,omitempty"`
 	Status      *string     `json:"status,omitempty"`
 	Conclusion  *string     `json:"conclusion,omitempty"`
+	CreatedAt   *Timestamp  `json:"created_at,omitempty"`
 	StartedAt   *Timestamp  `json:"started_at,omitempty"`
 	CompletedAt *Timestamp  `json:"completed_at,omitempty"`
 	Name        *string     `json:"name,omitempty"`

--- a/vendor/github.com/google/go-github/v50/github/apps_marketplace.go
+++ b/vendor/github.com/google/go-github/v50/github/apps_marketplace.go
@@ -46,6 +46,7 @@ type MarketplacePlan struct {
 
 // MarketplacePurchase represents a GitHub Apps Marketplace Purchase.
 type MarketplacePurchase struct {
+	Account *MarketplacePurchaseAccount `json:"account,omitempty"`
 	// BillingCycle can be one of the values "yearly", "monthly" or nil.
 	BillingCycle    *string          `json:"billing_cycle,omitempty"`
 	NextBillingDate *Timestamp       `json:"next_billing_date,omitempty"`
@@ -73,6 +74,17 @@ type MarketplacePlanAccount struct {
 	OrganizationBillingEmail *string                   `json:"organization_billing_email,omitempty"`
 	MarketplacePurchase      *MarketplacePurchase      `json:"marketplace_purchase,omitempty"`
 	MarketplacePendingChange *MarketplacePendingChange `json:"marketplace_pending_change,omitempty"`
+}
+
+// MarketplacePurchaseAccount represents a GitHub Account (user or organization) for a Purchase.
+type MarketplacePurchaseAccount struct {
+	URL                      *string `json:"url,omitempty"`
+	Type                     *string `json:"type,omitempty"`
+	ID                       *int64  `json:"id,omitempty"`
+	Login                    *string `json:"login,omitempty"`
+	OrganizationBillingEmail *string `json:"organization_billing_email,omitempty"`
+	Email                    *string `json:"email,omitempty"`
+	NodeID                   *string `json:"node_id,omitempty"`
 }
 
 // ListPlans lists all plans for your Marketplace listing.

--- a/vendor/github.com/google/go-github/v50/github/event_types.go
+++ b/vendor/github.com/google/go-github/v50/github/event_types.go
@@ -485,6 +485,7 @@ type IssuesEvent struct {
 	Repo         *Repository   `json:"repository,omitempty"`
 	Sender       *User         `json:"sender,omitempty"`
 	Installation *Installation `json:"installation,omitempty"`
+	Milestone    *Milestone    `json:"milestone,omitempty"`
 }
 
 // LabelEvent is triggered when a repository's label is created, edited, or deleted.

--- a/vendor/github.com/google/go-github/v50/github/github-accessors.go
+++ b/vendor/github.com/google/go-github/v50/github/github-accessors.go
@@ -174,6 +174,46 @@ func (a *ActionsPermissionsRepository) GetSelectedActionsURL() string {
 	return *a.SelectedActionsURL
 }
 
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (a *ActionsVariable) GetCreatedAt() Timestamp {
+	if a == nil || a.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *a.CreatedAt
+}
+
+// GetSelectedRepositoriesURL returns the SelectedRepositoriesURL field if it's non-nil, zero value otherwise.
+func (a *ActionsVariable) GetSelectedRepositoriesURL() string {
+	if a == nil || a.SelectedRepositoriesURL == nil {
+		return ""
+	}
+	return *a.SelectedRepositoriesURL
+}
+
+// GetSelectedRepositoryIDs returns the SelectedRepositoryIDs field.
+func (a *ActionsVariable) GetSelectedRepositoryIDs() *SelectedRepoIDs {
+	if a == nil {
+		return nil
+	}
+	return a.SelectedRepositoryIDs
+}
+
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (a *ActionsVariable) GetUpdatedAt() Timestamp {
+	if a == nil || a.UpdatedAt == nil {
+		return Timestamp{}
+	}
+	return *a.UpdatedAt
+}
+
+// GetVisibility returns the Visibility field if it's non-nil, zero value otherwise.
+func (a *ActionsVariable) GetVisibility() string {
+	if a == nil || a.Visibility == nil {
+		return ""
+	}
+	return *a.Visibility
+}
+
 // GetFrom returns the From field if it's non-nil, zero value otherwise.
 func (a *AdminEnforcedChanges) GetFrom() bool {
 	if a == nil || a.From == nil {
@@ -862,12 +902,76 @@ func (a *Artifact) GetSizeInBytes() int64 {
 	return *a.SizeInBytes
 }
 
+// GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
+func (a *Artifact) GetUpdatedAt() Timestamp {
+	if a == nil || a.UpdatedAt == nil {
+		return Timestamp{}
+	}
+	return *a.UpdatedAt
+}
+
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (a *Artifact) GetURL() string {
+	if a == nil || a.URL == nil {
+		return ""
+	}
+	return *a.URL
+}
+
+// GetWorkflowRun returns the WorkflowRun field.
+func (a *Artifact) GetWorkflowRun() *ArtifactWorkflowRun {
+	if a == nil {
+		return nil
+	}
+	return a.WorkflowRun
+}
+
 // GetTotalCount returns the TotalCount field if it's non-nil, zero value otherwise.
 func (a *ArtifactList) GetTotalCount() int64 {
 	if a == nil || a.TotalCount == nil {
 		return 0
 	}
 	return *a.TotalCount
+}
+
+// GetHeadBranch returns the HeadBranch field if it's non-nil, zero value otherwise.
+func (a *ArtifactWorkflowRun) GetHeadBranch() string {
+	if a == nil || a.HeadBranch == nil {
+		return ""
+	}
+	return *a.HeadBranch
+}
+
+// GetHeadRepositoryID returns the HeadRepositoryID field if it's non-nil, zero value otherwise.
+func (a *ArtifactWorkflowRun) GetHeadRepositoryID() int64 {
+	if a == nil || a.HeadRepositoryID == nil {
+		return 0
+	}
+	return *a.HeadRepositoryID
+}
+
+// GetHeadSHA returns the HeadSHA field if it's non-nil, zero value otherwise.
+func (a *ArtifactWorkflowRun) GetHeadSHA() string {
+	if a == nil || a.HeadSHA == nil {
+		return ""
+	}
+	return *a.HeadSHA
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (a *ArtifactWorkflowRun) GetID() int64 {
+	if a == nil || a.ID == nil {
+		return 0
+	}
+	return *a.ID
+}
+
+// GetRepositoryID returns the RepositoryID field if it's non-nil, zero value otherwise.
+func (a *ArtifactWorkflowRun) GetRepositoryID() int64 {
+	if a == nil || a.RepositoryID == nil {
+		return 0
+	}
+	return *a.RepositoryID
 }
 
 // GetBody returns the Body field if it's non-nil, zero value otherwise.
@@ -1118,6 +1222,14 @@ func (a *AuditEntry) GetName() string {
 	return *a.Name
 }
 
+// GetOldPermission returns the OldPermission field if it's non-nil, zero value otherwise.
+func (a *AuditEntry) GetOldPermission() string {
+	if a == nil || a.OldPermission == nil {
+		return ""
+	}
+	return *a.OldPermission
+}
+
 // GetOldUser returns the OldUser field if it's non-nil, zero value otherwise.
 func (a *AuditEntry) GetOldUser() string {
 	if a == nil || a.OldUser == nil {
@@ -1140,6 +1252,14 @@ func (a *AuditEntry) GetOrg() string {
 		return ""
 	}
 	return *a.Org
+}
+
+// GetPermission returns the Permission field if it's non-nil, zero value otherwise.
+func (a *AuditEntry) GetPermission() string {
+	if a == nil || a.Permission == nil {
+		return ""
+	}
+	return *a.Permission
 }
 
 // GetPreviousVisibility returns the PreviousVisibility field if it's non-nil, zero value otherwise.
@@ -8286,6 +8406,14 @@ func (i *IssuesEvent) GetLabel() *Label {
 	return i.Label
 }
 
+// GetMilestone returns the Milestone field.
+func (i *IssuesEvent) GetMilestone() *Milestone {
+	if i == nil {
+		return nil
+	}
+	return i.Milestone
+}
+
 // GetRepo returns the Repo field.
 func (i *IssuesEvent) GetRepo() *Repository {
 	if i == nil {
@@ -9134,6 +9262,14 @@ func (m *MarketplacePlanAccount) GetURL() string {
 	return *m.URL
 }
 
+// GetAccount returns the Account field.
+func (m *MarketplacePurchase) GetAccount() *MarketplacePurchaseAccount {
+	if m == nil {
+		return nil
+	}
+	return m.Account
+}
+
 // GetBillingCycle returns the BillingCycle field if it's non-nil, zero value otherwise.
 func (m *MarketplacePurchase) GetBillingCycle() string {
 	if m == nil || m.BillingCycle == nil {
@@ -9188,6 +9324,62 @@ func (m *MarketplacePurchase) GetUpdatedAt() Timestamp {
 		return Timestamp{}
 	}
 	return *m.UpdatedAt
+}
+
+// GetEmail returns the Email field if it's non-nil, zero value otherwise.
+func (m *MarketplacePurchaseAccount) GetEmail() string {
+	if m == nil || m.Email == nil {
+		return ""
+	}
+	return *m.Email
+}
+
+// GetID returns the ID field if it's non-nil, zero value otherwise.
+func (m *MarketplacePurchaseAccount) GetID() int64 {
+	if m == nil || m.ID == nil {
+		return 0
+	}
+	return *m.ID
+}
+
+// GetLogin returns the Login field if it's non-nil, zero value otherwise.
+func (m *MarketplacePurchaseAccount) GetLogin() string {
+	if m == nil || m.Login == nil {
+		return ""
+	}
+	return *m.Login
+}
+
+// GetNodeID returns the NodeID field if it's non-nil, zero value otherwise.
+func (m *MarketplacePurchaseAccount) GetNodeID() string {
+	if m == nil || m.NodeID == nil {
+		return ""
+	}
+	return *m.NodeID
+}
+
+// GetOrganizationBillingEmail returns the OrganizationBillingEmail field if it's non-nil, zero value otherwise.
+func (m *MarketplacePurchaseAccount) GetOrganizationBillingEmail() string {
+	if m == nil || m.OrganizationBillingEmail == nil {
+		return ""
+	}
+	return *m.OrganizationBillingEmail
+}
+
+// GetType returns the Type field if it's non-nil, zero value otherwise.
+func (m *MarketplacePurchaseAccount) GetType() string {
+	if m == nil || m.Type == nil {
+		return ""
+	}
+	return *m.Type
+}
+
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (m *MarketplacePurchaseAccount) GetURL() string {
+	if m == nil || m.URL == nil {
+		return ""
+	}
+	return *m.URL
 }
 
 // GetAction returns the Action field if it's non-nil, zero value otherwise.
@@ -19326,6 +19518,14 @@ func (t *Timeline) GetRename() *Rename {
 	return t.Rename
 }
 
+// GetRequestedTeam returns the RequestedTeam field.
+func (t *Timeline) GetRequestedTeam() *Team {
+	if t == nil {
+		return nil
+	}
+	return t.RequestedTeam
+}
+
 // GetRequester returns the Requester field.
 func (t *Timeline) GetRequester() *User {
 	if t == nil {
@@ -20804,6 +21004,14 @@ func (w *WorkflowJob) GetConclusion() string {
 		return ""
 	}
 	return *w.Conclusion
+}
+
+// GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
+func (w *WorkflowJob) GetCreatedAt() Timestamp {
+	if w == nil || w.CreatedAt == nil {
+		return Timestamp{}
+	}
+	return *w.CreatedAt
 }
 
 // GetHeadSHA returns the HeadSHA field if it's non-nil, zero value otherwise.

--- a/vendor/github.com/google/go-github/v50/github/github.go
+++ b/vendor/github.com/google/go-github/v50/github/github.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	Version = "v50.0.0"
+	Version = "v50.1.0"
 
 	defaultAPIVersion = "2022-11-28"
 	defaultBaseURL    = "https://api.github.com/"
@@ -171,8 +171,9 @@ type Client struct {
 	// User agent used when communicating with the GitHub API.
 	UserAgent string
 
-	rateMu     sync.Mutex
-	rateLimits [categories]Rate // Rate limits for the client as determined by the most recent API calls.
+	rateMu                  sync.Mutex
+	rateLimits              [categories]Rate // Rate limits for the client as determined by the most recent API calls.
+	secondaryRateLimitReset time.Time        // Secondary rate limit reset for the client as determined by the most recent API calls.
 
 	common service // Reuse a single struct instead of allocating one for each service on the heap.
 
@@ -570,7 +571,8 @@ type Response struct {
 	// propagate to Response.
 	Rate Rate
 
-	// token's expiration date
+	// token's expiration date. Timestamp is 0001-01-01 when token doesn't expire.
+	// So it is valid for TokenExpiration.Equal(Timestamp{}) or TokenExpiration.Time.After(time.Now())
 	TokenExpiration Timestamp
 }
 
@@ -671,14 +673,19 @@ func parseRate(r *http.Response) Rate {
 }
 
 // parseTokenExpiration parses the TokenExpiration related headers.
+// Returns 0001-01-01 if the header is not defined or could not be parsed.
 func parseTokenExpiration(r *http.Response) Timestamp {
-	var exp Timestamp
 	if v := r.Header.Get(headerTokenExpiration); v != "" {
-		if t, err := time.Parse("2006-01-02 03:04:05 MST", v); err == nil {
-			exp = Timestamp{t.Local()}
+		if t, err := time.Parse("2006-01-02 15:04:05 MST", v); err == nil {
+			return Timestamp{t.Local()}
+		}
+		// Some tokens include the timezone offset instead of the timezone.
+		// https://github.com/google/go-github/issues/2649
+		if t, err := time.Parse("2006-01-02 15:04:05 -0700", v); err == nil {
+			return Timestamp{t.Local()}
 		}
 	}
-	return exp
+	return Timestamp{} // 0001-01-01 00:00:00
 }
 
 type requestContext uint8
@@ -702,7 +709,7 @@ func (c *Client) BareDo(ctx context.Context, req *http.Request) (*Response, erro
 
 	req = withContext(ctx, req)
 
-	rateLimitCategory := category(req.URL.Path)
+	rateLimitCategory := category(req.Method, req.URL.Path)
 
 	if bypass := ctx.Value(bypassRateLimitCheck); bypass == nil {
 		// If we've hit rate limit, don't make further requests before Reset time.
@@ -710,6 +717,12 @@ func (c *Client) BareDo(ctx context.Context, req *http.Request) (*Response, erro
 			return &Response{
 				Response: err.Response,
 				Rate:     err.Rate,
+			}, err
+		}
+		// If we've hit a secondary rate limit, don't make further requests before Retry After.
+		if err := c.checkSecondaryRateLimitBeforeDo(ctx, req); err != nil {
+			return &Response{
+				Response: err.Response,
 			}, err
 		}
 	}
@@ -762,6 +775,14 @@ func (c *Client) BareDo(ctx context.Context, req *http.Request) (*Response, erro
 
 			aerr.Raw = b
 			err = aerr
+		}
+
+		// Update the secondary rate limit if we hit it.
+		rerr, ok := err.(*AbuseRateLimitError)
+		if ok && rerr.RetryAfter != nil {
+			c.rateMu.Lock()
+			c.secondaryRateLimitReset = time.Now().Add(*rerr.RetryAfter)
+			c.rateMu.Unlock()
 		}
 	}
 	return response, err
@@ -821,6 +842,35 @@ func (c *Client) checkRateLimitBeforeDo(req *http.Request, rateLimitCategory rat
 			Rate:     rate,
 			Response: resp,
 			Message:  fmt.Sprintf("API rate limit of %v still exceeded until %v, not making remote request.", rate.Limit, rate.Reset.Time),
+		}
+	}
+
+	return nil
+}
+
+// checkSecondaryRateLimitBeforeDo does not make any network calls, but uses existing knowledge from
+// current client state in order to quickly check if *AbuseRateLimitError can be immediately returned
+// from Client.Do, and if so, returns it so that Client.Do can skip making a network API call unnecessarily.
+// Otherwise it returns nil, and Client.Do should proceed normally.
+func (c *Client) checkSecondaryRateLimitBeforeDo(ctx context.Context, req *http.Request) *AbuseRateLimitError {
+	c.rateMu.Lock()
+	secondary := c.secondaryRateLimitReset
+	c.rateMu.Unlock()
+	if !secondary.IsZero() && time.Now().Before(secondary) {
+		// Create a fake response.
+		resp := &http.Response{
+			Status:     http.StatusText(http.StatusForbidden),
+			StatusCode: http.StatusForbidden,
+			Request:    req,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("")),
+		}
+
+		retryAfter := time.Until(secondary)
+		return &AbuseRateLimitError{
+			Response:   resp,
+			Message:    fmt.Sprintf("API secondary rate limit exceeded until %v, not making remote request.", secondary),
+			RetryAfter: &retryAfter,
 		}
 	}
 
@@ -1197,13 +1247,36 @@ const (
 	categories // An array of this length will be able to contain all rate limit categories.
 )
 
-// category returns the rate limit category of the endpoint, determined by Request.URL.Path.
-func category(path string) rateLimitCategory {
+// category returns the rate limit category of the endpoint, determined by HTTP method and Request.URL.Path.
+func category(method, path string) rateLimitCategory {
 	switch {
+	// https://docs.github.com/en/rest/rate-limit#about-rate-limits
 	default:
+		// NOTE: coreCategory is returned for actionsRunnerRegistrationCategory too,
+		// because no API found for this category.
 		return coreCategory
 	case strings.HasPrefix(path, "/search/"):
 		return searchCategory
+	case path == "/graphql":
+		return graphqlCategory
+	case strings.HasPrefix(path, "/app-manifests/") &&
+		strings.HasSuffix(path, "/conversions") &&
+		method == http.MethodPost:
+		return integrationManifestCategory
+
+	// https://docs.github.com/en/rest/migrations/source-imports#start-an-import
+	case strings.HasPrefix(path, "/repos/") &&
+		strings.HasSuffix(path, "/import") &&
+		method == http.MethodPut:
+		return sourceImportCategory
+
+	// https://docs.github.com/en/rest/code-scanning#upload-an-analysis-as-sarif-data
+	case strings.HasSuffix(path, "/code-scanning/sarifs"):
+		return codeScanningUploadCategory
+
+	// https://docs.github.com/en/enterprise-cloud@latest/rest/scim
+	case strings.HasPrefix(path, "/scim/"):
+		return scimCategory
 	}
 }
 

--- a/vendor/github.com/google/go-github/v50/github/issues_timeline.go
+++ b/vendor/github.com/google/go-github/v50/github/issues_timeline.go
@@ -143,6 +143,8 @@ type Timeline struct {
 
 	// The person requested to review the pull request.
 	Reviewer *User `json:"requested_reviewer,omitempty"`
+	// RequestedTeam contains the team requested to review the pull request.
+	RequestedTeam *Team `json:"requested_team,omitempty"`
 	// The person who requested a review.
 	Requester *User `json:"review_requester,omitempty"`
 

--- a/vendor/github.com/google/go-github/v50/github/orgs_audit_log.go
+++ b/vendor/github.com/google/go-github/v50/github/orgs_audit_log.go
@@ -63,8 +63,10 @@ type AuditEntry struct {
 	Message               *string     `json:"message,omitempty"`
 	Name                  *string     `json:"name,omitempty"`
 	OldUser               *string     `json:"old_user,omitempty"`
+	OldPermission         *string     `json:"old_permission,omitempty"` // The permission level for membership changes, for example `admin` or `read`.
 	OpenSSHPublicKey      *string     `json:"openssh_public_key,omitempty"`
 	Org                   *string     `json:"org,omitempty"`
+	Permission            *string     `json:"permission,omitempty"` // The permission level for membership changes, for example `admin` or `read`.
 	PreviousVisibility    *string     `json:"previous_visibility,omitempty"`
 	ReadOnly              *string     `json:"read_only,omitempty"`
 	Repo                  *string     `json:"repo,omitempty"`

--- a/vendor/github.com/google/go-github/v50/github/repos_collaborators.go
+++ b/vendor/github.com/google/go-github/v50/github/repos_collaborators.go
@@ -23,6 +23,13 @@ type ListCollaboratorsOptions struct {
 	// Default value is "all".
 	Affiliation string `url:"affiliation,omitempty"`
 
+	// Permission specifies how collaborators should be filtered by the permissions they have on the repository.
+	// Possible values are:
+	// "pull", "triage", "push", "maintain", "admin"
+	//
+	// If not specified, all collaborators will be returned.
+	Permission string `url:"permission,omitempty"`
+
 	ListOptions
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -295,7 +295,7 @@ github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
-# github.com/google/go-github/v50 v50.0.0
+# github.com/google/go-github/v50 v50.1.0
 ## explicit; go 1.17
 github.com/google/go-github/v50/github
 # github.com/google/go-querystring v1.1.0

--- a/website/docs/r/actions_repository_variable.html.markdown
+++ b/website/docs/r/actions_repository_variable.html.markdown
@@ -1,0 +1,54 @@
+---
+layout: "github"
+page_title: "GitHub: github_actions_repository_variable"
+description: |-
+  Creates and manages a GitHub Actions variable within a GitHub repository
+---
+
+# github_actions_repository_variable
+
+This resource allows you to create and manage GitHub Actions variables within your GitHub repositories. You must have write access to a repository to use this resource.
+
+GitHub Actions variables are not encrypted or secret. To store secret values, use `github_actions_secret` instead.
+
+## Example Usage
+
+```hcl
+resource "github_repository" "repo" {
+  name = "my-repo"
+}
+
+resource "github_actions_repository_variable" "username" {
+  repository = github_repository.repo.name
+  name       = "username"
+  value      = "defunkt"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `repository` - (Required) Name of the repository in which to create the variable.
+
+- `name` - (Required) Name of the variable to create. See GitHub's [naming constraints][naming-constraints] for more information.
+
+- `value` - (Required) Value of the variable. This value is stored in plaintext and available to anyone with access to read repository variables.
+
+
+## Attributes Reference
+
+- `created_at` - Timestamp of when the repository variable was created.
+
+- `updated_at` - Timestamp of when the repository variable was last updated.
+
+## Import
+
+This resource can be imported using an ID made up of the repo name  and variable name separated by a colon:
+
+```shell
+terraform import github_actions_repository_variable.username my-repo:username
+```
+
+
+[naming-constraints]: https://docs.github.com/en/actions/learn-github-actions/variables#naming-conventions-for-configuration-variables


### PR DESCRIPTION
This adds a new resource `github_actions_repository_variable` for adding [Actions Variable](https://docs.github.com/en/actions/learn-github-actions/variables#naming-conventions-for-configuration-variables) using the API. This required updating to the latest version of go-github, which is updated in `vendor/`.

Resolves #1534

----

## Behavior

### Before the change?

* There was no resource for managing repository actions variables.


### After the change?

* There is a resource for managing repository actions variables.


### Other information

* N/A

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No


### Pull request type

- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`