### PR TITLE
Fixed repo envs so terraform will add back in deployment branch protection if it is removed manually from GitHub

### DIFF
--- a/github/resource_github_branch.go
+++ b/github/resource_github_branch.go
@@ -191,7 +191,7 @@ func resourceGithubBranchImport(d *schema.ResourceData, meta interface{}) ([]*sc
 
 	// resourceGithubBranchRead calls d.SetId("") if the branch does not exist
 	if d.Id() == "" {
-		return nil, fmt.Errorf("repository %s does not have a branch named %s.", repoName, branchName)
+		return nil, fmt.Errorf("repository %s does not have a branch named %s", repoName, branchName)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/github/resource_github_branch_protection_v3_utils.go
+++ b/github/resource_github_branch_protection_v3_utils.go
@@ -283,7 +283,7 @@ func expandRequiredStatusChecks(d *schema.ResourceData) (*github.RequiredStatusC
 					// If we have a valid app_id, include it in the RSC
 					rscAppId, err := strconv.Atoi(cAppId)
 					if err != nil {
-						return nil, fmt.Errorf("Could not parse %v as valid app_id", cAppId)
+						return nil, fmt.Errorf("could not parse %v as valid app_id", cAppId)
 					}
 					rscAppId64 := int64(rscAppId)
 					rscCheck = &github.RequiredStatusCheck{Context: cContext, AppID: &rscAppId64}

--- a/github/resource_github_repository_environment.go
+++ b/github/resource_github_repository_environment.go
@@ -172,6 +172,8 @@ func resourceGithubRepositoryEnvironmentRead(d *schema.ResourceData, meta interf
 				"custom_branch_policies": env.DeploymentBranchPolicy.CustomBranchPolicies,
 			},
 		})
+	} else {
+		d.Set("deployment_branch_policy", []interface{}{})
 	}
 
 	return nil


### PR DESCRIPTION
Resolves https://github.com/integrations/terraform-provider-github/issues/1955

----

### Before the change?
Manually removing an environment's deployment branch protection in GitHub (setting it back to no restriction) would not show a diff when terraform was applied.  This meant terraform and GitHub were out of line.

* 

### After the change?
Terraform brings the environment's deployment branch protection back inline with terraform.

The tests pass - albeit they don't give full coverage, and never did (I have not updated the tests).  They need some extra work to make them better.

There are also two minor changes (as vscode was complaining) which just set lowercase for an error message and remove a full stop for another error message in two unrelated files.

* 

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [X] No

----

