### PR TITLE
Fix: incorrect field name in docs for github_repository_collaborators

### DIFF
--- a/website/docs/r/repository_collaborators.html.markdown
+++ b/website/docs/r/repository_collaborators.html.markdown
@@ -77,7 +77,7 @@ The `user` block supports:
 
 The `team` block supports:
 
-* `team` - (Required) The GitHub team id or the GitHub team slug
+* `team_id` - (Required) The GitHub team id or the GitHub team slug
 * `permission` - (Optional) The permission of the outside collaborators for the repository.
   Must be one of `pull`, `triage`, `push`, `maintain`, `admin` or the name of an existing [custom repository role](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-peoples-access-to-your-organization-with-roles/managing-custom-repository-roles-for-an-organization) within the organisation. Defaults to `pull`.
   Must be `push` for personal repositories. Defaults to `push`.


### PR DESCRIPTION
The doc for the [repository_collaborators](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_collaborators#team) was having:
> The team block supports:
> [team](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_collaborators#team) - (Required) The GitHub team id or the GitHub team slug

But the actual field name used in terraform is `team_id`, not `team`.

Updated the docs to prevent confusion.

