### PR TITLE
update repository_ruleset r doc

### DIFF
--- a/website/docs/r/repository_ruleset.html.markdown
+++ b/website/docs/r/repository_ruleset.html.markdown
@@ -173,7 +173,7 @@ The `rules` block supports the following:
 
 * `strict_required_status_checks_policy` - (Optional) (Boolean) Whether pull requests targeting a matching branch must be tested with the latest code. This setting will not take effect unless at least one status check is enabled. Defaults to `false`.
 
-#### required_status_checks.required_check ####
+#### rules.required_status_checks.required_check ####
 
 * `context` - (Required) (String) The status check context name that must be present on the commit.
 


### PR DESCRIPTION
Update github_repository_ruleset.rules.required_status_checks.required_check property to define nested dependency more clear

Resolves #1893 

----

### Before the change?

* Under the "Rules" block section a nested property `github_repository_ruleset.rules.required_status_checks.required_check` is defined as `required_status_checks.required_check`, which causes unclarity.

### After the change?

* A nested property `github_repository_ruleset.rules.required_status_checks.required_check` is defined as `rules.required_status_checks.required_check` under the "Rules" block section.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

----

