### PR TITLE
Fix update of github release

### DIFF
--- a/github/resource_github_release.go
+++ b/github/resource_github_release.go
@@ -182,10 +182,13 @@ func resourceGithubReleaseCreateUpdate(d *schema.ResourceData, meta interface{})
 			log.Printf("[DEBUG] Response from creating release: %#v", *resp)
 		}
 	} else {
-		number := d.Get("number").(int64)
+		id, err := strconv.ParseInt(d.Id(), 10, 64)
+		if err != nil {
+			return err
+		}
 		log.Printf("[DEBUG] Updating release: %d:%s (%s/%s)",
-			number, targetCommitish, owner, repoName)
-		release, resp, err = client.Repositories.EditRelease(ctx, owner, repoName, number, req)
+			id, targetCommitish, owner, repoName)
+		release, resp, err = client.Repositories.EditRelease(ctx, owner, repoName, id, req)
 		if resp != nil {
 			log.Printf("[DEBUG] Response from updating release: %#v", *resp)
 		}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2062

This PR fixing update of GitHub release.
Previous code was getting release ID with `d.Get("number").(int64)`.
This resulted in panic because `Get("number")` returned `nil` and it couldn't be converted to `int64`.
I adjusted the code to get release ID correctly.

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Provider failed to update a release.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Provider can update a release.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

