### PR TITLE
docs: update github membersip admin role explanation

### DIFF
--- a/website/docs/r/membership.html.markdown
+++ b/website/docs/r/membership.html.markdown
@@ -30,6 +30,7 @@ The following arguments are supported:
 * `username` - (Required) The user to add to the organization.
 * `role` - (Optional) The role of the user within the organization.
             Must be one of `member` or `admin`. Defaults to `member`.
+            `admin` role represents the `owner` role available via GitHub UI.
 * `downgrade_on_destroy` - (Optional) Defaults to `false`. If set to true,
             when this resource is destroyed, the member will not be removed
             from the organization. Instead, the member's role will be


### PR DESCRIPTION
Updated `admin` role option description for `github_membership` resource to explain its equivalence with the `owner` role available in GitHub UI.

Resolves #886

----

### Before the change?

* Membership `member` and `admin` role options were not in agreement with the `member` and `owner` options available when adding a new user via GitHub UI.

### After the change?

* The explanation of the equivalence of `admin` option in terraform and `owner` option in GitHub UI has been added.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

