### PR TITLE
[FEAT]: expose primary language in github_repository

### DIFF
--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -110,6 +110,10 @@ func dataSourceGithubRepository() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"primary_language": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"archived": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -271,6 +275,7 @@ func dataSourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("has_downloads", repo.GetHasDownloads())
 	d.Set("full_name", repo.GetFullName())
 	d.Set("default_branch", repo.GetDefaultBranch())
+	d.Set("primary_language", repo.GetLanguage())
 	d.Set("html_url", repo.GetHTMLURL())
 	d.Set("ssh_clone_url", repo.GetSSHURL())
 	d.Set("svn_url", repo.GetSVNURL())

--- a/github/data_source_github_repository_test.go
+++ b/github/data_source_github_repository_test.go
@@ -269,4 +269,114 @@ func TestAccGithubRepositoryDataSource(t *testing.T) {
 		})
 
 	})
+
+	t.Run("queries a repository that has no primary_language", func(t *testing.T) {
+
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name = "tf-acc-%s"
+			}
+
+			data "github_repository" "test" {
+				name = github_repository.test.name
+			}
+		`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"data.github_repository.test", "primary_language",
+				"",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
+
+	t.Run("queries a repository that has go as primary_language", func(t *testing.T) {
+
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name = "tf-acc-%s"
+				auto_init = true
+			}
+			
+			resource "github_repository_file" "test_1" {
+				repository     = github_repository.test.name
+				file           = "test_1.go"
+				content        = "package main"
+			}
+
+			# Calling the datasource directly after the file is created doesnt give it time to update the primary_language. Create a second one to give it more time (see https://github.com/integrations/terraform-provider-github/pull/1836 for reference)
+			resource "github_repository_file" "test_2" {
+				repository     = github_repository_file.test_1.repository
+				file           = "test_2.go"
+				content        = "package main"
+			}
+			
+			data "github_repository" "test" {
+				name = github_repository_file.test_2.repository
+			}
+		`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"data.github_repository.test", "primary_language",
+				"Go",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
 }

--- a/github/data_source_github_repository_test.go
+++ b/github/data_source_github_repository_test.go
@@ -351,7 +351,7 @@ func TestAccGithubRepositoryDataSource(t *testing.T) {
 				Providers: testAccProviders,
 				Steps: []resource.TestStep{
 					{
-						// Not doing any checks since the file needs to be created before the language can be updated
+						// Not doing any checks since the language doesnt have time to be updated on the first apply
 						Config: config,
 					},
 					{

--- a/github/data_source_github_repository_test.go
+++ b/github/data_source_github_repository_test.go
@@ -327,22 +327,14 @@ func TestAccGithubRepositoryDataSource(t *testing.T) {
 				name = "tf-acc-%s"
 				auto_init = true
 			}
-			
-			resource "github_repository_file" "test_1" {
+			resource "github_repository_file" "test" {
 				repository     = github_repository.test.name
-				file           = "test_1.go"
+				file           = "test.go"
 				content        = "package main"
 			}
 
-			# Calling the datasource directly after the file is created doesnt give it time to update the primary_language. Create a second one to give it more time (see https://github.com/integrations/terraform-provider-github/pull/1836 for reference)
-			resource "github_repository_file" "test_2" {
-				repository     = github_repository_file.test_1.repository
-				file           = "test_2.go"
-				content        = "package main"
-			}
-			
 			data "github_repository" "test" {
-				name = github_repository_file.test_2.repository
+				name = github_repository_file.test.repository
 			}
 		`, randomID)
 
@@ -359,6 +351,11 @@ func TestAccGithubRepositoryDataSource(t *testing.T) {
 				Providers: testAccProviders,
 				Steps: []resource.TestStep{
 					{
+						// Not doing any checks since the file needs to be created before the language can be updated
+						Config: config,
+					},
+					{
+						// Re-running the terraform will refresh the language since the go-file has been created
 						Config: config,
 						Check:  check,
 					},

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -352,6 +352,10 @@ func resourceGithubRepository() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"primary_language": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"template": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -642,6 +646,7 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("etag", resp.Header.Get("ETag"))
 	d.Set("name", repoName)
 	d.Set("description", repo.GetDescription())
+	d.Set("primary_language", repo.GetLanguage())
 	d.Set("homepage_url", repo.GetHomepage())
 	d.Set("private", repo.GetPrivate())
 	d.Set("visibility", repo.GetVisibility())

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -897,7 +897,7 @@ func TestAccGithubRepositories(t *testing.T) {
 					{
 						// Re-running the terraform will refresh the language since the go-file has been created
 						Config: config,
-						Check: check,
+						Check:  check,
 					},
 				},
 			})

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -865,7 +865,7 @@ func TestAccGithubRepositories(t *testing.T) {
 			testCase(t, organization)
 		})
 	})
-	t.Run("updates a repositories name without error", func(t *testing.T) {
+	t.Run("create a repository with go as primary_language", func(t *testing.T) {
 		config := fmt.Sprintf(`
 			resource "github_repository" "test" {
 				name = "tf-acc-%s"

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -865,6 +865,57 @@ func TestAccGithubRepositories(t *testing.T) {
 			testCase(t, organization)
 		})
 	})
+	t.Run("updates a repositories name without error", func(t *testing.T) {
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name = "tf-acc-%s"
+				auto_init = true
+			}
+			resource "github_repository_file" "test" {
+				repository     = github_repository.test.name
+				file           = "test.go"
+				content        = "package main"
+			}
+		`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_repository.test", "primary_language",
+				"Go",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						// Not doing any checks since the file needs to be created before the language can be updated
+						Config: config,
+					},
+					{
+						// Re-running the terraform will refresh the language since the go-file has been created
+						Config: config,
+						Check: check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
 
 }
 func TestAccGithubRepositoryPages(t *testing.T) {

--- a/website/docs/d/repository.html.markdown
+++ b/website/docs/d/repository.html.markdown
@@ -69,6 +69,8 @@ The following arguments are supported:
 
 * `default_branch` - The name of the default branch of the repository.
 
+* `primary_language` - The primary language used in the repository.
+
 * `archived` - Whether the repository is archived.
 
 * `pages` - The repository's GitHub Pages configuration.

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -194,6 +194,8 @@ The following additional attributes are exported:
 
 * `repo_id` - GitHub ID for the repository
 
+* `primary_language` - The primary language used in the repository.
+
 * `pages` - The block consisting of the repository's GitHub Pages configuration with the following additional attributes:
  * `custom_404` - Whether the rendered GitHub Pages site has a custom 404 page.
  * `html_url` - The absolute URL (including scheme) of the rendered GitHub Pages site e.g. `https://username.github.io`.


### PR DESCRIPTION
Resolves #1835

----

### Before the change?

* The primary language of a repository was not exposed in either the `github_repository` datasource or resource

### After the change?

* The primary language of a repository is now exposed in both the `github_repository` datasource and resource

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

