### PR TITLE
fix(etag): fix etag being noisy when no actual state has been changed

### DIFF
--- a/github/resource_github_membership.go
+++ b/github/resource_github_membership.go
@@ -37,6 +37,10 @@ func resourceGithubMembership() *schema.Resource {
 			"etag": {
 				Type:     schema.TypeString,
 				Computed: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
+				DiffSuppressOnRefresh: true,
 			},
 			"downgrade_on_destroy": {
 				Type:        schema.TypeBool,

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -360,6 +360,10 @@ func resourceGithubRepository() *schema.Resource {
 			"etag": {
 				Type:     schema.TypeString,
 				Computed: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
+				DiffSuppressOnRefresh: true,
 			},
 			"primary_language": {
 				Type:     schema.TypeString,

--- a/github/resource_github_team.go
+++ b/github/resource_github_team.go
@@ -89,6 +89,10 @@ func resourceGithubTeam() *schema.Resource {
 			"etag": {
 				Type:     schema.TypeString,
 				Computed: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
+				DiffSuppressOnRefresh: true,
 			},
 			"node_id": {
 				Type:        schema.TypeString,

--- a/github/resource_github_team_membership.go
+++ b/github/resource_github_team_membership.go
@@ -58,6 +58,10 @@ func resourceGithubTeamMembership() *schema.Resource {
 			"etag": {
 				Type:     schema.TypeString,
 				Computed: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
+				DiffSuppressOnRefresh: true,
 			},
 		},
 	}

--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -55,6 +55,10 @@ func resourceGithubTeamRepository() *schema.Resource {
 			"etag": {
 				Type:     schema.TypeString,
 				Computed: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
+				DiffSuppressOnRefresh: true,
 			},
 		},
 	}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/schema.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/schema.go
@@ -980,7 +980,8 @@ func (m schemaMap) internalValidate(topSchemaMap schemaMap, attrsOnly bool) erro
 				return fmt.Errorf("%s: DefaultFunc is for configurable attributes,"+
 					"there's nothing to configure on computed-only field", k)
 			}
-			if v.DiffSuppressFunc != nil {
+			// Allow this behavior for etag, which is a special case (being too noisy)
+			if v.DiffSuppressFunc != nil && k != "etag" {
 				return fmt.Errorf("%s: DiffSuppressFunc is for suppressing differences"+
 					" between config and state representation. "+
 					"There is no config for computed-only field, nothing to compare.", k)


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves:
- https://github.com/integrations/terraform-provider-github/issues/796
- https://github.com/integrations/terraform-provider-github/issues/910
- https://github.com/hashicorp/terraform/issues/28803
- https://github.com/integrations/terraform-provider-github/pull/911
- https://github.com/integrations/terraform-provider-github/pull/909

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* ETag are shown in diff on almost every plan, even after apply just before the next plan.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* ETag is hidden from output.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

*Disclaimer - I made the change according to my needs, please let me know if this should be extended to all/other resources.*