### PR TITLE
Fix typos in github_repository_collaborators docs

### DIFF
--- a/website/docs/r/repository_collaborators.html.markdown
+++ b/website/docs/r/repository_collaborators.html.markdown
@@ -45,7 +45,7 @@ resource "github_repository" "some_repo" {
   name = "some-repo"
 }
 
-resource "github_repository_collaborators" "a_repo_collaborators" {
+resource "github_repository_collaborators" "some_repo_collaborators" {
   repository = github_repository.some_repo.name
 
   user {
@@ -65,12 +65,12 @@ resource "github_repository_collaborators" "a_repo_collaborators" {
 The following arguments are supported:
 
 * `repository` - (Required) The GitHub repository
-* `user` - (Optional) List of uses
+* `user` - (Optional) List of users
 * `team` - (Optional) List of teams
 
 The `user` block supports:
 
-* `usernames` - (Required) The user to add to the repository as a collaborator.
+* `username` - (Required) The user to add to the repository as a collaborator.
 * `permission` - (Optional) The permission of the outside collaborators for the repository.
             Must be one of `pull`, `push`, `maintain`, `triage` or `admin` or the name of an existing [custom repository role](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-peoples-access-to-your-organization-with-roles/managing-custom-repository-roles-for-an-organization) within the organization for organization-owned repositories.
             Must be `push` for personal repositories. Defaults to `push`.


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #1935 

----

### Before the change?
- "List of uses" should read "List of users"
- usernames in the user block should be username
- Example code should name resource "some_repo_collaborators" for clarity

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Docs issues have been fixed

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

