### PR TITLE
fix: Repo Creation fails with enabled Pages

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -836,20 +836,23 @@ func expandPages(input []interface{}) *github.Pages {
 		return nil
 	}
 	pages := input[0].(map[string]interface{})
-	var source *github.PagesSource
-	if pagesSource, ok := pages["source"].([]interface{})[0].(map[string]interface{}); ok {
-		if v, ok := pagesSource["branch"].(string); ok {
-			if v != "" {
+	source := &github.PagesSource{
+		Branch: github.String("main"),
+	}
+	if len(pages["source"].([]interface{})) == 1 {
+		if pagesSource, ok := pages["source"].([]interface{})[0].(map[string]interface{}); ok {
+			if v, ok := pagesSource["branch"].(string); ok {
 				source.Branch = github.String(v)
 			}
-		}
-		if v, ok := pagesSource["path"].(string); ok {
-			// To set to the root directory "/", leave source.Path unset
-			if v != "" && v != "/" {
-				source.Path = github.String(v)
+			if v, ok := pagesSource["path"].(string); ok {
+				// To set to the root directory "/", leave source.Path unset
+				if v != "" && v != "/" {
+					source.Path = github.String(v)
+				}
 			}
 		}
 	}
+
 	var buildType *string
 	if v, ok := pages["build_type"].(string); ok {
 		buildType = github.String(v)

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -859,6 +859,47 @@ func TestAccGithubRepositoryPages(t *testing.T) {
 
 	})
 
+	t.Run("expand Pages configuration with workflow", func(t *testing.T) {
+		input := []interface{}{map[string]interface{}{
+			"build_type": "workflow",
+			"source":     []interface{}{map[string]interface{}{}},
+		}}
+
+		pages := expandPages(input)
+		if pages == nil {
+			t.Fatal("pages is nil")
+		}
+		if pages.GetBuildType() != "workflow" {
+			t.Errorf("got %q; want %q", pages.GetBuildType(), "workflow")
+		}
+		if pages.GetSource().GetBranch() != "main" {
+			t.Errorf("got %q; want %q", pages.GetSource().GetBranch(), "main")
+		}
+	})
+
+	t.Run("expand Pages configuration with source", func(t *testing.T) {
+		input := []interface{}{map[string]interface{}{
+			"build_type": "legacy",
+			"source": []interface{}{map[string]interface{}{
+				"branch": "main",
+				"path":   "/docs",
+			}},
+		}}
+
+		pages := expandPages(input)
+		if pages == nil {
+			t.Fatal("pages is nil")
+		}
+		if pages.GetBuildType() != "legacy" {
+			t.Errorf("got %q; want %q", pages.GetBuildType(), "legacy")
+		}
+		if pages.GetSource().GetBranch() != "main" {
+			t.Errorf("got %q; want %q", pages.GetSource().GetBranch(), "main")
+		}
+		if pages.GetSource().GetPath() != "/docs" {
+			t.Errorf("got %q; want %q", pages.GetSource().GetPath(), "/docs")
+		}
+	})
 }
 
 func TestAccGithubRepositorySecurity(t *testing.T) {


### PR DESCRIPTION
Resolves #1743

----

## Behavior

### Before the change?

* Repository creation fails due to a nil pointer in `expandPages`

### After the change?

* `expandPages` is properly checks the input
* Tests added for `expandPages`

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A




