### PR TITLE
[docs]: remove references to "owner" parameter in github_issue, because it's not needed

### DIFF
--- a/website/docs/r/issue.html.markdown
+++ b/website/docs/r/issue.html.markdown
@@ -62,8 +62,6 @@ resource "github_issue" "test" {
 
 The following arguments are supported:
 
-* `owner` - (Required) Owner of the repository the issue belongs to
-
 * `repository` - (Required) The GitHub repository name
 
 * `title` - (Required) Title of the issue


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves https://github.com/integrations/terraform-provider-github/issues/1849

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Parameter described in the docks 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Parameter removed from the docks 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

