### PR TITLE
fix: github_rest_api data source always returns header and body as null

### DIFF
--- a/github/data_source_github_rest_api.go
+++ b/github/data_source_github_rest_api.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -25,11 +26,11 @@ func dataSourceGithubRestApi() *schema.Resource {
 				Computed: true,
 			},
 			"headers": {
-				Type:     schema.TypeMap,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"body": {
-				Type:     schema.TypeMap,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},
@@ -51,11 +52,21 @@ func dataSourceGithubRestApiRead(d *schema.ResourceData, meta interface{}) error
 
 	resp, _ := client.Do(ctx, req, &body)
 
+	h, err := json.Marshal(resp.Header)
+	if err != nil {
+		return err
+	}
+
+	b, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
 	d.SetId(resp.Header.Get("x-github-request-id"))
 	d.Set("code", resp.StatusCode)
 	d.Set("status", resp.Status)
-	d.Set("headers", resp.Header)
-	d.Set("body", body)
+	d.Set("headers", string(h))
+	d.Set("body", string(b))
 
 	return nil
 }

--- a/github/data_source_github_rest_api_test.go
+++ b/github/data_source_github_rest_api_test.go
@@ -30,6 +30,11 @@ func TestAccGithubRestApiDataSource(t *testing.T) {
 			resource.TestMatchResourceAttr(
 				"data.github_rest_api.test", "code", regexp.MustCompile("200"),
 			),
+			resource.TestMatchResourceAttr(
+				"data.github_rest_api.test", "status", regexp.MustCompile("200 OK"),
+			),
+			resource.TestCheckResourceAttrSet("data.github_rest_api.test", "body"),
+			resource.TestCheckResourceAttrSet("data.github_rest_api.test", "headers"),
 		)
 
 		testCase := func(t *testing.T, mode string) {
@@ -76,6 +81,11 @@ func TestAccGithubRestApiDataSource(t *testing.T) {
 			resource.TestMatchResourceAttr(
 				"data.github_rest_api.test", "code", regexp.MustCompile("404"),
 			),
+			resource.TestMatchResourceAttr(
+				"data.github_rest_api.test", "status", regexp.MustCompile("404 Not Found"),
+			),
+			resource.TestCheckResourceAttrSet("data.github_rest_api.test", "body"),
+			resource.TestCheckResourceAttrSet("data.github_rest_api.test", "headers"),
 		)
 
 		testCase := func(t *testing.T, mode string) {

--- a/website/docs/d/rest_api.html.markdown
+++ b/website/docs/d/rest_api.html.markdown
@@ -23,7 +23,8 @@ data "github_rest_api" "example" {
 
 ## Attributes Reference
 
+ * `id`       - The GitHub API Request ID
  * `code`     - A response status code.
  * `status`   - A response status string.
- * `headers`  - A map of response headers.
- * `body`     - A map of response body.
+ * `headers`  - A JSON string containing response headers.
+ * `body`     - A JSON string containing response body.


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2109 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The GitHub REST API data source would always return null or incomplete map values for body and headers attributes.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The GitHub REST API data source now returns the body and headers attributes as a JSON string, allowing users to decode them and use them. 

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [x] Yes
- [ ] No

This is technically a breaking change as it changes the type of the attributes involved to strings rather than maps - however, as this would have almost never worked properly, i'm not sure how much breaking it would do.

----