### PR TITLE
[bug] Fix not detecting changes

### DIFF
--- a/github/resource_github_actions_runner_group.go
+++ b/github/resource_github_actions_runner_group.go
@@ -183,9 +183,6 @@ func resourceGithubActionsRunnerGroupRead(d *schema.ResourceData, meta interface
 		return err
 	}
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	runnerGroup, resp, err := getOrganizationRunnerGroup(client, ctx, orgName, runnerGroupID)
 	if err != nil {

--- a/github/resource_github_branch.go
+++ b/github/resource_github_branch.go
@@ -108,9 +108,6 @@ func resourceGithubBranchCreate(d *schema.ResourceData, meta interface{}) error 
 
 func resourceGithubBranchRead(d *schema.ResourceData, meta interface{}) error {
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	client := meta.(*Owner).v3client
 	orgName := meta.(*Owner).name

--- a/github/resource_github_branch_protection_v3.go
+++ b/github/resource_github_branch_protection_v3.go
@@ -259,9 +259,6 @@ func resourceGithubBranchProtectionV3Read(d *schema.ResourceData, meta interface
 	orgName := meta.(*Owner).name
 
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	githubProtection, resp, err := client.Repositories.GetBranchProtection(ctx,
 		orgName, repoName, branch)

--- a/github/resource_github_branch_protection_v3_utils.go
+++ b/github/resource_github_branch_protection_v3_utils.go
@@ -88,9 +88,6 @@ func requireSignedCommitsRead(d *schema.ResourceData, meta interface{}) error {
 	orgName := meta.(*Owner).name
 
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	signedCommitStatus, _, err := client.Repositories.GetSignaturesProtectedBranch(ctx,
 		orgName, repoName, branch)
@@ -113,9 +110,6 @@ func requireSignedCommitsUpdate(d *schema.ResourceData, meta interface{}) (err e
 	orgName := meta.(*Owner).name
 
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	if requiredSignedCommit {
 		_, _, err = client.Repositories.RequireSignaturesOnProtectedBranch(ctx, orgName, repoName, branch)

--- a/github/resource_github_issue.go
+++ b/github/resource_github_issue.go
@@ -142,9 +142,6 @@ func resourceGithubIssueRead(d *schema.ResourceData, meta interface{}) error {
 
 	orgName := meta.(*Owner).name
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	log.Printf("[DEBUG] Reading issue: %d (%s/%s)", number, orgName, repoName)
 	issue, resp, err := client.Issues.Get(ctx,

--- a/github/resource_github_issue_label.go
+++ b/github/resource_github_issue_label.go
@@ -146,9 +146,6 @@ func resourceGithubIssueLabelRead(d *schema.ResourceData, meta interface{}) erro
 
 	orgName := meta.(*Owner).name
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	githubLabel, resp, err := client.Issues.GetLabel(ctx,
 		orgName, repoName, name)

--- a/github/resource_github_membership.go
+++ b/github/resource_github_membership.go
@@ -94,9 +94,6 @@ func resourceGithubMembershipRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	membership, resp, err := client.Organizations.GetOrgMembership(ctx,
 		username, orgName)

--- a/github/resource_github_organization_project.go
+++ b/github/resource_github_organization_project.go
@@ -86,9 +86,6 @@ func resourceGithubOrganizationProjectRead(d *schema.ResourceData, meta interfac
 		return err
 	}
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	project, resp, err := client.Projects.GetProject(ctx, projectID)
 	if err != nil {

--- a/github/resource_github_organization_webhook.go
+++ b/github/resource_github_organization_webhook.go
@@ -122,9 +122,6 @@ func resourceGithubOrganizationWebhookRead(d *schema.ResourceData, meta interfac
 		return unconvertibleIdErr(d.Id(), err)
 	}
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	hook, resp, err := client.Organizations.GetHook(ctx, orgName, hookID)
 	if err != nil {

--- a/github/resource_github_project_card.go
+++ b/github/resource_github_project_card.go
@@ -103,9 +103,6 @@ func resourceGithubProjectCardRead(d *schema.ResourceData, meta interface{}) err
 	nodeID := d.Id()
 	cardID := d.Get("card_id").(int)
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	log.Printf("[DEBUG] Reading project card: %s", nodeID)
 	card, _, err := client.Projects.GetProjectCard(ctx, int64(cardID))

--- a/github/resource_github_project_column.go
+++ b/github/resource_github_project_column.go
@@ -87,9 +87,6 @@ func resourceGithubProjectColumnRead(d *schema.ResourceData, meta interface{}) e
 		return unconvertibleIdErr(d.Id(), err)
 	}
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	column, _, err := client.Projects.GetProjectColumn(ctx, columnID)
 	if err != nil {

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -623,9 +623,6 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	repo, resp, err := client.Repositories.Get(ctx, owner, repoName)
 	if err != nil {

--- a/github/resource_github_repository_autolink_reference.go
+++ b/github/resource_github_repository_autolink_reference.go
@@ -124,9 +124,6 @@ func resourceGithubRepositoryAutolinkReferenceRead(d *schema.ResourceData, meta 
 		return unconvertibleIdErr(d.Id(), err)
 	}
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	autolinkRef, _, err := client.Repositories.GetAutolink(ctx, owner, repoName, autolinkRefID)
 	if err != nil {

--- a/github/resource_github_repository_deploy_key.go
+++ b/github/resource_github_repository_deploy_key.go
@@ -98,9 +98,6 @@ func resourceGithubRepositoryDeployKeyRead(d *schema.ResourceData, meta interfac
 		return unconvertibleIdErr(idString, err)
 	}
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	key, resp, err := client.Repositories.GetKey(ctx, owner, repoName, id)
 	if err != nil {

--- a/github/resource_github_repository_project.go
+++ b/github/resource_github_repository_project.go
@@ -93,9 +93,6 @@ func resourceGithubRepositoryProjectRead(d *schema.ResourceData, meta interface{
 		return unconvertibleIdErr(d.Id(), err)
 	}
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	project, resp, err := client.Projects.GetProject(ctx, projectID)
 	if err != nil {

--- a/github/resource_github_repository_webhook.go
+++ b/github/resource_github_repository_webhook.go
@@ -139,9 +139,6 @@ func resourceGithubRepositoryWebhookRead(d *schema.ResourceData, meta interface{
 		return unconvertibleIdErr(d.Id(), err)
 	}
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	hook, _, err := client.Repositories.GetHook(ctx, owner, repoName, hookID)
 	if err != nil {

--- a/github/resource_github_team.go
+++ b/github/resource_github_team.go
@@ -189,9 +189,6 @@ func resourceGithubTeamRead(d *schema.ResourceData, meta interface{}) error {
 		return unconvertibleIdErr(d.Id(), err)
 	}
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	team, resp, err := client.Teams.GetTeamByID(ctx, orgId, id)
 	if err != nil {

--- a/github/resource_github_team_membership.go
+++ b/github/resource_github_team_membership.go
@@ -114,9 +114,6 @@ func resourceGithubTeamMembershipRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("username", username)
 
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	membership, resp, err := client.Teams.GetTeamMembershipByID(ctx,
 		orgId, teamId, username)

--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -119,9 +119,6 @@ func resourceGithubTeamRepositoryRead(d *schema.ResourceData, meta interface{}) 
 	}
 	orgName := meta.(*Owner).name
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	repo, resp, repoErr := client.Teams.IsTeamRepoByID(ctx, orgId, teamId, orgName, repoName)
 	if repoErr != nil {

--- a/github/resource_github_team_sync_group_mapping.go
+++ b/github/resource_github_team_sync_group_mapping.go
@@ -96,9 +96,6 @@ func resourceGithubTeamSyncGroupMappingRead(d *schema.ResourceData, meta interfa
 	slug := d.Get("team_slug").(string)
 
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	idpGroupList, resp, err := client.Teams.ListIDPGroupsForTeamBySlug(ctx, orgName, slug)
 	if err != nil {

--- a/github/resource_github_user_gpg_key.go
+++ b/github/resource_github_user_gpg_key.go
@@ -60,9 +60,6 @@ func resourceGithubUserGpgKeyRead(d *schema.ResourceData, meta interface{}) erro
 		return unconvertibleIdErr(d.Id(), err)
 	}
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	key, _, err := client.Users.GetGPGKey(ctx, id)
 	if err != nil {

--- a/github/resource_github_user_ssh_key.go
+++ b/github/resource_github_user_ssh_key.go
@@ -78,9 +78,6 @@ func resourceGithubUserSshKeyRead(d *schema.ResourceData, meta interface{}) erro
 		return unconvertibleIdErr(d.Id(), err)
 	}
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	key, resp, err := client.Users.GetKey(ctx, id)
 	if err != nil {

--- a/github/resource_organization_block.go
+++ b/github/resource_organization_block.go
@@ -61,9 +61,6 @@ func resourceOrganizationBlockRead(d *schema.ResourceData, meta interface{}) err
 	username := d.Id()
 
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
-	}
 
 	blocked, resp, err := client.Organizations.IsBlocked(ctx, orgName, username)
 	if err != nil {


### PR DESCRIPTION
Do not rely on ETag to detect changes

Resolves #1446 

----

### Before the change?

github_repository does not detect changes in many of the arguments if they are either done directly on GitHub or the resource is imported. Here are some parameters which are affected (the list is not comprehensive):
- allow_rebase_merge
- allow_squash_merge
- allow_update_branch
- delete_branch_on_merge

The reason for this behaviour seems to be related to how GitHub treats ETag. Specifically ETag update is not triggered by the changes in the parameters listed above.

### After the change?

Changes in argument values are always detected

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

