### PR TITLE
Add documentation for importing github_organization_block resources

### DIFF
--- a/website/docs/r/organization_block.html.markdown
+++ b/website/docs/r/organization_block.html.markdown
@@ -22,3 +22,11 @@ resource "github_organization_block" "example" {
 The following arguments are supported:
 
 * `username` - (Required) The name of the user to block.
+
+## Import
+
+GitHub organization block can be imported using a username, e.g.
+
+```
+$ terraform import github_github_organization_block.example someuser
+```


### PR DESCRIPTION
This PR adds missing documentation for importing github_organization_block resources.
I tested the syntax and it worked for me.