### PR TITLE
fix: support team slug in github_team_membership

### DIFF
--- a/github/resource_github_team_membership.go
+++ b/github/resource_github_team_membership.go
@@ -36,11 +36,10 @@ func resourceGithubTeamMembership() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"team_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				Description:  "The GitHub team id or the GitHub team slug.",
-				ValidateFunc: validateTeamIDFunc,
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The GitHub team id or the GitHub team slug.",
 			},
 			"username": {
 				Type:             schema.TypeString,

--- a/github/resource_github_team_membership_test.go
+++ b/github/resource_github_team_membership_test.go
@@ -24,6 +24,7 @@ func TestAccGithubTeamMembership_basic(t *testing.T) {
 	var membership github.Membership
 
 	rn := "github_team_membership.test_team_membership"
+	rns := "github_team_membership.test_team_membership_slug"
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -36,6 +37,8 @@ func TestAccGithubTeamMembership_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGithubTeamMembershipExists(rn, &membership),
 					testAccCheckGithubTeamMembershipRoleState(rn, "member", &membership),
+					testAccCheckGithubTeamMembershipExists(rns, &membership),
+					testAccCheckGithubTeamMembershipRoleState(rns, "member", &membership),
 				),
 			},
 			{
@@ -43,10 +46,17 @@ func TestAccGithubTeamMembership_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGithubTeamMembershipExists(rn, &membership),
 					testAccCheckGithubTeamMembershipRoleState(rn, "maintainer", &membership),
+					testAccCheckGithubTeamMembershipExists(rns, &membership),
+					testAccCheckGithubTeamMembershipRoleState(rns, "maintainer", &membership),
 				),
 			},
 			{
 				ResourceName:      rn,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      rns,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -222,12 +232,23 @@ resource "github_team" "test_team" {
   description = "Terraform acc test group"
 }
 
+resource "github_team" "test_team_slug" {
+  name        = "tf-acc-test-team-membership-%s-slug"
+  description = "Terraform acc test group"
+}
+
 resource "github_team_membership" "test_team_membership" {
   team_id  = "${github_team.test_team.id}"
   username = "%s"
   role     = "%s"
 }
-`, username, randString, username, role)
+
+resource "github_team_membership" "test_team_membership_slug" {
+  team_id  = "${github_team.test_team_slug.slug}"
+  username = "%s"
+  role     = "%s"
+}
+`, username, randString, randString, username, role, username, role)
 }
 
 func testAccGithubTeamMembershipTheSame(orig, other *github.Membership) resource.TestCheckFunc {


### PR DESCRIPTION
Resolves #1749.

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

The `github_team_membership` would only accept numeric ID as `team_id`,
despite the docs claiming to accept a team slug as well.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Both numeric ID and team slug are accepted by the `team_id` field.

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

