### PR TITLE
fix markdown for `github_repository`

### DIFF
--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -10,11 +10,7 @@ description: |-
 This resource allows you to create and manage repositories within your
 GitHub organization or personal account.
 
-~> Note: When used with GitHub App authentication, even GET requests must have the `contents:write` permission. Without it, the following attributes will be ignored, leading to unexpected behavior and confusing diffs:
-
-- `allow_merge_commit` (including the related `merge_commit_title` and `merge_commit_message`)
-- `allow_squash_merge` (including the related `squash_merge_commit_title` and `squash_merge_commit_message`)
-- `allow_rebase_merge`
+~> **Note** When used with GitHub App authentication, even GET requests must have the `contents:write` permission. Without it, the following arguments will be ignored, leading to unexpected behavior and confusing diffs: `allow_merge_commit`, `allow_squash_merge`, `allow_rebase_merge`, `merge_commit_title`, `merge_commit_message`, `squash_merge_commit_title` and `squash_merge_commit_message`.
 
 ## Example Usage
 


### PR DESCRIPTION
### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

![image](https://github.com/user-attachments/assets/22f78c39-7e4c-423f-adf6-eebb5aa373be)

### After the change?

![image](https://github.com/user-attachments/assets/cd3c327a-d951-4b36-8c70-c001baabf1b9)

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

