### PR TITLE
Set group_id correctly in EMU mapping resource

### DIFF
--- a/github/resource_github_emu_group_mapping.go
+++ b/github/resource_github_emu_group_mapping.go
@@ -98,7 +98,7 @@ func resourceGithubEMUGroupMappingRead(d *schema.ResourceData, meta interface{})
 	if err = d.Set("etag", resp.Header.Get("ETag")); err != nil {
 		return err
 	}
-	if err = d.Set("group", group); err != nil {
+	if err = d.Set("group_id", int(*group.GroupID)); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Fixes #2131. 

The "group_id" of the EMU feature was being set incorrectly. In previous versions of the provider, this error was ignored.