### PR TITLE
docs: configure release notes categories based on labels

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -23,14 +23,11 @@ changelog:
     - title: 🛠️ Maintenance
       labels:
         - "Type: Maintenance"
+        - "dependencies"
 
     - title: 📝 Documentation
       labels:
         - "Type: Documentation"
-
-    - title: 📦 Dependency Updates
-      labels:
-        - "dependencies"
 
     - title: 🏷 Other Changes
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,6 +9,8 @@ changelog:
     - title: 🚀 New Features
       labels:
         - "Type: Feature"
+        - "New data source"
+        - "New resource"
 
     - title: 🐛 Bugfixes
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,35 @@
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes
+
+changelog:
+  categories:
+    - title: 💥 Breaking Changes
+      labels:
+        - "Type: Breaking change"
+
+    - title: 🚀 New Features
+      labels:
+        - "Type: Feature"
+
+    - title: 🐛 Bugfixes
+      labels:
+        - "Type: Bug"
+
+    - title: 🪦 Deprecations
+      labels:
+        - "Deprecation"
+
+    - title: 🛠️ Maintenance
+      labels:
+        - "Type: Maintenance"
+
+    - title: 📝 Documentation
+      labels:
+        - "Type: Documentation"
+
+    - title: 📦 Dependency Updates
+      labels:
+        - "dependencies"
+
+    - title: 🏷 Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #1506

Based on https://github.com/integrations/terraform-provider-github/issues/1506#issuecomment-1530476255, I added a configuration to customize the auto-generated changelog (release notes). I mainly used the labels with `Type:` prefix, but added a couple more categories for dependency updates and deprecations. Any changes that don't have one of those labels will go into the "Others" category.

This is purely cosmetic change, but I believe it will make it easier for the users to see what's new and what is more important to them.

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* All changes in the release notes were listed together under "What's Changed"

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Release notes will group changes based on the labels assigned to the merged PRs

### Pull request checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----

