### PR TITLE
update documentation for github_team_members to recommended team id

### DIFF
--- a/website/docs/r/team_members.html.markdown
+++ b/website/docs/r/team_members.html.markdown
@@ -59,7 +59,10 @@ resource "github_team_members" "some_team_members" {
 
 The following arguments are supported:
 
-* `team_id` - (Required) The GitHub team id or the GitHub team slug
+* `team_id` - (Required) The team id or the team slug
+
+~> **Note** Although the team id or team slug can be used it is recommended to use the team id.  Using the team slug will cause the team members associations to the team to be destroyed and recreated if the team name is updated.
+
 * `members` - (Required) List of team members. See [Members](#members) below for details.
 
 ### Members
@@ -72,7 +75,9 @@ The following arguments are supported:
 
 ## Import
 
-GitHub Team Membership can be imported using the team ID `teamid` or team name, e.g.
+~> **Note** Although the team id or team slug can be used it is recommended to use the team id.  Using the team slug will result in terraform doing conversions between the team slug and team id.  This will cause team members associations to the team to be destroyed and recreated on import.
+
+GitHub Team Membership can be imported using the team ID team id or team slug, e.g.
 
 ```
 $ terraform import github_team_members.some_team 1234567


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves https://github.com/integrations/terraform-provider-github/issues/1964

The issue seemed difficult to correct via code. It seems better to still allow the current behaviour but recommend the desired approach.

----

### Before the change?
Documentation did not describe the pitfalls of using the team slug when creating or importing the ```github_team_members``` resource.

* 

### After the change?
Documentation recommends that the team id, rather than team slug, is used for the  ```github_team_members``` resource and gives the reasons why.

* 

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

