### PR TITLE
fix: remove validation for team.permission on `github_repository_collaborators`

### DIFF
--- a/github/resource_github_repository_collaborators.go
+++ b/github/resource_github_repository_collaborators.go
@@ -54,10 +54,9 @@ func resourceGithubRepositoryCollaborators() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"permission": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Default:      "push",
-							ValidateFunc: validateValueFunc([]string{"pull", "triage", "push", "maintain", "admin"}),
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "push",
 						},
 						"team_id": {
 							Type:        schema.TypeString,


### PR DESCRIPTION
Resolves #1775 

----

## Behavior

### Before the change?
* `github_repository_collaborators.team.#.permission` had validation that prevented the use of custom roles

### After the change?
* `github_repository_collaborators.team.#.permission` no longer has a validation rule, matching the same configuration as the `github_repository_collaborators.user.#.permission` attribute.

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

- Bugfix: `Type: Bug`

