### PR TITLE
Ikegentz/1840

### DIFF
--- a/examples/issue_label/main.tf
+++ b/examples/issue_label/main.tf
@@ -1,0 +1,14 @@
+resource "github_issue_label" "individual_repo_label" {
+  repository  = var.individual_repo
+  name        = "foo"
+  color       = "000000"
+  description = "Test issue"
+}
+
+  resource "github_issue_label" "org_repo_label" {
+  repository  = var.org_repo
+  name        = "bar"
+  color       = "000000"
+  description = "Test issue"
+  org         = var.org
+}

--- a/examples/issue_label/providers.tf
+++ b/examples/issue_label/providers.tf
@@ -1,0 +1,4 @@
+provider "github" {
+  owner = var.owner
+  token = var.github_token
+}

--- a/examples/issue_label/variables.tf
+++ b/examples/issue_label/variables.tf
@@ -1,0 +1,24 @@
+variable "owner" {
+  description = "GitHub owner used to configure the provider"
+  type        = string
+}
+
+variable "github_token" {
+  description = "GitHub access token used to configure the provider"
+  type        = string
+}
+
+variable "individual_repo" {
+  description = "Name of repo owned by an individual to create the issue in"
+  type = string
+}
+
+variable "org_repo" {
+  description = "Name of repo owned by an organization to create the issue in"
+  type = string
+}
+
+variable "org" {
+  description = "Name of an org that owns the repo specified in org_repo"
+  type = string
+}

--- a/github/resource_github_issue_label.go
+++ b/github/resource_github_issue_label.go
@@ -44,7 +44,7 @@ func resourceGithubIssueLabel() *schema.Resource {
 			"org": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Org ID of an organization for the repository to create this label in, instead of an individual's repository",
+				Description: "Organization for repo to create this label in. Superscedes owner in provider",
 			},
 			"url": {
 				Type:        schema.TypeString,
@@ -154,7 +154,12 @@ func resourceGithubIssueLabelRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	orgName := meta.(*Owner).name
+	var orgName string
+	if d.Get("org").(string) == "" {
+		orgName = meta.(*Owner).name
+	} else {
+		orgName = d.Get("org").(string)
+	}
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 	if !d.IsNewResource() {
 		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
@@ -190,7 +195,12 @@ func resourceGithubIssueLabelRead(d *schema.ResourceData, meta interface{}) erro
 func resourceGithubIssueLabelDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Owner).v3client
 
-	orgName := meta.(*Owner).name
+	var orgName string
+	if d.Get("org").(string) == "" {
+		orgName = meta.(*Owner).name
+	} else {
+		orgName = d.Get("org").(string)
+	}
 	repoName := d.Get("repository").(string)
 	name := d.Get("name").(string)
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())

--- a/github/resource_github_issue_label.go
+++ b/github/resource_github_issue_label.go
@@ -41,6 +41,11 @@ func resourceGithubIssueLabel() *schema.Resource {
 				Optional:    true,
 				Description: "A short description of the label.",
 			},
+			"org": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Org ID of an organization for the repository to create this label in, instead of an individual's repository",
+			},
 			"url": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -66,7 +71,12 @@ func resourceGithubIssueLabel() *schema.Resource {
 
 func resourceGithubIssueLabelCreateOrUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Owner).v3client
-	orgName := meta.(*Owner).name
+	var orgName string
+	if d.Get("org").(string) == "" {
+		orgName = meta.(*Owner).name
+	} else {
+		orgName = d.Get("org").(string)
+	}
 	repoName := d.Get("repository").(string)
 	name := d.Get("name").(string)
 	color := d.Get("color").(string)

--- a/github/resource_github_issue_label_test.go
+++ b/github/resource_github_issue_label_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -78,6 +79,57 @@ func TestAccGithubIssueLabel(t *testing.T) {
 		t.Run("with an organization account", func(t *testing.T) {
 			testCase(t, organization)
 		})
+	})
+}
+
+func TestAccGithubIssueLabelOrg(t *testing.T) {
+
+	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+	// run test cases
+	t.Run("creates and updates labels without error", func(t *testing.T) {
+		// make a config
+		description := "test org label"
+		config := fmt.Sprintf(`
+
+	resource "github_repository" "test" {
+		name = "tf-acc-test-%s"
+		auto_init = true
+	}
+
+	resource "github_issue_label" "test" {
+		repository  = github_repository.test.id
+		name        = "foo"
+		color       = "000000"
+		description = "%s"
+		org         = "%s"	
+	}
+`, randomID, description, os.Getenv("GITHUB_ORGANIZATION"))
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { testAccPreCheck(t) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						// Check: resource.TestCheckResourceAttr("github_issue_label")
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
 	})
 
 }

--- a/github/resource_github_issue_label_test.go
+++ b/github/resource_github_issue_label_test.go
@@ -84,26 +84,20 @@ func TestAccGithubIssueLabel(t *testing.T) {
 
 func TestAccGithubIssueLabelOrg(t *testing.T) {
 
-	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+	// randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 	// run test cases
 	t.Run("creates and updates labels without error", func(t *testing.T) {
 		// make a config
 		description := "test org label"
 		config := fmt.Sprintf(`
-
-	resource "github_repository" "test" {
-		name = "tf-acc-test-%s"
-		auto_init = true
-	}
-
 	resource "github_issue_label" "test" {
-		repository  = github_repository.test.id
+		repository  = "%s"
 		name        = "foo"
 		color       = "000000"
 		description = "%s"
 		org         = "%s"	
 	}
-`, randomID, description, os.Getenv("GITHUB_ORGANIZATION"))
+`, os.Getenv("GITHUB_TEMPLATE_REPOSITORY"), description, os.Getenv("GITHUB_ORGANIZATION"))
 
 		testCase := func(t *testing.T, mode string) {
 			resource.Test(t, resource.TestCase{


### PR DESCRIPTION
Resolves #1840

----

### Before the change?

* There was no way with the `github_issue_label` resource to specify an Organization in which the repo you wanted to create the label for, lived

### After the change?

* This adds an `org` attribute to the `github_issue_label` resource that lets the end-user explicitly specify where the repo lives they want to add the label to

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
Nothing I'm aware of!

- [ ] Yes
- [X] No

----

