### PR TITLE
fix(resource_github_branch): creating branch and repo with gitignore doesn't 422 [1284]

### DIFF
--- a/github/resource_github_branch.go
+++ b/github/resource_github_branch.go
@@ -94,7 +94,9 @@ func resourceGithubBranchCreate(d *schema.ResourceData, meta interface{}) error 
 		Ref:    &branchRefName,
 		Object: &github.GitObject{SHA: &sourceBranchSHA},
 	})
-	if err != nil {
+	// If the branch already exists, rather than erroring out just continue on to importing the branch
+	//   This avoids the case where a repo with gitignore_template and branch are being created at the same time crashing terraform
+	if err != nil && !strings.HasSuffix(err.Error(), "422 Reference already exists []") {
 		return fmt.Errorf("error creating GitHub branch reference %s/%s (%s): %s",
 			orgName, repoName, branchRefName, err)
 	}


### PR DESCRIPTION
Resolves #1284 

----

## Behavior

### Before the change?
When creating a github_repository containing a gitignore_template and a github_branch named `main`, a 422 is returned and terraform fails to apply.

### After the change?
The above scenario creates the requested resources successfully

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?

- [ ] Yes (Please add the `Type: Breaking change` label)
- [X] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

