### PR TITLE
feat: Adding summary_only field to the organization data source

### DIFF
--- a/github/data_source_github_organization.go
+++ b/github/data_source_github_organization.go
@@ -139,6 +139,11 @@ func dataSourceGithubOrganization() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"summary_only": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -165,75 +170,100 @@ func dataSourceGithubOrganizationRead(d *schema.ResourceData, meta interface{}) 
 		ListOptions: github.ListOptions{PerPage: 100, Page: 1},
 	}
 
-	var repoList []string
-	var allRepos []*github.Repository
+	summaryOnly := d.Get("summary_only").(bool)
+	if !summaryOnly {
+		var repoList []string
+		var allRepos []*github.Repository
 
-	for {
-		repos, resp, err := client3.Repositories.ListByOrg(ctx, name, opts)
-		if err != nil {
-			return err
-		}
-		allRepos = append(allRepos, repos...)
+		for {
+			repos, resp, err := client3.Repositories.ListByOrg(ctx, name, opts)
+			if err != nil {
+				return err
+			}
+			allRepos = append(allRepos, repos...)
 
-		opts.Page = resp.NextPage
+			opts.Page = resp.NextPage
 
-		if resp.NextPage == 0 {
-			break
-		}
-	}
-
-	ignoreArchiveRepos := d.Get("ignore_archived_repos").(bool)
-	for index := range allRepos {
-		repo := allRepos[index]
-		if ignoreArchiveRepos && repo.GetArchived() {
-			continue
+			if resp.NextPage == 0 {
+				break
+			}
 		}
 
-		repoList = append(repoList, repo.GetFullName())
-	}
+		ignoreArchiveRepos := d.Get("ignore_archived_repos").(bool)
+		for index := range allRepos {
+			repo := allRepos[index]
+			if ignoreArchiveRepos && repo.GetArchived() {
+				continue
+			}
 
-	var query struct {
-		Organization struct {
-			MembersWithRole struct {
-				Edges []struct {
-					Role githubv4.String
-					Node struct {
-						Id    githubv4.String
-						Login githubv4.String
-						Email githubv4.String
+			repoList = append(repoList, repo.GetFullName())
+		}
+
+		var query struct {
+			Organization struct {
+				MembersWithRole struct {
+					Edges []struct {
+						Role githubv4.String
+						Node struct {
+							Id    githubv4.String
+							Login githubv4.String
+							Email githubv4.String
+						}
 					}
-				}
-				PageInfo struct {
-					EndCursor   githubv4.String
-					HasNextPage bool
-				}
-			} `graphql:"membersWithRole(first: 100, after: $after)"`
-		} `graphql:"organization(login: $login)"`
-	}
-	variables := map[string]interface{}{
-		"login": githubv4.String(name),
-		"after": (*githubv4.String)(nil),
-	}
-	var members []string
-	var users []map[string]string
-	for {
-		err := client4.Query(ctx, &query, variables)
-		if err != nil {
-			return err
+					PageInfo struct {
+						EndCursor   githubv4.String
+						HasNextPage bool
+					}
+				} `graphql:"membersWithRole(first: 100, after: $after)"`
+			} `graphql:"organization(login: $login)"`
 		}
-		for _, edge := range query.Organization.MembersWithRole.Edges {
-			members = append(members, string(edge.Node.Login))
-			users = append(users, map[string]string{
-				"id":    string(edge.Node.Id),
-				"login": string(edge.Node.Login),
-				"email": string(edge.Node.Email),
-				"role":  string(edge.Role),
-			})
+		variables := map[string]interface{}{
+			"login": githubv4.String(name),
+			"after": (*githubv4.String)(nil),
 		}
-		if !query.Organization.MembersWithRole.PageInfo.HasNextPage {
-			break
+		var members []string
+		var users []map[string]string
+		for {
+			err := client4.Query(ctx, &query, variables)
+			if err != nil {
+				return err
+			}
+			for _, edge := range query.Organization.MembersWithRole.Edges {
+				members = append(members, string(edge.Node.Login))
+				users = append(users, map[string]string{
+					"id":    string(edge.Node.Id),
+					"login": string(edge.Node.Login),
+					"email": string(edge.Node.Email),
+					"role":  string(edge.Role),
+				})
+			}
+			if !query.Organization.MembersWithRole.PageInfo.HasNextPage {
+				break
+			}
+			variables["after"] = githubv4.NewString(query.Organization.MembersWithRole.PageInfo.EndCursor)
 		}
-		variables["after"] = githubv4.NewString(query.Organization.MembersWithRole.PageInfo.EndCursor)
+
+		d.Set("repositories", repoList)
+		d.Set("members", members)
+		d.Set("users", users)
+		d.Set("two_factor_requirement_enabled", organization.GetTwoFactorRequirementEnabled())
+		d.Set("default_repository_permission", organization.GetDefaultRepoPermission())
+		d.Set("members_can_create_repositories", organization.GetMembersCanCreateRepos())
+		d.Set("members_allowed_repository_creation_type", organization.GetMembersAllowedRepositoryCreationType())
+		d.Set("members_can_create_public_repositories", organization.GetMembersCanCreatePublicRepos())
+		d.Set("members_can_create_private_repositories", organization.GetMembersCanCreatePrivateRepos())
+		d.Set("members_can_create_internal_repositories", organization.GetMembersCanCreateInternalRepos())
+		d.Set("members_can_fork_private_repositories", organization.GetMembersCanCreatePrivateRepos())
+		d.Set("web_commit_signoff_required", organization.GetWebCommitSignoffRequired())
+		d.Set("members_can_create_pages", organization.GetMembersCanCreatePages())
+		d.Set("members_can_create_public_pages", organization.GetMembersCanCreatePublicPages())
+		d.Set("members_can_create_private_pages", organization.GetMembersCanCreatePrivatePages())
+		d.Set("advanced_security_enabled_for_new_repositories", organization.GetAdvancedSecurityEnabledForNewRepos())
+		d.Set("dependabot_alerts_enabled_for_new_repositories", organization.GetDependabotAlertsEnabledForNewRepos())
+		d.Set("dependabot_security_updates_enabled_for_new_repositories", organization.GetDependabotSecurityUpdatesEnabledForNewRepos())
+		d.Set("dependency_graph_enabled_for_new_repositories", organization.GetDependencyGraphEnabledForNewRepos())
+		d.Set("secret_scanning_enabled_for_new_repositories", organization.GetSecretScanningEnabledForNewRepos())
+		d.Set("secret_scanning_push_protection_enabled_for_new_repositories", organization.GetSecretScanningPushProtectionEnabledForNewRepos())
 	}
 
 	d.SetId(strconv.FormatInt(organization.GetID(), 10))
@@ -243,27 +273,6 @@ func dataSourceGithubOrganizationRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("node_id", organization.GetNodeID())
 	d.Set("description", organization.GetDescription())
 	d.Set("plan", planName)
-	d.Set("repositories", repoList)
-	d.Set("members", members)
-	d.Set("users", users)
-	d.Set("two_factor_requirement_enabled", organization.GetTwoFactorRequirementEnabled())
-	d.Set("default_repository_permission", organization.GetDefaultRepoPermission())
-	d.Set("members_can_create_repositories", organization.GetMembersCanCreateRepos())
-	d.Set("members_allowed_repository_creation_type", organization.GetMembersAllowedRepositoryCreationType())
-	d.Set("members_can_create_public_repositories", organization.GetMembersCanCreatePublicRepos())
-	d.Set("members_can_create_private_repositories", organization.GetMembersCanCreatePrivateRepos())
-	d.Set("members_can_create_internal_repositories", organization.GetMembersCanCreateInternalRepos())
-	d.Set("members_can_fork_private_repositories", organization.GetMembersCanCreatePrivateRepos())
-	d.Set("web_commit_signoff_required", organization.GetWebCommitSignoffRequired())
-	d.Set("members_can_create_pages", organization.GetMembersCanCreatePages())
-	d.Set("members_can_create_public_pages", organization.GetMembersCanCreatePublicPages())
-	d.Set("members_can_create_private_pages", organization.GetMembersCanCreatePrivatePages())
-	d.Set("advanced_security_enabled_for_new_repositories", organization.GetAdvancedSecurityEnabledForNewRepos())
-	d.Set("dependabot_alerts_enabled_for_new_repositories", organization.GetDependabotAlertsEnabledForNewRepos())
-	d.Set("dependabot_security_updates_enabled_for_new_repositories", organization.GetDependabotSecurityUpdatesEnabledForNewRepos())
-	d.Set("dependency_graph_enabled_for_new_repositories", organization.GetDependencyGraphEnabledForNewRepos())
-	d.Set("secret_scanning_enabled_for_new_repositories", organization.GetSecretScanningEnabledForNewRepos())
-	d.Set("secret_scanning_push_protection_enabled_for_new_repositories", organization.GetSecretScanningPushProtectionEnabledForNewRepos())
 
 	return nil
 }

--- a/github/data_source_github_organization_test.go
+++ b/github/data_source_github_organization_test.go
@@ -138,4 +138,68 @@ func TestAccGithubOrganizationDataSource(t *testing.T) {
 
 	})
 
+	t.Run("queries for an organization summary_only without error", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+			data "github_organization" "test" {
+				name = "%s"
+				summary_only = true
+			}
+		`, testOrganization)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr("data.github_organization.test", "login", testOrganization),
+			resource.TestCheckResourceAttrSet("data.github_organization.test", "name"),
+			resource.TestCheckResourceAttrSet("data.github_organization.test", "orgname"),
+			resource.TestCheckResourceAttrSet("data.github_organization.test", "node_id"),
+			resource.TestCheckResourceAttrSet("data.github_organization.test", "description"),
+			resource.TestCheckResourceAttrSet("data.github_organization.test", "plan"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "repositories.#"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "members.#"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "two_factor_requirement_enabled"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "default_repository_permission"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "members_can_create_repositories"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "members_allowed_repository_creation_type"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "members_can_create_public_repositories"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "members_can_create_private_repositories"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "members_can_create_internal_repositories"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "members_can_fork_private_repositories"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "web_commit_signoff_required"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "members_can_create_pages"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "members_can_create_public_pages"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "members_can_create_private_pages"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "advanced_security_enabled_for_new_repositories"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "dependabot_alerts_enabled_for_new_repositories"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "dependabot_security_updates_enabled_for_new_repositories"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "dependency_graph_enabled_for_new_repositories"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "secret_scanning_enabled_for_new_repositories"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "secret_scanning_push_protection_enabled_for_new_repositories"),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
 }

--- a/website/docs/d/organization.html.markdown
+++ b/website/docs/d/organization.html.markdown
@@ -19,7 +19,8 @@ data "github_organization" "example" {
 
 ## Argument Reference
 
-* `ignore_archived_repos` - Whether or not to include archived repos in the `repositories` list
+* `ignore_archived_repos` - (Optional) Whether or not to include archived repos in the `repositories` list. Defaults to `false`.
+* `summary_only` - (Optional) Exclude the repos, members and other attributes from the returned result. Defaults to `false`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* `organization` data source pulls all repos and members for the organization. A pull could take several minutes for one large organization.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* `organization` resource can add `summary_only` field (similiar to the `github_organization_teams` resource) which will pull org ID and name. This is useful for [`github_enterprise_actions_permissions`](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/enterprise_actions_permissions) which may pull dozens of organization resources.

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [X] No

----

