### PR TITLE
Fix nil pointer in runner group if not modified

### DIFF
--- a/github/resource_github_actions_runner_group.go
+++ b/github/resource_github_actions_runner_group.go
@@ -197,6 +197,11 @@ func resourceGithubActionsRunnerGroupRead(d *schema.ResourceData, meta interface
 		return err
 	}
 
+	//if runner group is nil (typically not modified) we can return early
+	if runnerGroup == nil {
+		return nil
+	}
+
 	d.Set("etag", resp.Header.Get("ETag"))
 	d.Set("allows_public_repositories", runnerGroup.GetAllowsPublicRepositories())
 	d.Set("default", runnerGroup.GetDefault())


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* reading the github_actions_runner_group will lead to a nil pointer exception if the API returns a 304 not modified response

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* the read method will return early (not setting the attributes on the schema) if the resource is not modified


### Other information
<!-- Any other information that is important to this PR  -->

* Partly fixes #1524 

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

