### PR TITLE
fix: Add build_type to datasource github_repository's pages (closes #1709)

### DIFF
--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -135,6 +135,10 @@ func dataSourceGithubRepository() *schema.Resource {
 								},
 							},
 						},
+						"build_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"cname": {
 							Type:     schema.TypeString,
 							Computed: true,


### PR DESCRIPTION
PR #1663 added the "build_type" attribute to the github_repository resource. Since the corresponding data source uses the same code to parse the pages endpoint data, any use of the github_repository datasource would lead to an error, since the attribute did not exist there:

> Error: error setting pages: Invalid address to set: []string{"pages", "0", "build_type"}

This commit adds the missing attribute. The existing acceptance tests already cover it, failed for me when running without this commit, and passed after.

Resolves #1709

----

## Behavior

### Before the change?
Provider would error for github_repository data sources, when the repository had actions enabled (both legacy and workflow build_types).

### After the change?
Provider exposes new `build_type` attribute inside `pages` map for `github_repository` datasource.

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No
