### PR TITLE
make `github_ref` respect `owner`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project is used to read and write to/from GitHub (repositories, teams, file
 
 ## Usage
 
-Detailed documentation for the GitHub provider can be found [here](https://www.terraform.io/docs/providers/github/index.html).
+Detailed documentation for the GitHub provider can be found [here](https://registry.terraform.io/providers/integrations/github).
 
 ## Contributing
 

--- a/github/data_source_github_ref.go
+++ b/github/data_source_github_ref.go
@@ -24,6 +24,10 @@ func dataSourceGithubRef() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"owner": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
 			"etag": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -38,15 +42,15 @@ func dataSourceGithubRef() *schema.Resource {
 
 func dataSourceGithubRefRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Owner).v3client
-	orgName := meta.(*Owner).name
+	owner := d.Get("owner").(string)
 	repoName := d.Get("repository").(string)
 	ref := d.Get("ref").(string)
 
-	refData, resp, err := client.Git.GetRef(context.TODO(), orgName, repoName, ref)
+	refData, resp, err := client.Git.GetRef(context.TODO(), owner, repoName, ref)
 	if err != nil {
 		if err, ok := err.(*github.ErrorResponse); ok {
 			if err.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[DEBUG] Missing GitHub ref %s/%s (%s)", orgName, repoName, ref)
+				log.Printf("[DEBUG] Missing GitHub ref %s/%s (%s)", owner, repoName, ref)
 				d.SetId("")
 				return nil
 			}

--- a/github/data_source_github_ref.go
+++ b/github/data_source_github_ref.go
@@ -26,7 +26,7 @@ func dataSourceGithubRef() *schema.Resource {
 			},
 			"owner": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"etag": {
 				Type:     schema.TypeString,
@@ -42,7 +42,10 @@ func dataSourceGithubRef() *schema.Resource {
 
 func dataSourceGithubRefRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Owner).v3client
-	owner := d.Get("owner").(string)
+	owner, ok := d.Get("owner").(string)
+	if !ok {
+		owner = meta.(*Owner).name
+	}
 	repoName := d.Get("repository").(string)
 	ref := d.Get("ref").(string)
 

--- a/website/docs/d/ref.html.markdown
+++ b/website/docs/d/ref.html.markdown
@@ -35,4 +35,6 @@ The following additional attributes are exported:
 
 * `etag` - An etag representing the ref.
 
+* `id` - A string storing a reference to the repository name and ref.
+
 * `sha` - A string storing the reference's `HEAD` commit's SHA1.

--- a/website/docs/d/ref.html.markdown
+++ b/website/docs/d/ref.html.markdown
@@ -13,14 +13,17 @@ Use this data source to retrieve information about a repository ref.
 
 ```hcl
 data "github_ref" "development" {
+  owner      = "example"
   repository = "example"
-  ref     = "heads/development"
+  ref        = "heads/development"
 }
 ```
 
 ## Argument Reference
 
 The following arguments are supported:
+
+* `owner` -  (Required) Owner of the repository.
 
 * `repository` - (Required) The GitHub repository name.
 


### PR DESCRIPTION
Hello maintainers 👋🏼 

<!-- Issues are required for both bug fixes and features. -->
Resolves #1650

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The `github_ref` data source is **not** able to provide data on repositories that are not of the same owner as the PAT / token

```
  "etag" = tostring(null)
  "id" = tostring(null)
  "ref" = tostring(null)
  "repository" = tostring(null)
  "sha" = tostring(null)
``` 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The `github_ref` data source **is** able to provide data on repositories that are not of the same owner as the PAT / token

```
  "etag" = "W/\"a1946ae73434cb3bcf8720087f56b426943582a4debb54785c4d43d631b581dc\""
  "id" = "setup-terraform:tags/v2.0.3"
  "owner" = "hashicorp"
  "ref" = "tags/v2.0.3"
  "repository" = "setup-terraform"
  "sha" = "633666f66e0061ca3b725c73b2ec20cd13a8fdd1"
```

### Other information
<!-- Any other information that is important to this PR  -->

* 

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

The `github_ref` data source now requires an `owner` attribute. I marked it as `required` in the code, which brings this data source in line with other data sources.

Not providing an `owner` would result in Terraform informing the user of a missing attribute (`owner`), which could break a deployment.

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [X] Yes (Please add the `Type: Breaking change` label)
- [ ] No

If `Yes`, what's the impact:  

* When using the `github_ref` data source, an `owner` attribute must now be provided.


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`

----

