### PR TITLE
feat: Implement github_repository_dependabot_security_updates resource

### DIFF
--- a/github/provider.go
+++ b/github/provider.go
@@ -136,6 +136,7 @@ func Provider() terraform.ResourceProvider {
 			"github_release":                                                        resourceGithubRelease(),
 			"github_repository":                                                     resourceGithubRepository(),
 			"github_repository_autolink_reference":                                  resourceGithubRepositoryAutolinkReference(),
+			"github_repository_dependabot_security_updates":                         resourceGithubRepositoryDependabotSecurityUpdates(),
 			"github_repository_collaborator":                                        resourceGithubRepositoryCollaborator(),
 			"github_repository_collaborators":                                       resourceGithubRepositoryCollaborators(),
 			"github_repository_deploy_key":                                          resourceGithubRepositoryDeployKey(),

--- a/github/resource_github_repository_automated_security_fixes.go
+++ b/github/resource_github_repository_automated_security_fixes.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -75,7 +76,10 @@ func resourceGithubRepositoryDependabotSecurityUpdatesDelete(d *schema.ResourceD
 
 	ctx := context.Background()
 
-	client.Repositories.DisableAutomatedSecurityFixes(ctx, orgName, repoName)
+	_, err := client.Repositories.DisableAutomatedSecurityFixes(ctx, orgName, repoName)
+	if err != nil {
+		return err
+	}
 
 	return resourceGithubRepositoryDependabotSecurityUpdatesRead(d, meta)
 }

--- a/github/resource_github_repository_automated_security_fixes.go
+++ b/github/resource_github_repository_automated_security_fixes.go
@@ -1,0 +1,94 @@
+package github
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceGithubRepositoryDependabotSecurityUpdates() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGithubRepositoryDependabotSecurityUpdatesCreateOrUpdate,
+		Read:   resourceGithubRepositoryDependabotSecurityUpdatesRead,
+		Update: resourceGithubRepositoryDependabotSecurityUpdatesCreateOrUpdate,
+		Delete: resourceGithubRepositoryDependabotSecurityUpdatesDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceGithubRepositoryDependabotSecurityUpdatesImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"repository": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The GitHub repository.",
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: "The state of the automated security fixes.",
+			},
+		},
+	}
+}
+
+func resourceGithubRepositoryDependabotSecurityUpdatesCreateOrUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
+	repoName := d.Get("repository").(string)
+	enabled := d.Get("enabled").(bool)
+
+	ctx := context.Background()
+	var err error
+	if enabled {
+		_, err = client.Repositories.EnableAutomatedSecurityFixes(ctx, owner, repoName)
+	} else {
+		_, err = client.Repositories.DisableAutomatedSecurityFixes(ctx, owner, repoName)
+	}
+
+	if err != nil {
+		return err
+	}
+	d.SetId(repoName)
+	return resourceGithubRepositoryDependabotSecurityUpdatesRead(d, meta)
+}
+
+func resourceGithubRepositoryDependabotSecurityUpdatesRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
+	repoName := d.Get("repository").(string)
+
+	ctx := context.Background()
+
+	p, _, err := client.Repositories.GetAutomatedSecurityFixes(ctx, orgName, repoName)
+	if err != nil {
+		return err
+	}
+	d.Set("enabled", p.Enabled)
+
+	return nil
+}
+
+func resourceGithubRepositoryDependabotSecurityUpdatesDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
+	repoName := d.Get("repository").(string)
+
+	ctx := context.Background()
+
+	client.Repositories.DisableAutomatedSecurityFixes(ctx, orgName, repoName)
+
+	return resourceGithubRepositoryDependabotSecurityUpdatesRead(d, meta)
+}
+
+func resourceGithubRepositoryDependabotSecurityUpdatesImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	repoName := d.Id()
+
+	d.Set("repository", repoName)
+
+	err := resourceGithubRepositoryDependabotSecurityUpdatesRead(d, meta)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/github/resource_github_repository_automated_security_fixes_test.go
+++ b/github/resource_github_repository_automated_security_fixes_test.go
@@ -1,0 +1,200 @@
+package github
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccGithubAutomatedSecurityFixes(t *testing.T) {
+
+	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+	t.Run("enables automated security fixes without error", func(t *testing.T) {
+
+		enabled := "enabled = false"
+		updatedEnabled := "enabled = true"
+		config := fmt.Sprintf(`
+	
+			resource "github_repository" "test" {
+				name = "tf-acc-test-%s"
+				visibility = "private"
+			  	auto_init = true
+				vulnerability_alerts   = true
+			}
+	
+	
+			resource "github_repository_dependabot_security_updates" "test" {
+			  repository  = github_repository.test.id
+			  %s
+			}
+		`, randomID, enabled)
+
+		checks := map[string]resource.TestCheckFunc{
+			"before": resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"github_repository_dependabot_security_updates.test", "enabled",
+					"false",
+				),
+			),
+			"after": resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"github_repository_dependabot_security_updates.test", "enabled",
+					"true",
+				),
+			),
+		}
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  checks["before"],
+					},
+					{
+						Config: strings.Replace(config,
+							enabled,
+							updatedEnabled, 1),
+						Check: checks["after"],
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+
+	t.Run("disables automated security fixes without error", func(t *testing.T) {
+
+		enabled := "enabled = true"
+		updatedEnabled := "enabled = false"
+
+		config := fmt.Sprintf(`
+	
+			resource "github_repository" "test" {
+				name = "tf-acc-test-%s"
+				visibility = "private"
+			  	auto_init = true
+				vulnerability_alerts   = true
+			}
+	
+	
+			resource "github_repository_dependabot_security_updates" "test" {
+			  repository  = github_repository.test.id
+			  %s
+			}
+		`, randomID, enabled)
+
+		checks := map[string]resource.TestCheckFunc{
+			"before": resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"github_repository_dependabot_security_updates.test", "enabled",
+					"true",
+				),
+			),
+			"after": resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"github_repository_dependabot_security_updates.test", "enabled",
+					"false",
+				),
+			),
+		}
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  checks["before"],
+					},
+					{
+						Config: strings.Replace(config,
+							enabled,
+							updatedEnabled, 1),
+						Check: checks["after"],
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+
+	t.Run("imports automated security fixes without error", func(t *testing.T) {
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+			  name = "tf-acc-test-%s"
+			  vulnerability_alerts   = true
+			}
+
+			resource "github_repository_dependabot_security_updates" "test" {
+			  repository  = github_repository.test.id
+			  enabled = false
+			}
+    `, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttrSet("github_repository_dependabot_security_updates.test", "repository"),
+			resource.TestCheckResourceAttrSet("github_repository_dependabot_security_updates.test", "enabled"),
+			resource.TestCheckResourceAttr("github_repository_dependabot_security_updates.test", "enabled", "false"),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+					{
+						ResourceName:      "github_repository_dependabot_security_updates.test",
+						ImportState:       true,
+						ImportStateVerify: true,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+}

--- a/website/docs/r/repository_automated_security_fixes.html.markdown
+++ b/website/docs/r/repository_automated_security_fixes.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "github"
+page_title: "GitHub: github_repository_dependabot_security_updates"
+description: |-
+  Manages automated security fixes for a single repository
+---
+
+# github_repository_dependabot_security_updates
+
+This resource allows you to manage dependabot automated security fixes for a single repository. See the 
+[documentation](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates)
+for details of usage and how this will impact your repository
+
+## Example Usage
+
+```hcl
+resource "github_repository" "repo" {
+  name         = "my-repo"
+  description  = "GitHub repo managed by Terraform"
+  
+  private = false
+  
+  vulnerability_alerts   = true
+}
+
+
+resource "github_repository_dependabot_security_updates" "example" {
+  repository  = github_repository.test.id
+  enabled     = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `repository` - (Required) The repository to manage.
+
+* `enabled` - (Required) The state of the automated security fixes.
+
+## Import
+
+Automated security references can be imported using the `name` of the repository
+
+### Import by name
+
+```sh
+terraform import github_repository_dependabot_security_updates.example my-repo
+```

--- a/website/github.erb
+++ b/website/github.erb
@@ -299,6 +299,9 @@
               <a href="/docs/providers/github/r/repository_autolink_reference.html">github_repository_autolink_reference</a>
             </li>
             <li>
+              <a href="/docs/providers/github/r/repository_automated_security_fixes.html">github_repository_dependabot_security_updates</a>
+            </li>
+            <li>
               <a href="/docs/providers/github/r/repository_collaborator.html">github_repository_collaborator</a>
             </li>
             <li>


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #1301

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

There is no resource to manage the Dependabot Security Updates.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Adds a new resource  `github_repository_dependabot_security_updates` to allow enabling and disabling the Dependabot Security Updates.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

```
TF_ACC=1 go test -v ./... -run ^TestAccGithubAutomatedSecurityFixes
?       github.com/integrations/terraform-provider-github/v5    [no test files]
=== RUN   TestAccGithubAutomatedSecurityFixes
=== RUN   TestAccGithubAutomatedSecurityFixes/enables_automated_security_fixes_without_error
=== RUN   TestAccGithubAutomatedSecurityFixes/enables_automated_security_fixes_without_error/with_an_anonymous_account
    resource_github_repository_automated_security_fixes_test.go:71: anonymous account not supported for this operation
=== RUN   TestAccGithubAutomatedSecurityFixes/enables_automated_security_fixes_without_error/with_an_individual_account
=== RUN   TestAccGithubAutomatedSecurityFixes/enables_automated_security_fixes_without_error/with_an_organization_account
=== RUN   TestAccGithubAutomatedSecurityFixes/disables_automated_security_fixes_without_error
=== RUN   TestAccGithubAutomatedSecurityFixes/disables_automated_security_fixes_without_error/with_an_anonymous_account
    resource_github_repository_automated_security_fixes_test.go:139: anonymous account not supported for this operation
=== RUN   TestAccGithubAutomatedSecurityFixes/disables_automated_security_fixes_without_error/with_an_individual_account
=== RUN   TestAccGithubAutomatedSecurityFixes/disables_automated_security_fixes_without_error/with_an_organization_account
=== RUN   TestAccGithubAutomatedSecurityFixes/imports_automated_security_fixes_without_error
=== RUN   TestAccGithubAutomatedSecurityFixes/imports_automated_security_fixes_without_error/with_an_anonymous_account
    resource_github_repository_automated_security_fixes_test.go:189: anonymous account not supported for this operation
=== RUN   TestAccGithubAutomatedSecurityFixes/imports_automated_security_fixes_without_error/with_an_individual_account
=== RUN   TestAccGithubAutomatedSecurityFixes/imports_automated_security_fixes_without_error/with_an_organization_account
--- PASS: TestAccGithubAutomatedSecurityFixes (89.73s)
    --- PASS: TestAccGithubAutomatedSecurityFixes/enables_automated_security_fixes_without_error (32.99s)
        --- SKIP: TestAccGithubAutomatedSecurityFixes/enables_automated_security_fixes_without_error/with_an_anonymous_account (0.00s)
        --- PASS: TestAccGithubAutomatedSecurityFixes/enables_automated_security_fixes_without_error/with_an_individual_account (17.24s)
        --- PASS: TestAccGithubAutomatedSecurityFixes/enables_automated_security_fixes_without_error/with_an_organization_account (15.75s)
    --- PASS: TestAccGithubAutomatedSecurityFixes/disables_automated_security_fixes_without_error (32.98s)
        --- SKIP: TestAccGithubAutomatedSecurityFixes/disables_automated_security_fixes_without_error/with_an_anonymous_account (0.00s)
        --- PASS: TestAccGithubAutomatedSecurityFixes/disables_automated_security_fixes_without_error/with_an_individual_account (16.19s)
        --- PASS: TestAccGithubAutomatedSecurityFixes/disables_automated_security_fixes_without_error/with_an_organization_account (16.79s)
    --- PASS: TestAccGithubAutomatedSecurityFixes/imports_automated_security_fixes_without_error (23.75s)
        --- SKIP: TestAccGithubAutomatedSecurityFixes/imports_automated_security_fixes_without_error/with_an_anonymous_account (0.00s)
        --- PASS: TestAccGithubAutomatedSecurityFixes/imports_automated_security_fixes_without_error/with_an_individual_account (12.08s)
        --- PASS: TestAccGithubAutomatedSecurityFixes/imports_automated_security_fixes_without_error/with_an_organization_account (11.67s)
PASS
ok      github.com/integrations/terraform-provider-github/v5/github     90.088s

```
