### PR TITLE
feat: read timeout for github_ip_ranges data source

### DIFF
--- a/github/data_source_github_ip_ranges.go
+++ b/github/data_source_github_ip_ranges.go
@@ -3,6 +3,7 @@ package github
 import (
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -10,6 +11,10 @@ import (
 func dataSourceGithubIpRanges() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceGithubIpRangesRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			"hooks": {


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #1961 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

*  Adds 5 minutes default timeout for `github_ip_ranges` data source.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Terraform will stop reading github ip ranges after 5 minutes timeout

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

