### PR TITLE
Fix #1555: Avoid duplication of pull reqyuest bypasser

### DIFF
--- a/github/util_v4_branch_protection.go
+++ b/github/util_v4_branch_protection.go
@@ -343,6 +343,7 @@ func setBypassPullRequestActorIDs(actors []BypassPullRequestActorTypes, data Bra
 			}
 			if a.Actor.User.Login != "" {
 				bypassActors = append(bypassActors, "/"+string(a.Actor.User.Login))
+				continue
 			}
 			if a.Actor.App != (Actor{}) {
 				bypassActors = append(bypassActors, a.Actor.App.ID.(string))


### PR DESCRIPTION
Fix #1555 

This one line patch avoid to duplicate pull request bypasser while reading branch protection.