### PR TITLE
feat: allow team slug instead of team id in github_team and github_team_members

### DIFF
--- a/github/resource_github_team.go
+++ b/github/resource_github_team.go
@@ -47,9 +47,9 @@ func resourceGithubTeam() *schema.Resource {
 				ValidateFunc: validateValueFunc([]string{"secret", "closed"}),
 			},
 			"parent_team_id": {
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "The ID of the parent team, if this is a nested team.",
+				Description: "The ID or slug of the parent team, if this is a nested team.",
 			},
 			"ldap_dn": {
 				Type:        schema.TypeString,
@@ -106,8 +106,11 @@ func resourceGithubTeamCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if parentTeamID, ok := d.GetOk("parent_team_id"); ok {
-		id := int64(parentTeamID.(int))
-		newTeam.ParentTeamID = &id
+		teamId, err := getTeamID(parentTeamID.(string), meta)
+		if err != nil {
+			return err
+		}
+		newTeam.ParentTeamID = &teamId
 	}
 	ctx := context.Background()
 

--- a/github/resource_github_team_members.go
+++ b/github/resource_github_team_members.go
@@ -26,11 +26,10 @@ func resourceGithubTeamMembers() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"team_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				Description:  "The GitHub team id.",
-				ValidateFunc: validateTeamIDFunc,
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The GitHub team id or slug",
 			},
 			"members": {
 				Type:        schema.TypeSet,

--- a/github/resource_github_team_test.go
+++ b/github/resource_github_team_test.go
@@ -65,17 +65,25 @@ func TestAccGithubTeamHierarchical(t *testing.T) {
 				description = "Terraform acc test parent team"
 				privacy     = "closed"
 			}
-			
+
 			resource "github_team" "child" {
 				name           = "tf-acc-child-%[1]s"
 				description    = "Terraform acc test child team"
 				privacy        = "closed"
 				parent_team_id = "${github_team.parent.id}"
 			}
+
+			resource "github_team" "child2" {
+				name           = "tf-acc-child-2-%[1]s"
+				description    = "Terraform acc test child 2 team"
+				privacy        = "closed"
+				parent_team_id = "${github_team.parent.slug}"
+			}
 		`, randomID)
 
 		check := resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttrSet("github_team.child", "parent_team_id"),
+			resource.TestCheckResourceAttrSet("github_team.child2", "parent_team_id"),
 		)
 
 		testCase := func(t *testing.T, mode string) {

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -31,7 +31,7 @@ The following arguments are supported:
 * `description` - (Optional) A description of the team.
 * `privacy` - (Optional) The level of privacy for the team. Must be one of `secret` or `closed`.
                Defaults to `secret`.
-* `parent_team_id` - (Optional) The ID of the parent team, if this is a nested team.
+* `parent_team_id` - (Optional) The ID or slug of the parent team, if this is a nested team.
 * `ldap_dn` - (Optional) The LDAP Distinguished Name of the group where membership will be synchronized. Only available in GitHub Enterprise Server.
 * `create_default_maintainer` - (Optional) Adds a default maintainer to the team. Defaults to `false` and adds the creating user to the team when `true`.
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #1583 

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->
- github_team_members supports passing a slug instead of an id directly, but the schema for the resource doesn't because of the validation function
- github_team doesn't support passing a slug instead of an id for the `parent_team_id`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- github_team_members no longer validates that the id is an int
- github_team supports using a slug instead of an id for `parent_team_id`


### Other information
<!-- Any other information that is important to this PR  -->

* 

----

## Additional info

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [X] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

