### PR TITLE
Add data source for github_actions_environment_public_key

### DIFF
--- a/github/data_source_github_actions_environment_public_key.go
+++ b/github/data_source_github_actions_environment_public_key.go
@@ -1,0 +1,58 @@
+package github
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceGithubActionsEnvironmentPublicKey() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGithubActionsEnvironmentPublicKeyRead,
+
+		Schema: map[string]*schema.Schema{
+			"repository": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"environment": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceGithubActionsEnvironmentPublicKeyRead(d *schema.ResourceData, meta interface{}) error {
+	repoName := d.Get("repository").(string)
+	envName := d.Get("environment").(string)
+
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
+
+	ctx := context.Background()
+
+	repo, _, err := client.Repositories.Get(ctx, owner, repoName)
+	if err != nil {
+		return err
+	}
+
+	publicKey, _, err := client.Actions.GetEnvPublicKey(ctx, int(repo.GetID()), envName)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(publicKey.GetKeyID())
+	d.Set("key_id", publicKey.GetKeyID())
+	d.Set("key", publicKey.GetKey())
+
+	return nil
+}

--- a/github/data_source_github_actions_environment_public_key_test.go
+++ b/github/data_source_github_actions_environment_public_key_test.go
@@ -1,0 +1,49 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccGithubActionsEnvironmentPublicKeyDataSource(t *testing.T) {
+
+	t.Run("queries an environment public key without error", func(t *testing.T) {
+
+		config := `
+			data "github_actions_environment_public_key" "test" {}
+		`
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttrSet(
+				"data.github_actions_environment_public_key.test", "key",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			t.Skip("individual account not supported for this operation")
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
+}

--- a/github/data_source_github_actions_environment_public_key_test.go
+++ b/github/data_source_github_actions_environment_public_key_test.go
@@ -11,7 +11,20 @@ func TestAccGithubActionsEnvironmentPublicKeyDataSource(t *testing.T) {
 	t.Run("queries an environment public key without error", func(t *testing.T) {
 
 		config := `
-			data "github_actions_environment_public_key" "test" {}
+		    resource "github_repository" "test" {
+		        name      = "tf-acc-test-%s"
+		        auto_init = true
+		    }
+
+			resource "github_repository_environment" "test" {
+				repository       = github_repository.test.name
+				environment      = "test_environment_name"
+			}
+
+			data "github_actions_environment_public_key" "test" {
+				repository       = github_repository.test.name
+				environment      = "test_environment_name"
+			}
 		`
 
 		check := resource.ComposeTestCheckFunc(

--- a/github/provider.go
+++ b/github/provider.go
@@ -159,6 +159,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"github_actions_environment_public_key":                                 dataSourceGithubActionsEnvironmentPublicKey(),
 			"github_actions_environment_secrets":                                    dataSourceGithubActionsEnvironmentSecrets(),
 			"github_actions_environment_variables":                                  dataSourceGithubActionsEnvironmentVariables(),
 			"github_actions_organization_oidc_subject_claim_customization_template": dataSourceGithubActionsOrganizationOIDCSubjectClaimCustomizationTemplate(),

--- a/website/docs/d/actions_environment_public_key.html.markdown
+++ b/website/docs/d/actions_environment_public_key.html.markdown
@@ -1,0 +1,30 @@
+---
+layout: "github"
+page_title: "GitHub: github_actions_environment_public_key"
+description: |-
+  Get information on a GitHub Actions Environment Public Key.
+---
+
+# github_actions_environment_public_key
+
+Use this data source to retrieve information about a GitHub Actions Environment public key. This data source is required to be used with other GitHub secrets interactions.
+Note that the provider `token` must have admin rights to an organization to retrieve it's actions environment public key.
+
+## Example Usage
+
+```hcl
+data "github_actions_environment_public_key" "example" {
+  repository = "example_repo"
+  environment = "example_environment" 
+}
+```
+
+## Argument Reference
+
+* `repository`  - (Required) Name of the repository to get public key from.
+* `environment` - (Required) Name of the environment.
+
+## Attributes Reference
+
+* `key_id` - ID of the key that has been retrieved.
+* `key`    - Actual key retrieved.

--- a/website/github.erb
+++ b/website/github.erb
@@ -14,6 +14,9 @@
           <a href="#">Data Sources</a>
           <ul class="nav nav-visible">
             <li>
+              <a href="/docs/providers/github/d/actions_environment_public_key.html">actions_environment_public_key</a>
+            </li>          
+            <li>
               <a href="/docs/providers/github/d/actions_environment_secrets.html">actions_environment_secrets</a>
             </li>
             <li>


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #1769

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* When setting secrets for an action environment, you need to use the key for that environment. There is currently no datasource for fetching this particular key.

 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* There is now a data source for github_actions_environment_public_key


### Other information

* 

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

I'm looking for guidance on how to best test this.
I'm also looking for guidance on how to update the docs. Are they auto-generated or does one edit stuff under `website/`?

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->
No

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

