### PR TITLE
[Fix] missing environment name encoding for secrets

### DIFF
--- a/github/resource_github_actions_environment_secret.go
+++ b/github/resource_github_actions_environment_secret.go
@@ -108,7 +108,7 @@ func resourceGithubActionsEnvironmentSecretCreateOrUpdate(d *schema.ResourceData
 		EncryptedValue: encryptedValue,
 	}
 
-	_, err = client.Actions.CreateOrUpdateEnvSecret(ctx, int(repo.GetID()), envName, eSecret)
+	_, err = client.Actions.CreateOrUpdateEnvSecret(ctx, int(repo.GetID()), escapedEnvName, eSecret)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Resolves #1960

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* secrets in environment name needing encoding were in error (The test was already failing because of this)

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* secrets in environment name needing encoding are manageable

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features) (I fixed the failing test)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [X] No

----

