### PR TITLE
Fix organization ruleset conditions schema validation, update docs

### DIFF
--- a/github/resource_github_organization_ruleset.go
+++ b/github/resource_github_organization_ruleset.go
@@ -52,7 +52,7 @@ func resourceGithubOrganizationRuleset() *schema.Resource {
 						"actor_id": {
 							Type:        schema.TypeInt,
 							Required:    true,
-							Description: "The ID of the actor that can bypass a ruleset",
+							Description: "The ID of the actor that can bypass a ruleset. When `actor_type` is `OrganizationAdmin`, this should be set to `1`.",
 						},
 						"actor_type": {
 							Type:         schema.TypeString,
@@ -83,7 +83,7 @@ func resourceGithubOrganizationRuleset() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				MaxItems:    1,
-				Description: "Parameters for a repository ruleset ref name condition.",
+				Description: "Parameters for an organization ruleset condition. `ref_name` is required alongside one of `repository_name` or `repository_id`.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"ref_name": {
@@ -112,10 +112,11 @@ func resourceGithubOrganizationRuleset() *schema.Resource {
 							},
 						},
 						"repository_name": {
-							Type:          schema.TypeList,
-							Optional:      true,
-							MaxItems:      1,
-							ConflictsWith: []string{"conditions.0.repository_id"},
+							Type:         schema.TypeList,
+							Optional:     true,
+							MaxItems:     1,
+							ExactlyOneOf: []string{"conditions.0.repository_id"},
+							AtLeastOneOf: []string{"conditions.0.repository_id"},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"include": {
@@ -144,10 +145,9 @@ func resourceGithubOrganizationRuleset() *schema.Resource {
 							},
 						},
 						"repository_id": {
-							Type:          schema.TypeList,
-							Optional:      true,
-							ConflictsWith: []string{"conditions.0.repository_name"},
-							Description:   "The repository IDs that the ruleset applies to. One of these IDs must match for the condition to pass.",
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "The repository IDs that the ruleset applies to. One of these IDs must match for the condition to pass.",
 							Elem: &schema.Schema{
 								Type: schema.TypeInt,
 							},

--- a/github/resource_github_repository_ruleset.go
+++ b/github/resource_github_repository_ruleset.go
@@ -57,7 +57,7 @@ func resourceGithubRepositoryRuleset() *schema.Resource {
 						"actor_id": {
 							Type:        schema.TypeInt,
 							Required:    true,
-							Description: "The ID of the actor that can bypass a ruleset",
+							Description: "The ID of the actor that can bypass a ruleset. When `actor_type` is `OrganizationAdmin`, this should be set to `1`.",
 						},
 						"actor_type": {
 							Type:         schema.TypeString,

--- a/website/docs/r/organization_ruleset.html.markdown
+++ b/website/docs/r/organization_ruleset.html.markdown
@@ -61,7 +61,7 @@ resource "github_organization_ruleset" "example" {
 
 * `bypass_actors` - (Optional) (Block List) The actors that can bypass the rules in this ruleset. (see [below for nested schema](#bypass_actors))
 
-* `conditions` - (Optional) (Block List, Max: 1) Parameters for an organization ruleset ref name condition. (see [below for nested schema](#conditions))
+* `conditions` - (Optional) (Block List, Max: 1) Parameters for an organization ruleset condition. `ref_name` is required alongside one of `repository_name` or `repository_id`. (see [below for nested schema](#conditions))
 
 #### Rules ####
 
@@ -178,7 +178,7 @@ The `rules` block supports the following:
 
 #### bypass_actors ####
 
-* `actor_id` - (Required) (Number) The ID of the actor that can bypass a ruleset
+* `actor_id` - (Required) (Number) The ID of the actor that can bypass a ruleset. When `actor_type` is `OrganizationAdmin`, this should be set to `1`.
 
 * `actor_type` (String) The type of actor that can bypass a ruleset. Can be one of: `RepositoryRole`, `Team`, `Integration`, `OrganizationAdmin`.
 

--- a/website/docs/r/repository_ruleset.html.markdown
+++ b/website/docs/r/repository_ruleset.html.markdown
@@ -195,7 +195,7 @@ The `rules` block supports the following:
 
 #### bypass_actors ####
 
-* `actor_id` - (Required) (Number) The ID of the actor that can bypass a ruleset
+* `actor_id` - (Required) (Number) The ID of the actor that can bypass a ruleset. When `actor_type` is `OrganizationAdmin`, this should be set to `1`.
 
 * `actor_type` (String) The type of actor that can bypass a ruleset. Can be one of: `RepositoryRole`, `Team`, `Integration`, `OrganizationAdmin`.
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #1899 & #1909

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Validation on `organization_ruleset.conditions.0` was partially broken.
  * It correctly prevented setting both `repository_name` and `repository_id`.
  * It incorrectly allowed setting neither `repository_name` nor `repository_id`.
* Documentation for `bypass_actors` didn't specify anything related to `actor_id` when setting type to `OrganizationAdmin`, the API docs also don't mention anything but the expected value is `1` as tested by @YElyousfi.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* At least one of `repository_name` and `repository_id` is required for organization rulesets conditions, previously this would fail on apply since the API requires at least one to be set alongside `ref_name`. This shouldn't require a major version change because requests sent using the previous iteration weren't actually succeeding, so there shouldn't be a state change or breakage of existing use.
* Updated docs for both of the issues mentioned in the before section.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

