### PR TITLE
Add DefaultFunc to repo ruleset required deploy env, base role IDs to docs

### DIFF
--- a/github/resource_github_repository_ruleset.go
+++ b/github/resource_github_repository_ruleset.go
@@ -162,6 +162,7 @@ func resourceGithubRepositoryRuleset() *schema.Resource {
 									"required_deployment_environments": {
 										Type:        schema.TypeList,
 										Required:    true,
+										DefaultFunc: func() (interface{}, error) { return []string{}, nil },
 										Description: "The environments that must be successfully deployed to before branches can be merged.",
 										Elem: &schema.Schema{
 											Type: schema.TypeString,

--- a/website/docs/r/organization_ruleset.html.markdown
+++ b/website/docs/r/organization_ruleset.html.markdown
@@ -178,12 +178,18 @@ The `rules` block supports the following:
 
 #### bypass_actors ####
 
-* `actor_id` - (Required) (Number) The ID of the actor that can bypass a ruleset. When `actor_type` is `OrganizationAdmin`, this should be set to `1`.
+* `actor_id` - (Required) (Number) The ID of the actor that can bypass a ruleset.
 
 * `actor_type` (String) The type of actor that can bypass a ruleset. Can be one of: `RepositoryRole`, `Team`, `Integration`, `OrganizationAdmin`.
 
 * `bypass_mode` - (Optional) (String) When the specified actor can bypass the ruleset. pull_request means that an actor can only bypass rules on pull requests. Can be one of: `always`, `pull_request`.
 
+~>Note: at the time of writing this, the following actor types correspond to the following actor IDs:
+* `OrganizationAdmin` -> `1`
+* `RepositoryRole` (This is the actor type, the following are the base repository roles and their associated IDs.)
+  * `maintain` -> `2`
+  * `write` -> `4`
+  * `admiin` -> `5`
 
 #### conditions ####
 

--- a/website/docs/r/repository_ruleset.html.markdown
+++ b/website/docs/r/repository_ruleset.html.markdown
@@ -195,11 +195,18 @@ The `rules` block supports the following:
 
 #### bypass_actors ####
 
-* `actor_id` - (Required) (Number) The ID of the actor that can bypass a ruleset. When `actor_type` is `OrganizationAdmin`, this should be set to `1`.
+* `actor_id` - (Required) (Number) The ID of the actor that can bypass a ruleset.
 
 * `actor_type` (String) The type of actor that can bypass a ruleset. Can be one of: `RepositoryRole`, `Team`, `Integration`, `OrganizationAdmin`.
 
 * `bypass_mode` - (Optional) (String) When the specified actor can bypass the ruleset. pull_request means that an actor can only bypass rules on pull requests. Can be one of: `always`, `pull_request`.
+
+~> Note: at the time of writing this, the following actor types correspond to the following actor IDs:
+* `OrganizationAdmin` -> `1`
+* `RepositoryRole` (This is the actor type, the following are the base repository roles and their associated IDs.)
+  * `maintain` -> `2`
+  * `write` -> `4`
+  * `admiin` -> `5`
 
 
 #### conditions ####


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #1915

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* If an empty list is passed to `rules.required_deployments.required_deployment_environments`, the following is what we get:
`required_deployments:[<nil>]`
The reason it's bad is because we want to be able to strictly specify an empty list, the GitHub API accepts that as a valid input.
The reason it's set to nil is because the elements of `rules.required_deployments` are pointers, an empty slice is the zero value and thus treated as a nil pointer.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Setting a `DefaultFunc` to return an empty slice gives us the following:
`required_deployments:[map[required_deployment_environments:[]]]`
The API accepts this as a valid input and can successfully apply changes. It also doesn't affect anything that's existing since any input overrides the `DefaultFunc`.
* Added base role mapping in the docs since there seems to be confusion regarding this.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

