### PR TITLE
[docs]: update import examples for some number of resources

### DIFF
--- a/website/docs/r/actions_organization_permissions.html.markdown
+++ b/website/docs/r/actions_organization_permissions.html.markdown
@@ -56,8 +56,8 @@ The `enabled_repositories_config` block supports the following:
 
 ## Import
 
-This resource can be imported using the ID of the GitHub organization:
+This resource can be imported using the name of the GitHub organization:
 
 ```
-$ terraform import github_actions_organization_permissions.test <github_organization_name>
+$ terraform import github_actions_organization_permissions.test github_organization_name
 ```

--- a/website/docs/r/actions_repository_access_level.html.markdown
+++ b/website/docs/r/actions_repository_access_level.html.markdown
@@ -36,5 +36,5 @@ The following arguments are supported:
 This resource can be imported using the name of the GitHub repository:
 
 ```
-$ terraform import github_actions_repository_access_level.test <github_repository_name>
+$ terraform import github_actions_repository_access_level.test my-repository
 ```

--- a/website/docs/r/codespaces_secret.html.markdown
+++ b/website/docs/r/codespaces_secret.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 This resource can be imported using an ID made up of the `repository` and `secret_name`:
 
 ```
-$ terraform import github_codespaces_secret.example_secret <repository>/<secret_name>
+$ terraform import github_codespaces_secret.example_secret example_repository/example_secret_name
 ```
 
 NOTE: the implementation is limited in that it won't fetch the value of the

--- a/website/docs/r/dependabot_secret.html.markdown
+++ b/website/docs/r/dependabot_secret.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 This resource can be imported using an ID made up of the `repository` and `secret_name`:
 
 ```
-$ terraform import github_dependabot_secret.example_secret <repository>/<secret_name>
+$ terraform import github_dependabot_secret.example_secret example_repository/example_secret
 ```
 
 NOTE: the implementation is limited in that it won't fetch the value of the


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves https://github.com/integrations/terraform-provider-github/issues/1598

It looks like the `<>` characters are not showing up in the documentation, all examples without `<>` characters works as expected.

Updated resources:

- actions_organization_permissions
- actions_repository_access_level
- codespaces_secret
- dependabot_secret

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

*  Docks contain wrong examples with unshown options for terraform import

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Docks contain correct examples for terraform import

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

