### PR TITLE
changed logic on repositories_detailed

### DIFF
--- a/github/data_source_github_team.go
+++ b/github/data_source_github_team.go
@@ -168,13 +168,13 @@ func dataSourceGithubTeamRead(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 
+		repositories_detailed = make([]interface{}, 0, resultsPerPage) //removed this from the loop
+
 		for {
 			repository, resp, err := client.Teams.ListTeamReposByID(ctx, orgId, team.GetID(), &options.ListOptions)
 			if err != nil {
 				return err
 			}
-
-			repositories_detailed = make([]interface{}, 0, len(repository))
 
 			for _, v := range repository {
 				repositories = append(repositories, v.GetName())


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2094 

----

### Before the change?
The **repositories_detailed** attribute was incorrectly truncating the repositories associated with a team to the last page of repositories associated with that team. 

* 

### After the change?
The **repositories_detailed** data attribute will no longer be incorrectly truncated.

* 

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

