### PR TITLE
chore(docs): use consistent spacing in github_organization docs

### DIFF
--- a/website/docs/d/organization.html.markdown
+++ b/website/docs/d/organization.html.markdown
@@ -33,21 +33,21 @@ data "github_organization" "example" {
    * `login` - The members login
    * `email` - Publicly available email
    * `role` - Member role `ADMIN`, `MEMBER`
-* `two_factor_requirement_enabled` - Whether two-factor authentication is required for all members of the organization.
-* `default_repository_permission` - Default permission level members have for organization repositories.
-* `members_allowed_repository_creation_type` - The type of repository allowed to be created by members of the organization. Can be one of `ALL`, `PUBLIC`, `PRIVATE`, `NONE`.
-* `members_can_create_repositories` - Whether non-admin organization members can create repositories.
-* `members_can_create_internal_repositories` - Whether organization members can create internal repositories.
-* `members_can_create_private_repositories` - Whether organization members can create private repositories.
-* `members_can_create_public_repositories` - Whether organization members can create public repositories.
-* `members_can_create_pages` - Whether organization members can create pages sites.
-* `members_can_create_public_pages` - Whether organization members can create public pages sites.
-* `members_can_create_private_pages` - Whether organization members can create private pages sites.
-* `members_can_fork_private_repositories` - Whether organization members can create private repository forks.
-* `web_commit_signoff_required` - Whether organization members must sign all commits.
-* `advanced_security_enabled_for_new_repositories` - Whether advanced security is enabled for new repositories.
-* `dependabot_alerts_enabled_for_new_repositories` - Whether Dependabot alerts is automatically enabled for new repositories.
-* `dependabot_security_updates_enabled_for_new_repositories` - Whether Dependabot security updates is automatically enabled for new repositories.
-* `dependency_graph_enabled_for_new_repositories` - Whether dependency graph is automatically enabled for new repositories.
-* `secret_scanning_enabled_for_new_repositories` - Whether secret scanning is automatically enabled for new repositories.
-* `secret_scanning_push_protection_enabled_for_new_repositories` - Whether secret scanning push protection is automatically enabled for new repositories.
+ * `two_factor_requirement_enabled` - Whether two-factor authentication is required for all members of the organization.
+ * `default_repository_permission` - Default permission level members have for organization repositories.
+ * `members_allowed_repository_creation_type` - The type of repository allowed to be created by members of the organization. Can be one of `ALL`, `PUBLIC`, `PRIVATE`, `NONE`.
+ * `members_can_create_repositories` - Whether non-admin organization members can create repositories.
+ * `members_can_create_internal_repositories` - Whether organization members can create internal repositories.
+ * `members_can_create_private_repositories` - Whether organization members can create private repositories.
+ * `members_can_create_public_repositories` - Whether organization members can create public repositories.
+ * `members_can_create_pages` - Whether organization members can create pages sites.
+ * `members_can_create_public_pages` - Whether organization members can create public pages sites.
+ * `members_can_create_private_pages` - Whether organization members can create private pages sites.
+ * `members_can_fork_private_repositories` - Whether organization members can create private repository forks.
+ * `web_commit_signoff_required` - Whether organization members must sign all commits.
+ * `advanced_security_enabled_for_new_repositories` - Whether advanced security is enabled for new repositories.
+ * `dependabot_alerts_enabled_for_new_repositories` - Whether Dependabot alerts is automatically enabled for new repositories.
+ * `dependabot_security_updates_enabled_for_new_repositories` - Whether Dependabot security updates is automatically enabled for new repositories.
+ * `dependency_graph_enabled_for_new_repositories` - Whether dependency graph is automatically enabled for new repositories.
+ * `secret_scanning_enabled_for_new_repositories` - Whether secret scanning is automatically enabled for new repositories.
+ * `secret_scanning_push_protection_enabled_for_new_repositories` - Whether secret scanning push protection is automatically enabled for new repositories.


### PR DESCRIPTION
### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Some GitHub org attributes are being rendered as sub-attributes of the users list.

![image](https://github.com/integrations/terraform-provider-github/assets/1141646/c4ca3186-b4f2-4d0e-9ce0-fe08c664cb81)


### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
* I have updated the spacing in the markdown to be consistent with the other attributes.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

No

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

