### PR TITLE
fix: Apply `include_all_branches` correctly on `github_repository` template

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -708,8 +708,10 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	if repo.TemplateRepository != nil {
 		if err = d.Set("template", []interface{}{
 			map[string]interface{}{
-				"owner":      repo.TemplateRepository.Owner.Login,
-				"repository": repo.TemplateRepository.Name,
+				// GitHub API doesn't respond with include_all_branches
+				"include_all_branches": d.Get("template.0.include_all_branches"),
+				"owner":                repo.TemplateRepository.Owner.Login,
+				"repository":           repo.TemplateRepository.Name,
 			},
 		}); err != nil {
 			return err

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -1565,6 +1565,107 @@ func TestAccGithubRepositoryVisibility(t *testing.T) {
 		})
 	})
 
+	t.Run("sets include all branches when true for repositories created with a template", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name       = "tf-acc-test-template-include-all-branches-%s"
+				vulnerability_alerts = true
+				template {
+					include_all_branches = true
+					owner      = "%s"
+					repository = "%s"
+				}
+			}
+		`, randomID, testOrganization, "terraform-template-module")
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_repository.test", "template.0.owner",
+				testOrganization,
+			),
+			resource.TestCheckResourceAttr(
+				"github_repository.test", "template.0.include_all_branches",
+				"true",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+
+	t.Run("sets include all branches when false for repositories created with a template", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name       = "tf-acc-test-template-include-all-branches-%s"
+				vulnerability_alerts = true
+				template {
+					owner      = "%s"
+					repository = "%s"
+				}
+			}
+		`, randomID, testOrganization, "terraform-template-module")
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_repository.test", "template.0.owner",
+				testOrganization,
+			),
+			resource.TestCheckResourceAttr(
+				"github_repository.test", "template.0.include_all_branches",
+				"false",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+
 }
 
 func TestGithubRepositoryTopicPassesValidation(t *testing.T) {


### PR DESCRIPTION
Resolves #2130

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The repository is created successfully (with all the branches), but during a second apply it will change include_all_branches = false -> true while it was never set to false.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The repository is created successfully (with all the branches if requested, with the main branch if not), and the provided value for `include_all_branches` will be applied in state.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

