### PR TITLE
Fix issues/2252

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -752,6 +752,9 @@ func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 	// handle visibility updates separately from other fields
 	repoReq.Visibility = nil
 
+	// handle security and analysis separately from other fields
+	repoReq.SecurityAndAnalysis = nil
+
 	// The documentation for `default_branch` states: "This can only be set
 	// after a repository has already been created". However, for backwards
 	// compatibility we need to allow terraform configurations that set
@@ -849,6 +852,17 @@ func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 	} else {
 		log.Printf("[DEBUG] No privacy update required. private: %v", d.Get("private"))
+	}
+
+	if d.HasChange("security_and_analysis") {
+		repoReq.SecurityAndAnalysis = calculateSecurityAndAnalysis(d)
+		log.Printf("[DEBUG] Updating repository security_and_analysis to %v", repoReq.SecurityAndAnalysis)
+		_, _, err = client.Repositories.Edit(ctx, owner, repoName, repoReq)
+		if err != nil {
+			return err
+		}
+	} else {
+		log.Printf("[DEBUG] No security_and_analysis update required. security_and_analysis: %v", d.Get("security_and_analysis"))
 	}
 
 	return resourceGithubRepositoryRead(d, meta)


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2252

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

If the `security_and_analysis` block of `github_repository` is either unset, unchanged, or ignored by Terraform by using the `ignore_changes` list in the `lifecycle` block, the provider sends an update containing that information. This causes the following error if there are enterprise policies preventing such a change:

`│ Error: PATCH https://api.github.com/repos/$ORG_REDACTED/$REPO_REDACTED: 422 An enterprise policy prevented modifying advanced security enablement. Contact your enterprise owner for details. []
│ 
│   with github_repository.all['$REPO_REDACTED'],
│   on main.tf line 1, in resource "github_repository" "all":
│    1: resource "github_repository" "all" {`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The provider properly ignores unset, unchanged, or ignored values for `security_and_analysis`

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Not specifically, but if anyone was relying on the incorrect behavior, this will likely break that workflow.

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

