### PR TITLE
Fix required workflows for organization rulesets

### DIFF
--- a/github/respository_rules_utils.go
+++ b/github/respository_rules_utils.go
@@ -472,6 +472,29 @@ func flattenRules(rules []*github.RepositoryRule, org bool) []interface{} {
 			rule["required_check"] = requiredStatusChecksSlice
 			rule["strict_required_status_checks_policy"] = params.StrictRequiredStatusChecksPolicy
 			rulesMap[v.Type] = []map[string]interface{}{rule}
+
+		case "workflows":
+			var params github.RequiredWorkflowsRuleParameters
+			log.Printf("[DEBUG] osama test: %v", v.Parameters)
+
+			err := json.Unmarshal(*v.Parameters, &params)
+			if err != nil {
+				log.Printf("[INFO] Unexpected error unmarshalling rule %s with parameters: %v",
+					v.Type, v.Parameters)
+			}
+
+			requiredWorkflowsSlice := make([]map[string]interface{}, 0)
+			for _, workflow := range params.RequiredWorkflows {
+				requiredWorkflowsSlice = append(requiredWorkflowsSlice, map[string]interface{}{
+					"repository_id": workflow.RepositoryID,
+					"ref":           *workflow.Ref,
+					"path":          workflow.Path,
+				})
+			}
+
+			rule := make(map[string]interface{})
+			rule["required_workflow"] = requiredWorkflowsSlice
+			rulesMap[v.Type] = []map[string]interface{}{rule}
 		}
 	}
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2113 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* When you apply the Terraform plan, you have the following: `"required_workflows": []` in state. This happens because there was no code that flattens this specific rule.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Added the required code to flatten this rule when flattening the ruleset's rules. When you apply the Terraform plan, you have the following in state if successful:
```
                "required_workflows": [
                  {
                    "required_workflow": [
                      {
                        "path": "<PATH>",
                        "ref": "<REF>",
                        "repository_id": <REPO_ID>
                      }
                    ]
                  }
                ]
```

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

