### PR TITLE
fix(data_source_github_rest_api): only allow for 404 on err

### DIFF
--- a/github/data_source_github_rest_api.go
+++ b/github/data_source_github_rest_api.go
@@ -50,7 +50,10 @@ func dataSourceGithubRestApiRead(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	resp, _ := client.Do(ctx, req, &body)
+	resp, err := client.Do(ctx, req, &body)
+	if err != nil && resp.StatusCode != 404 {
+		return err
+	}
 
 	h, err := json.Marshal(resp.Header)
 	if err != nil {

--- a/github/data_source_github_rest_api_test.go
+++ b/github/data_source_github_rest_api_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -96,6 +97,43 @@ func TestAccGithubRestApiDataSource(t *testing.T) {
 					{
 						Config: config,
 						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
+
+	t.Run("fails for invalid endpoint", func(t *testing.T) {
+
+		// 4096 characters is the maximum length for a URL
+		var endpoint = strings.Repeat("x", 4096)
+		config := fmt.Sprintf(`
+			data "github_rest_api" "test" {
+				endpoint = "/%v"
+			}
+		`, endpoint)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config:      config,
+						ExpectError: regexp.MustCompile("Error: GET https://api.github.com/xx.*: 414"),
 					},
 				},
 			})


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2156 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* all exceptions are swallowed, even the json decode issue

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* 404 is allowed as status code (keeping current behaviour), other errors are raised

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

