### PR TITLE
add version tag comment for peter-evans/create-or-update-comment

### DIFF
--- a/.github/workflows/immediate-response.yml
+++ b/.github/workflows/immediate-response.yml
@@ -18,7 +18,7 @@ jobs:
         run: echo "NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
 
       - name: Respond to issue or PR
-        uses: peter-evans/create-or-update-comment@94ff3426b71db76bdf47e8a2f6446d88727c7443
+        uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa # v3.0.2
         with:
           issue-number: ${{ steps.extract.outputs.NUMBER }}
           body: >


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

N/A

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Pull requests sent by dependabot are difficult to find the version number
  * "build(deps): bump peter-evans/create-or-update-comment from 94ff3426b71db76bdf47e8a2f6446d88727c7443 to 223779bc560943cb8f2aa0484a7c225c1585c597"
  * https://github.com/integrations/terraform-provider-github/pull/1879

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* the title will be "build(deps): bump peter-evans/create-or-update-comment from v3.0.1 to v3.0.2"
* https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

