### PR TITLE
fix(data_source_github_organization): update users shape

### DIFF
--- a/github/data_source_github_organization_test.go
+++ b/github/data_source_github_organization_test.go
@@ -27,6 +27,7 @@ func TestAccGithubOrganizationDataSource(t *testing.T) {
 			resource.TestCheckResourceAttrSet("data.github_organization.test", "plan"),
 			resource.TestCheckResourceAttrSet("data.github_organization.test", "repositories.#"),
 			resource.TestCheckResourceAttrSet("data.github_organization.test", "members.#"),
+			resource.TestCheckResourceAttrSet("data.github_organization.test", "users.#"),
 			resource.TestCheckResourceAttrSet("data.github_organization.test", "two_factor_requirement_enabled"),
 			resource.TestCheckResourceAttrSet("data.github_organization.test", "default_repository_permission"),
 			resource.TestCheckResourceAttrSet("data.github_organization.test", "members_can_create_repositories"),

--- a/website/docs/d/organization.html.markdown
+++ b/website/docs/d/organization.html.markdown
@@ -33,7 +33,9 @@ data "github_organization" "example" {
  * `repositories` - (`list`) A list of the full names of the repositories in the organization formatted as `owner/name` strings
  * `members` - **Deprecated**: use `users` instead by replacing `github_organization.example.members` to `github_organization.example.users[*].login` which will give you the same value, expect this field to be removed in next major version
  * `users` - (`list`) A list with the members of the organization with following fields:
-   * `id` - The ID of the member
+   * `id` - **Deprecated**: Use `node_id` instead. Expect this to become equivalent to `database_id` in next major version
+   * `node_id` - The Node ID of the member
+   * `database_id` - The ID of the member
    * `login` - The members login
    * `email` - Publicly available email
    * `role` - Member role `ADMIN`, `MEMBER`


### PR DESCRIPTION
Updates the shape of the user objects on the github_organization data source to better match that of the github_user data source.

Particularly, exposing the database_id allows this user list to drive some other resources (such as github_repository_environment.reviewers) which require numeric ids without additional github_user data sources.

* Adds new node_id property for the GraphQL Node ID
* Deprecates id property in favour of using node_id
* Adds new database_id property which exposes the integer id of the user

Proposal is for v7 to switch id to the integer id, deprecating database_id. v8 would then drop database_id.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2207

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No (To the best of my knowledge)

----

