### PR TITLE
Goreleaser deprecation: skip --> disable

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,4 +57,4 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
Required before https://github.com/integrations/terraform-provider-github/pull/2293 can be merged. 