### PR TITLE
Documentation enhancements for `github_repository_deployment_branch_policy` resource

### DIFF
--- a/website/docs/r/repository_deployment_branch_policy.html.markdown
+++ b/website/docs/r/repository_deployment_branch_policy.html.markdown
@@ -23,9 +23,11 @@ resource "github_repository_environment" "env" {
 }
 
 resource "github_repository_deployment_branch_policy" "foo" {
-  repository = "my_repo"
+  depends_on = [github_repository_environment.env]
+
+  repository       = "my_repo"
   environment_name = "my_env"
-  name = "foo"
+  name             = "foo"
 }
 ```
 
@@ -36,7 +38,7 @@ The following arguments are supported:
 
 * `repository` - (Required) The repository to create the policy in.
 
-* `environment_name` - (Required) The name of the environment. This environment must have `deployment_branch_policy.custom_branch_policies` set to true.
+* `environment_name` - (Required) The name of the environment. This environment must have `deployment_branch_policy.custom_branch_policies` set to true or a 404 error will be thrown.
 
 * `name` - (Required) The name pattern that branches must match in order to deploy to the environment.
 


### PR DESCRIPTION
### Before the change?
1. The documentation example is missing the required `depends_on` meta-argument. Without this, Terraform will often try to deploy the `github_repository_deployment_branch_policy` before the corresponding `github_repository_environment` which results in an ambiguous 404 error being returned from the API.

2. A separate (but equally ambiguous) 404 is returned from the API when the `github_repository_environment` referenced by the `github_repository_deployment_branch_policy` resource has `custom_branch_policies` set to `false`. I believe the design pattern is to catch this error in the Terraform provider rather than rely on the API returning a descriptive error (which it doesn't do). This can catch one off-guard since the documentation says the `custom_branch_policies` must be set to `true`, but doesn't mention the somewhat unusual behaviour of the API returning a 404 (rather than Terraform complaining about the attribute) if this attribute is set incorrectly. This personally caused me a few hours of frustration, so it would be good to make others aware of this behaviour.

3. The Terraform code in the example hadn't been run through `terraform fmt`.

### After the change?
1. The required `depends_on` attribute has been added to the documentation example to prevent the branch policy being created before the corresponding environment.

2. The `environment_name` argument's description has been enhanced to describe the behaviour that occurs if `deployment_branch_policy.custom_branch_policies` is not set to `true`.

3. The examples have been run through `terraform fmt`.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

