### PR TITLE
New resource: github_user_email_address

### DIFF
--- a/github/provider.go
+++ b/github/provider.go
@@ -162,6 +162,7 @@ func Provider() terraform.ResourceProvider {
 			"github_team_repository":                                                resourceGithubTeamRepository(),
 			"github_team_settings":                                                  resourceGithubTeamSettings(),
 			"github_team_sync_group_mapping":                                        resourceGithubTeamSyncGroupMapping(),
+			"github_user_email_address":                                             resourceGithubUserEmailAddress(),
 			"github_user_gpg_key":                                                   resourceGithubUserGpgKey(),
 			"github_user_invitation_accepter":                                       resourceGithubUserInvitationAccepter(),
 			"github_user_ssh_key":                                                   resourceGithubUserSshKey(),

--- a/github/resource_github_user_email_address.go
+++ b/github/resource_github_user_email_address.go
@@ -1,0 +1,80 @@
+package github
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceGithubUserEmailAddress() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGithubUserEmailCreate,
+		Read:   resourceGithubUserEmailRead,
+		Delete: resourceGithubUserEmailDelete,
+
+		Schema: map[string]*schema.Schema{
+			"email_address": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The email address to add to the user account.",
+			},
+		},
+	}
+}
+
+func resourceGithubUserEmailCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Owner).v3client
+
+	emailAddress := d.Get("email_address").(string)
+	ctx := context.Background()
+
+	emails, _, err := client.Users.AddEmails(ctx, []string{emailAddress})
+	if err != nil {
+		return err
+	}
+
+	for _, email := range emails {
+		if *email.Email == emailAddress {
+			d.SetId(*email.Email)
+			return nil
+		}
+	}
+
+	return resourceGithubUserEmailRead(d, meta)
+}
+
+func resourceGithubUserEmailRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Owner).v3client
+
+	emailAddress := d.Id()
+	ctx := context.Background()
+
+	emails, _, err := client.Users.ListEmails(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, email := range emails {
+		if *email.Email == emailAddress {
+			d.Set("email_address", emailAddress)
+			return nil
+		}
+	}
+
+	log.Printf("[INFO] Email address %s no longer exists in GitHub", emailAddress)
+	d.SetId("")
+	return nil
+}
+
+func resourceGithubUserEmailDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Owner).v3client
+
+	emailAddress := d.Id()
+	ctx := context.Background()
+
+	_, err := client.Users.DeleteEmails(ctx, []string{emailAddress})
+
+	return err
+}

--- a/github/resource_github_user_email_address_test.go
+++ b/github/resource_github_user_email_address_test.go
@@ -1,0 +1,53 @@
+package github
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccGithubUserEmailAddress(t *testing.T) {
+
+	randomEmailAddress := "example@example.com"
+
+	t.Run("creates and destroys a user email address without error", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+			resource "github_user_email_address" "test" {
+				email_address = "tf-acc-test-%s"
+			}
+		`, randomEmailAddress)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestMatchResourceAttr(
+				"github_user_email_address.test", "email_address",
+				regexp.MustCompile(randomEmailAddress),
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+	})
+
+}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves https://github.com/integrations/terraform-provider-github/issues/2070

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* It is not possible to create/read/destroy an email address to/from the GitHub user account.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* It is possible to create/read/destroy an email address.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

