### PR TITLE
feat: Add data source to retrieve repo environment public key

### DIFF
--- a/github/data_source_github_actions_environment_public_key.go
+++ b/github/data_source_github_actions_environment_public_key.go
@@ -1,0 +1,64 @@
+package github
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceGithubActionsEnvironmentPublicKey() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGithubActionsEnvironmentPublicKeyRead,
+
+		Schema: map[string]*schema.Schema{
+			"repository_id": {
+				Type:        schema.TypeInt,
+				Description: "The repository in which the Environment is defined.",
+				Required:    true,
+			},
+			"environment": {
+				Type:        schema.TypeString,
+				Description: "The name of the Environment.",
+				Required:    true,
+			},
+			"key_id": {
+				Type:        schema.TypeString,
+				Description: "The ID of the public key.",
+				Computed:    true,
+			},
+			"key": {
+				Type:        schema.TypeString,
+				Description: "The public key value.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceGithubActionsEnvironmentPublicKeyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Owner).v3client
+	ctx := context.Background()
+
+	envName := d.Get("environment").(string)
+	escapedEnvName := url.PathEscape(envName)
+
+	repoId := d.Get("repository_id").(int)
+
+	publicKey, _, err := client.Actions.GetEnvPublicKey(ctx, repoId, escapedEnvName)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(publicKey.GetKeyID())
+	err = d.Set("key_id", publicKey.GetKeyID())
+	if err != nil {
+		return err
+	}
+	err = d.Set("key", publicKey.GetKey())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/github/data_source_github_actions_environment_public_key_test.go
+++ b/github/data_source_github_actions_environment_public_key_test.go
@@ -1,0 +1,63 @@
+package github
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccGithubActionsEnvironmentPublicKeyDataSource(t *testing.T) {
+
+	t.Run("queries actions public key from an environment", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name      = "tf-acc-test-%s"
+				auto_init = true
+			}
+
+			resource "github_repository_environment" "test" {
+				repository       = github_repository.test.name
+				environment      = "test"
+			  }
+
+			data "github_actions_environment_public_key" "test" {
+				repository_id	= github_repository.test.id
+				environment     = github_repository_environment.test.environment
+			}
+		`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttrSet("data.github_actions_environment_public_key.test", "key_id"),
+			resource.TestCheckResourceAttrSet("data.github_actions_environment_public_key.test", "key"),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+}

--- a/github/provider.go
+++ b/github/provider.go
@@ -198,6 +198,7 @@ func Provider() *schema.Provider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"github_actions_environment_public_key":                                 dataSourceGithubActionsEnvironmentPublicKey(),
 			"github_actions_environment_secrets":                                    dataSourceGithubActionsEnvironmentSecrets(),
 			"github_actions_environment_variables":                                  dataSourceGithubActionsEnvironmentVariables(),
 			"github_actions_organization_oidc_subject_claim_customization_template": dataSourceGithubActionsOrganizationOIDCSubjectClaimCustomizationTemplate(),

--- a/website/docs/d/actions_environment_public_key.html.markdown
+++ b/website/docs/d/actions_environment_public_key.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "github"
+page_title: "GitHub: github_actions_environment_public_key"
+description: |-
+  Get Actions public key of the repository environment
+---
+
+# github\_actions\_environment\_public\_key
+
+Use this data source to retrieve information about the public key of the repository environment.
+Note that the provider `token` must have the "Secrets" repository permissions (read) and "Environments" repository permissions (read) to retreive the public key of a given environment.
+
+## Example Usage
+
+```hcl
+resource "github_repository" "example" {
+    name      = "example"
+    auto_init = true
+}
+
+resource "github_repository_environment" "example" {
+    repository       = github_repository.example.name
+    environment      = "example"
+}
+
+data "github_actions_environment_public_key" "example" {
+    repository_id	= github_repository.test.repo_id
+    environment     = github_repository_environment.example.environment
+}
+```
+
+## Argument Reference
+
+* `repository_id` - (Required) The repository ID
+* `environment` - (Required) The repository's environment name
+
+## Attributes Reference
+
+* `key_id` - ID of the key that has been retrieved.
+* `key` - Actual key retrieved.

--- a/website/github.erb
+++ b/website/github.erb
@@ -14,6 +14,9 @@
           <a href="#">Data Sources</a>
           <ul class="nav nav-visible">
             <li>
+              <a href="/docs/providers/github/d/actions_environment_public_key.html">actions_environment_public_key</a>
+            </li>
+            <li>
               <a href="/docs/providers/github/d/actions_environment_secrets.html">actions_environment_secrets</a>
             </li>
             <li>


### PR DESCRIPTION
Resolves: Lack of a data source delivering a Public Key of a Repo's Environment

----

### Before the change?
Not possible to retrieve the Public Key of a Environment in a Repository.


### After the change?
Brand new data source delivering a Public Key created automatically by GitHub when a new Environment is created in a Repository.

* Retrieving the organization public key, repository public key, user public key, dependabot public key and codespaces public key are already implemented. This PR brings the lacking Environment Public Key.


### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
No breaking changes introduced.

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [X] No

----

