### PR TITLE
fix: remove MaxItems constraint from bypass_pull_request_allowances

### DIFF
--- a/github/resource_github_branch_protection_v3.go
+++ b/github/resource_github_branch_protection_v3.go
@@ -137,7 +137,6 @@ func resourceGithubBranchProtectionV3() *schema.Resource {
 						"bypass_pull_request_allowances": {
 							Type:     schema.TypeList,
 							Optional: true,
-							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"users": {

--- a/github/resource_github_branch_protection_v3_test.go
+++ b/github/resource_github_branch_protection_v3_test.go
@@ -325,9 +325,9 @@ func TestAccGithubBranchProtectionV3_required_pull_request_reviews(t *testing.T)
 				  dismissal_teams = ["b"]
 				  dismissal_apps = ["c"]
 				  bypass_pull_request_allowances {
-					  users = ["d"]
+					  users = ["d","e","f"]
 					  teams = [github_team.test.slug]
-					  apps = ["e"]
+					  apps = ["g"]
 				  }
 			  }
 
@@ -364,7 +364,7 @@ func TestAccGithubBranchProtectionV3_required_pull_request_reviews(t *testing.T)
 				"github_branch_protection_v3.test", "required_pull_request_reviews.0.bypass_pull_request_allowances.#", "1",
 			),
 			resource.TestCheckResourceAttr(
-				"github_branch_protection_v3.test", "required_pull_request_reviews.0.bypass_pull_request_allowances.0.users.#", "1",
+				"github_branch_protection_v3.test", "required_pull_request_reviews.0.bypass_pull_request_allowances.0.users.#", "3",
 			),
 			resource.TestCheckResourceAttr(
 				"github_branch_protection_v3.test", "required_pull_request_reviews.0.bypass_pull_request_allowances.0.teams.#", "1",


### PR DESCRIPTION
Resolves  [#2033](https://github.com/integrations/terraform-provider-github/issues/2033)

----

### Before the change?
Attempting to provide a list of multiple users, teams or apps in the bypass_pull_request_allowances block results in the error `422 Validation Failed [{Resource: Field: Code: Message:Context must be unique per branch protection.}]`

* 

### After the change?
You can provide a list of users, teams, or apps in the bypass_pull_request_allowances block and the apply will succeed.

* 

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?


Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [X] No

----

