### PR TITLE
Fix `resourceGithubDependabotOrganizationSecretCreateOrUpdate`

### DIFF
--- a/github/resource_github_dependabot_organization_secret.go
+++ b/github/resource_github_dependabot_organization_secret.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"log"
+	"net/http"
+
 	"github.com/google/go-github/v53/github"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"log"
-	"net/http"
 )
 
 func resourceGithubDependabotOrganizationSecret() *schema.Resource {
@@ -101,7 +102,7 @@ func resourceGithubDependabotOrganizationSecretCreateOrUpdate(d *schema.Resource
 		ids := selectedRepositories.(*schema.Set).List()
 
 		for _, id := range ids {
-			selectedRepositoryIDs = append(selectedRepositoryIDs, id.(int64))
+			selectedRepositoryIDs = append(selectedRepositoryIDs, int64(id.(int)))
 		}
 	}
 


### PR DESCRIPTION
Fixes a regression used when trying to create/update a dependabot organization secret. List is an `int` so cannot be cast to a different type. We therefore double convert it.

There was a regression introduced by version 5.27. This happened as the go-github client moved over to using int64 as ids in v53.0.0

```hcl
terraform {
  required_providers {
    github = {
      source = "integrations/github"
      version = "5.27.0"
    }
  }
}

provider "github" {
  owner = var.owner
}

variable "owner" {
  type = string
}

resource "github_repository" "example" {
  name        = "example"
  description = "My awesome codebase"
  visibility = "public"
}

resource "github_dependabot_organization_secret" "example" {
  secret_name     = "example"
  visibility      = "selected"
  plaintext_value = "anything"
  selected_repository_ids = [
    github_repository.example.repo_id,
  ]
}
```

Resolves https://github.com/integrations/terraform-provider-github/issues/1746

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
It should fix an issue after the provider get upgraded. 

- [x] No

Notes: 
  * Unsure how to write a test for this change. Guidance would be nice. I ran an integration test and it all worked using the sample code and a local build of the provider pointing the client that had the change.
  * Depends on https://github.com/google/go-github/pull/2817 being released (and client updated)