### PR TITLE
[FEAT] Pick up token from `gh auth login` CLI

### DIFF
--- a/github/provider.go
+++ b/github/provider.go
@@ -3,6 +3,9 @@ package github
 import (
 	"fmt"
 	"log"
+	"net/url"
+	"os"
+	"os/exec"
 	"regexp"
 	"strings"
 	"time"
@@ -331,6 +334,14 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 			token = appToken
 		}
 
+		if token == "" {
+			ghAuthToken, err := tokenFromGhCli(baseURL)
+			if err != nil {
+				return nil, fmt.Errorf("gh auth token: %w", err)
+			}
+			token = ghAuthToken
+		}
+
 		writeDelay := d.Get("write_delay_ms").(int)
 		if writeDelay <= 0 {
 			return nil, fmt.Errorf("write_delay_ms must be greater than 0ms")
@@ -373,4 +384,31 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 
 		return meta, nil
 	}
+}
+
+// See https://github.com/integrations/terraform-provider-github/issues/1822
+func tokenFromGhCli(baseURL string) (string, error) {
+	ghCliPath := os.Getenv("GH_PATH")
+	if ghCliPath == "" {
+		ghCliPath = "gh"
+	}
+	hostname := ""
+	if baseURL == "" {
+		hostname = "api.github.com"
+	} else {
+		parsedURL, err := url.Parse(baseURL)
+		if err != nil {
+			return "", fmt.Errorf("parse %s: %w", baseURL, err)
+		}
+		hostname = parsedURL.Host
+	}
+	out, err := exec.Command(ghCliPath, "auth", "token", "--hostname", hostname).Output()
+	if err != nil {
+		// GH CLI is either not installed or there was no `gh auth login` command issued,
+		// which is fine. don't return the error to keep the flow going
+		return "", nil
+	}
+
+	log.Printf("[INFO] Using the token from GitHub CLI")
+	return strings.TrimSpace(string(out)), nil
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -60,7 +60,7 @@ The GitHub provider offers multiple ways to authenticate with GitHub API.
 
 ### GitHub CLI
 
-The GitHub provider taps into [GitHub CLI](https://cli.github.com/) authentication, where it picks up the token issued by [`gh auth login`](https://cli.github.com/manual/gh_auth_login) command.
+The GitHub provider taps into [GitHub CLI](https://cli.github.com/) authentication, where it picks up the token issued by [`gh auth login`](https://cli.github.com/manual/gh_auth_login) command. It is possible to specify the path to the `gh` executable in the `GH_PATH` environment variable, which is useful for when the GitHub Terraform provider can not properly determine its the path to GitHub CLI such as in the cygwin terminal.
 
 ### OAuth / Personal Access Token
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -58,6 +58,10 @@ resource "github_membership" "membership_for_user_x" {
 
 The GitHub provider offers multiple ways to authenticate with GitHub API.
 
+### GitHub CLI
+
+The GitHub provider taps into [GitHub CLI](https://cli.github.com/) authentication, where it picks up the token issued by [`gh auth login`](https://cli.github.com/manual/gh_auth_login) command.
+
 ### OAuth / Personal Access Token
 
 To authenticate using OAuth tokens, ensure that the `token` argument or the `GITHUB_TOKEN` environment variable is set.


### PR DESCRIPTION
This PR adds the use of token persisted by GitHub CLI (https://cli.github.com) via running the `gh auth token --hostname $base_url` command and using the token from that command.

Resolves #1822

----

### Before the change?

`gh`-authenticated machines had to pass the token via env variable:

* `gh auth login`
* `GITHUB_TOKEN=$(gh auth token) terraform apply` 

### After the change?

`gh`-authenticated machines do not have to pass the token via env variable:

* `gh auth login`
* `terraform apply` 

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [X] No

----

