### PR TITLE
Don't run go mod tidy on release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,9 +1,11 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
 before:
-  hooks:
+  hooks: []
     # this is just an example and not a requirement for provider building/publishing
-    - go mod tidy
+    # commenting for now to unbreak releases. this can be uncommented when we
+    # update to the next major version of the terraform-provider-sdk.
+    # - go mod tidy
 builds:
 - env:
     # goreleaser does not work with CGO, it could also complicate

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@ before:
   hooks: []
     # this is just an example and not a requirement for provider building/publishing
     # commenting for now to unbreak releases. this can be uncommented when we
-    # update to the next major version of the terraform-provider-sdk.
+    # update from v1.17.2 to v2 of the terraform-provider-sdk.
     # - go mod tidy
 builds:
 - env:


### PR DESCRIPTION
This will temporarily unblock releases. The more permanent solution is present in #1780. 