### PR TITLE
fix: Prevent loading of allowed actions if not configured

### DIFF
--- a/github/resource_github_actions_organization_permissions.go
+++ b/github/resource_github_actions_organization_permissions.go
@@ -209,9 +209,14 @@ func resourceGithubActionsOrganizationPermissionsRead(d *schema.ResourceData, me
 	// only load and fill allowed_actions_config if allowed_actions_config is also set
 	// in the TF code. (see #2105)
 	// on initial import there might not be any value in the state, then we have to import the data
+	// -> but we can only load an existing state if the current config is set to "selected" (see #2182)
 	allowedActions := d.Get("allowed_actions").(string)
 	allowedActionsConfig := d.Get("allowed_actions_config").([]interface{})
-	if (allowedActions == "selected" && len(allowedActionsConfig) > 0) || allowedActions == "" {
+
+	serverHasAllowedActionsConfig := actionsPermissions.GetAllowedActions() == "selected"
+	userWantsAllowedActionsConfig := (allowedActions == "selected" && len(allowedActionsConfig) > 0) || allowedActions == ""
+
+	if serverHasAllowedActionsConfig && userWantsAllowedActionsConfig {
 		actionsAllowed, _, err := client.Actions.GetActionsAllowed(ctx, d.Id())
 		if err != nil {
 			return err


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2182 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* For import and initial load cases we were also attempting to load the selected actions config. But if on the org/repository the allowed_actions are not set to "selected" the API will respond with a 409 leading to an error.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* We now respect both what is desired by the user and what is possible from the server before calling APIs which might fail. 

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

