### PR TITLE
Fixes accidental deletion of Repository resource from state

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -593,8 +593,15 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 
 func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Owner).v3client
+
 	owner := meta.(*Owner).name
 	repoName := d.Id()
+
+	// When the user has not authenticated the provider, AnonymousHTTPClient is used, therefore owner == "". In this
+	// case lookup the owner in the data, and use that, if present.
+	if explicitOwner, _, ok := resourceGithubParseFullName(d); ok && owner == "" {
+		owner = explicitOwner
+	}
 
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 	if !d.IsNewResource() {
@@ -938,4 +945,24 @@ func flattenSecurityAndAnalysis(securityAndAnalysis *github.SecurityAndAnalysis)
 	}}
 
 	return []interface{}{securityAndAnalysisMap}
+}
+
+// In case full_name can be determined from the data, parses it into an org and repo name proper. For example,
+// resourceGithubParseFullName will return "myorg", "myrepo", true when full_name is "myorg/myrepo".
+func resourceGithubParseFullName(resourceDataLike interface {
+	GetOk(string) (interface{}, bool)
+}) (string, string, bool) {
+	x, ok := resourceDataLike.GetOk("full_name")
+	if !ok {
+		return "", "", false
+	}
+	s, ok := x.(string)
+	if !ok || s == "" {
+		return "", "", false
+	}
+	parts := strings.Split(s, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
 }

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAccGithubRepositories(t *testing.T) {
@@ -1365,4 +1366,22 @@ func reconfigureVisibility(config, visibility string) string {
 		fmt.Sprintf(`visibility = "%s"`, visibility),
 	)
 	return newConfig
+}
+
+type resourceDataLike map[string]interface{}
+
+func (d resourceDataLike) GetOk(key string) (interface{}, bool) {
+	v, ok := d[key]
+	return v, ok
+}
+
+func TestResourceGithubParseFullName(t *testing.T) {
+	repo, org, ok := resourceGithubParseFullName(resourceDataLike(map[string]interface{}{"full_name": "myrepo/myorg"}))
+	assert.True(t, ok)
+	assert.Equal(t, "myrepo", repo)
+	assert.Equal(t, "myorg", org)
+	_, _, ok = resourceGithubParseFullName(resourceDataLike(map[string]interface{}{}))
+	assert.False(t, ok)
+	_, _, ok = resourceGithubParseFullName(resourceDataLike(map[string]interface{}{"full_name": "malformed"}))
+	assert.False(t, ok)
 }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

Currently when the user does not authenticate the provider, refreshing a GithubRepository resource drops it from the state, which is unexpected and very confusing.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The suggested fix consults the resource data to infer the appropriate owner to use instead of the empty owner. For pubic repositories this makes the Read method proceed correctly.

### Other information
<!-- Any other information that is important to this PR  -->

The suspected root cause of this is: when AnonymousHTTPClient is used, owner == "" and this causes resourceGithubRepositoryRead to issue requests to non-existent URLs such as https://github.com//myrepo and subsequently interpret 404 as a reason to drop the resource from the state.

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

