### PR TITLE
Add note documenting weird permissions required

### DIFF
--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -11,7 +11,7 @@ This resource allows you to create and manage repositories within your
 GitHub organization or personal account.
 
 ~> Note: When used with GitHub App authentication, even GET requests must have
-the `contents:write` permission or else `allow_merge_commit`, `allow_rebase_merge`,
+the `contents:write` permission or else the `allow_merge_commit`, `allow_rebase_merge`,
 and `allow_squash_merge` attributes will be ignored, causing confusing diffs.
 
 ## Example Usage

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -10,6 +10,10 @@ description: |-
 This resource allows you to create and manage repositories within your
 GitHub organization or personal account.
 
+~> Note: When used with GitHub App authentication, even GET requests must have
+the `contents:write` permission or else `allow_merge_commit`, `allow_rebase_merge`,
+and `allow_squash_merge` attributes will be ignored, causing confusing diffs.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
See #679. The API requires write permissions to properly hydrate GET requests in some github_repository cases. While this is the case in the API, we should document it here to avoid confusion if possible. 