### PR TITLE
fix environment wait timer so GitHub stays in line with terraform

### DIFF
--- a/github/resource_github_repository_environment.go
+++ b/github/resource_github_repository_environment.go
@@ -136,11 +136,8 @@ func resourceGithubRepositoryEnvironmentRead(d *schema.ResourceData, meta interf
 	d.Set("environment", envName)
 
 	for _, pr := range env.ProtectionRules {
-		switch *pr.Type {
-		case "wait_timer":
-			d.Set("wait_timer", pr.WaitTimer)
 
-		case "required_reviewers":
+		if *pr.Type == "required_reviewers" {
 			teams := make([]int64, 0)
 			users := make([]int64, 0)
 
@@ -162,6 +159,12 @@ func resourceGithubRepositoryEnvironmentRead(d *schema.ResourceData, meta interf
 					"users": users,
 				},
 			})
+		}
+
+		d.Set("wait_timer", nil)
+
+		if *pr.Type == "wait_timer" {
+			d.Set("wait_timer", pr.WaitTimer)
 		}
 	}
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves https://github.com/integrations/terraform-provider-github/issues/1996

----

### Before the change?
Updating a repos environment protection rules to set the wait timer to 0 in the WebUI  (unchecking the Wait Timer select box) would not cause a diff in terraform.

This meant GitHub had a zero wait timer, while terraform had >0 wait timer (depending on what was put in the code).

* 

### After the change?
Updating the wait timer to 0 in the Web UI (unchecking the Wait Timer select box) will now cause a diff in Terraform (assuming Terraform has the wait timer set to >0.

* 

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

