### PR TITLE
Make allows_public_repositories attribute on github_actions_runner_group modifiable

### DIFF
--- a/github/resource_github_actions_runner_group.go
+++ b/github/resource_github_actions_runner_group.go
@@ -141,7 +141,6 @@ func resourceGithubActionsRunnerGroupCreate(d *schema.ResourceData, meta interfa
 	if err != nil {
 		return err
 	}
-
 	d.SetId(strconv.FormatInt(runnerGroup.GetID(), 10))
 	d.Set("etag", resp.Header.Get("ETag"))
 	d.Set("allows_public_repositories", runnerGroup.GetAllowsPublicRepositories())

--- a/github/resource_github_actions_runner_group.go
+++ b/github/resource_github_actions_runner_group.go
@@ -25,7 +25,8 @@ func resourceGithubActionsRunnerGroup() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"allows_public_repositories": {
 				Type:        schema.TypeBool,
-				Computed:    true,
+				Optional:    true,
+				Default:     false,
 				Description: "Whether public repositories can be added to the runner group.",
 			},
 			"default": {
@@ -101,6 +102,7 @@ func resourceGithubActionsRunnerGroupCreate(d *schema.ResourceData, meta interfa
 	restrictedToWorkflows := d.Get("restricted_to_workflows").(bool)
 	visibility := d.Get("visibility").(string)
 	selectedRepositories, hasSelectedRepositories := d.GetOk("selected_repository_ids")
+	allowsPublicRepositories := d.Get("allows_public_repositories").(bool)
 
 	selectedWorkflows := []string{}
 	if workflows, ok := d.GetOk("selected_workflows"); ok {
@@ -128,16 +130,18 @@ func resourceGithubActionsRunnerGroupCreate(d *schema.ResourceData, meta interfa
 	runnerGroup, resp, err := client.Actions.CreateOrganizationRunnerGroup(ctx,
 		orgName,
 		github.CreateRunnerGroupRequest{
-			Name:                  &name,
-			Visibility:            &visibility,
-			RestrictedToWorkflows: &restrictedToWorkflows,
-			SelectedRepositoryIDs: selectedRepositoryIDs,
-			SelectedWorkflows:     selectedWorkflows,
+			Name:                     &name,
+			Visibility:               &visibility,
+			RestrictedToWorkflows:    &restrictedToWorkflows,
+			SelectedRepositoryIDs:    selectedRepositoryIDs,
+			SelectedWorkflows:        selectedWorkflows,
+			AllowsPublicRepositories: &allowsPublicRepositories,
 		},
 	)
 	if err != nil {
 		return err
 	}
+
 	d.SetId(strconv.FormatInt(runnerGroup.GetID(), 10))
 	d.Set("etag", resp.Header.Get("ETag"))
 	d.Set("allows_public_repositories", runnerGroup.GetAllowsPublicRepositories())
@@ -254,6 +258,7 @@ func resourceGithubActionsRunnerGroupUpdate(d *schema.ResourceData, meta interfa
 	visibility := d.Get("visibility").(string)
 	restrictedToWorkflows := d.Get("restricted_to_workflows").(bool)
 	selectedWorkflows := []string{}
+	allowsPublicRepositories := d.Get("allows_public_repositories").(bool)
 	if workflows, ok := d.GetOk("selected_workflows"); ok {
 		for _, workflow := range workflows.([]interface{}) {
 			selectedWorkflows = append(selectedWorkflows, workflow.(string))
@@ -261,10 +266,11 @@ func resourceGithubActionsRunnerGroupUpdate(d *schema.ResourceData, meta interfa
 	}
 
 	options := github.UpdateRunnerGroupRequest{
-		Name:                  &name,
-		Visibility:            &visibility,
-		RestrictedToWorkflows: &restrictedToWorkflows,
-		SelectedWorkflows:     selectedWorkflows,
+		Name:                     &name,
+		Visibility:               &visibility,
+		RestrictedToWorkflows:    &restrictedToWorkflows,
+		SelectedWorkflows:        selectedWorkflows,
+		AllowsPublicRepositories: &allowsPublicRepositories,
 	}
 
 	runnerGroupID, err := strconv.ParseInt(d.Id(), 10, 64)

--- a/github/resource_github_actions_runner_group_test.go
+++ b/github/resource_github_actions_runner_group_test.go
@@ -28,6 +28,7 @@ func TestAccGithubActionsRunnerGroup(t *testing.T) {
 			  visibility = "all"
 			  restricted_to_workflows = true
 			  selected_workflows = [".github/workflows/test.yml"]
+              allows_public_repositories = true
 			}
 		`, randomID)
 
@@ -50,6 +51,10 @@ func TestAccGithubActionsRunnerGroup(t *testing.T) {
 			resource.TestCheckResourceAttr(
 				"github_actions_runner_group.test", "selected_workflows",
 				"[\".github/workflows/test.yml\"]",
+			),
+			resource.TestCheckResourceAttr(
+				"github_actions_runner_group.test", "allows_public_repositories",
+				"true",
 			),
 		)
 

--- a/github/resource_github_actions_runner_group_test.go
+++ b/github/resource_github_actions_runner_group_test.go
@@ -28,7 +28,7 @@ func TestAccGithubActionsRunnerGroup(t *testing.T) {
 			  visibility = "all"
 			  restricted_to_workflows = true
 			  selected_workflows = [".github/workflows/test.yml"]
-              allows_public_repositories = true
+			  allows_public_repositories = true
 			}
 		`, randomID)
 

--- a/github/resource_github_actions_runner_group_test.go
+++ b/github/resource_github_actions_runner_group_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -21,14 +22,39 @@ func TestAccGithubActionsRunnerGroup(t *testing.T) {
 			resource "github_repository" "test" {
 			  name = "tf-acc-test-%s"
 			  vulnerability_alerts = false
+			  auto_init = true
+			}
+
+			resource "github_branch" "test" {
+				repository = github_repository.test.name
+				branch     = "test"
+			}
+
+			resource "github_branch_default" "default"{
+				repository = github_repository.test.name
+				branch     = github_branch.test.branch
+			}
+
+			resource "github_repository_file" "workflow_file" {
+				depends_on  = [github_branch_default.default]
+
+				repository          = github_repository.test.name
+				file                = ".github/workflows/test.yml"
+				content             = ""
+				commit_message      = "Managed by Terraform"
+				commit_author       = "Terraform User"
+				commit_email        = "terraform@example.com"
+				overwrite_on_create = true
 			}
 
 			resource "github_actions_runner_group" "test" {
-			  name       = github_repository.test.name
-			  visibility = "all"
-			  restricted_to_workflows = true
-			  selected_workflows = [".github/workflows/test.yml"]
-			  allows_public_repositories = true
+				depends_on  = [github_repository_file.workflow_file]
+
+				name       = github_repository.test.name
+				visibility = "all"
+				restricted_to_workflows = true
+				selected_workflows = ["${github_repository.test.full_name}/.github/workflows/test.yml@refs/heads/${github_branch.test.branch}"]
+				allows_public_repositories = true
 			}
 		`, randomID)
 
@@ -49,9 +75,25 @@ func TestAccGithubActionsRunnerGroup(t *testing.T) {
 				"true",
 			),
 			resource.TestCheckResourceAttr(
-				"github_actions_runner_group.test", "selected_workflows",
-				"[\".github/workflows/test.yml\"]",
+				"github_actions_runner_group.test", "selected_workflows.#",
+				"1",
 			),
+			func(state *terraform.State) error {
+
+				githubRepository := state.RootModule().Resources["github_repository.test"].Primary
+				fullName := githubRepository.Attributes["full_name"]
+
+				runnerGroup := state.RootModule().Resources["github_actions_runner_group.test"].Primary
+				workflowActual := runnerGroup.Attributes["selected_workflows.0"]
+
+				workflowExpected := fmt.Sprintf("%s/.github/workflows/test.yml@refs/heads/test", fullName)
+
+				if workflowActual != workflowExpected {
+					return fmt.Errorf("actual selected workflows %s not the same as expected selected workflows %s",
+						workflowActual, workflowExpected)
+				}
+				return nil
+			},
 			resource.TestCheckResourceAttr(
 				"github_actions_runner_group.test", "allows_public_repositories",
 				"true",

--- a/github/resource_github_actions_runner_group_test.go
+++ b/github/resource_github_actions_runner_group_test.go
@@ -26,35 +26,34 @@ func TestAccGithubActionsRunnerGroup(t *testing.T) {
 			}
 
 			resource "github_branch" "test" {
-				repository = github_repository.test.name
-				branch     = "test"
+			  repository = github_repository.test.name
+			  branch     = "test"
 			}
 
 			resource "github_branch_default" "default"{
-				repository = github_repository.test.name
-				branch     = github_branch.test.branch
+			  repository = github_repository.test.name
+			  branch     = github_branch.test.branch
 			}
 
 			resource "github_repository_file" "workflow_file" {
-				depends_on  = [github_branch_default.default]
-
-				repository          = github_repository.test.name
-				file                = ".github/workflows/test.yml"
-				content             = ""
-				commit_message      = "Managed by Terraform"
-				commit_author       = "Terraform User"
-				commit_email        = "terraform@example.com"
-				overwrite_on_create = true
+			  depends_on  = [github_branch_default.default]
+			  repository          = github_repository.test.name
+			  file                = ".github/workflows/test.yml"
+			  content             = ""
+			  commit_message      = "Managed by Terraform"
+			  commit_author       = "Terraform User"
+			  commit_email        = "terraform@example.com"
+			  overwrite_on_create = true
 			}
 
 			resource "github_actions_runner_group" "test" {
-				depends_on  = [github_repository_file.workflow_file]
-
-				name       = github_repository.test.name
-				visibility = "all"
-				restricted_to_workflows = true
-				selected_workflows = ["${github_repository.test.full_name}/.github/workflows/test.yml@refs/heads/${github_branch.test.branch}"]
-				allows_public_repositories = true
+			  depends_on  = [github_repository_file.workflow_file]
+				
+			  name       = github_repository.test.name
+			  visibility = "all"
+			  restricted_to_workflows = true
+			  selected_workflows = ["${github_repository.test.full_name}/.github/workflows/test.yml@refs/heads/${github_branch.test.branch}"]
+			  allows_public_repositories = true
 			}
 		`, randomID)
 

--- a/website/docs/r/actions_runner_group.html.markdown
+++ b/website/docs/r/actions_runner_group.html.markdown
@@ -28,11 +28,12 @@ resource "github_actions_runner_group" "example" {
 
 The following arguments are supported:
 
-* `name`                    - (Required) Name of the runner group
-* `restricted_to_workflows` - (Optional) If true, the runner group will be restricted to running only the workflows specified in the selected_workflows array. Defaults to false.
-* `selected_repository_ids` - (Optional) IDs of the repositories which should be added to the runner group
-* `selected_workflows`      - (Optional) List of workflows the runner group should be allowed to run. This setting will be ignored unless restricted_to_workflows is set to true.
-* `visibility`              - (Optional) Visibility of a runner group. Whether the runner group can include `all`, `selected`, or `private` repositories. A value of `private` is not currently supported due to limitations in the GitHub API.
+* `name`                       - (Required) Name of the runner group
+* `restricted_to_workflows`    - (Optional) If true, the runner group will be restricted to running only the workflows specified in the selected_workflows array. Defaults to false.
+* `selected_repository_ids`    - (Optional) IDs of the repositories which should be added to the runner group
+* `selected_workflows`         - (Optional) List of workflows the runner group should be allowed to run. This setting will be ignored unless restricted_to_workflows is set to true.
+* `visibility`                 - (Optional) Visibility of a runner group. Whether the runner group can include `all`, `selected`, or `private` repositories. A value of `private` is not currently supported due to limitations in the GitHub API.
+* `allows_public_repositories` - (Optional) Whether public repositories can be added to the runner group. Defaults to false.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #1697

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Currently the allows_public_repositories attribute on the github_actions_runner_group resource is marked as computed an thus can not be set.
* The attribute is however settable via the API (see https://docs.github.com/en/enterprise-cloud@latest/rest/actions/self-hosted-runner-groups?apiVersion=2022-11-28#create-a-self-hosted-runner-group-for-an-organization)

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The allows_public_repositories attribute is now marked as Optional with the value defaulting to false (the same default value as described by the GitHub API)


### Other information
<!-- Any other information that is important to this PR  -->

* The Acceptance tests for the github_actions_runner_group were not working. The selected_workflows test case references a) a file that does not exist and b) uses an invalid ref. I have updated the acceptance tests ensuring that the workflow file exists in the given repo and that the correct ref to the file is used.
* One could think about updating the docs, as the ref in the current example is misleading

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

