### PR TITLE
fix(github_repository_tag_protection): Handle non-existent tag protections in state refresh

### DIFF
--- a/github/resource_github_repository_tag_protection.go
+++ b/github/resource_github_repository_tag_protection.go
@@ -98,6 +98,13 @@ func resourceGithubRepositoryTagProtectionRead(d *schema.ResourceData, meta inte
 		}
 		return err
 	}
+
+	if len(tag_protection) == 0 {
+		log.Printf("[INFO] Removing tag protection %s from state because it no longer exists in GitHub", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	for _, tag := range tag_protection {
 		if tag.GetID() == id {
 			if err = d.Set("pattern", tag.GetPattern()); err != nil {


### PR DESCRIPTION
This commit updates the `resourceGithubRepositoryTagProtectionRead` function to remove tag protections from Terraform's state if they no longer exist in GitHub. This ensures that the state accurately reflects the actual infrastructure and that Terraform will recreate the tag protections if necessary.