### PR TITLE
Use correct version of google/go-github, v55

### DIFF
--- a/github/resource_github_issue_labels.go
+++ b/github/resource_github_issue_labels.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/google/go-github/v52/github"
+	"github.com/google/go-github/v55/github"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 


### PR DESCRIPTION
Fixes the linting errors we've been seeing recently. `make lint` should now succeed in our builds. 