### PR TITLE
Fixed invalid default hostname for gh auth token

### DIFF
--- a/github/provider.go
+++ b/github/provider.go
@@ -398,7 +398,7 @@ func tokenFromGhCli(baseURL string) (string, error) {
 	}
 	hostname := ""
 	if baseURL == "" {
-		hostname = "api.github.com"
+		hostname = "github.com"
 	} else {
 		parsedURL, err := url.Parse(baseURL)
 		if err != nil {


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #1905

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

The current default hostname for getting the authentication token from GitHub CLI is "api.github.com"

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The default hostname is set to "github.com" which is the correct default hostname for `gh auth login`.

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

There should be no breaking changes contained in this PR.

----

