### PR TITLE
docs: mark name as required for data source github_organization

### DIFF
--- a/website/docs/d/organization.html.markdown
+++ b/website/docs/d/organization.html.markdown
@@ -19,7 +19,8 @@ data "github_organization" "example" {
 
 ## Argument Reference
 
-* `ignore_archived_repos` - Whether or not to include archived repos in the `repositories` list
+* `name` - (Required) The name of the organization.
+* `ignore_archived_repos` - (Optional) Whether or not to include archived repos in the `repositories` list.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Resolves #2263 

----

### Before the change?

* The attribute `name` was not listed in the argument section of data source `github_organization`.

### After the change?

* The attribute `name` is listed as required in the argument section of data source `github_organization`. In addition, the second argument is flagged as "(Optional)" ([link to implementation](https://github.com/integrations/terraform-provider-github/blob/b73422f2fc677d54db4d938176f3cabc6f3aa700/github/data_source_github_organization.go#L23))
 

### Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)


### Does this introduce a breaking change?

- [ ] Yes
- [X] No, only documentation for existing code base is updated.

----

