### PR TITLE
fix(resource_github_repository): Allow creating repo from template with internal visibility

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-github/v63/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/shurcooL/githubv4"
 )
 
 func resourceGithubRepository() *schema.Resource {
@@ -526,6 +527,7 @@ func resourceGithubRepositoryObject(d *schema.ResourceData) *github.Repository {
 
 func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Owner).v3client
+	graphql := meta.(*Owner).v4client
 
 	if branchName, hasDefaultBranch := d.GetOk("default_branch"); hasDefaultBranch && (branchName != "main") {
 		return fmt.Errorf("cannot set the default branch on a new repository to something other than 'main'")
@@ -539,11 +541,15 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 
 	// determine if repository should be private. assume public to start
 	isPrivate := false
+	effectiveVisibility := githubv4.RepositoryVisibilityPublic
 
 	// prefer visibility to private flag since private flag is deprecated
 	privateKeyword, ok := d.Get("private").(bool)
 	if ok {
 		isPrivate = privateKeyword
+		if privateKeyword {
+			effectiveVisibility = githubv4.RepositoryVisibilityPrivate
+		}
 	}
 
 	visibility, ok := d.Get("visibility").(string)
@@ -551,6 +557,7 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 		if visibility == "private" || visibility == "internal" {
 			isPrivate = true
 		}
+		effectiveVisibility = githubv4.RepositoryVisibility(strings.ToUpper(visibility))
 	}
 
 	repoReq.Private = github.Bool(isPrivate)
@@ -566,26 +573,40 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 
 			templateRepo := templateConfigMap["repository"].(string)
 			templateRepoOwner := templateConfigMap["owner"].(string)
-			includeAllBranches := templateConfigMap["include_all_branches"].(bool)
 
-			templateRepoReq := github.TemplateRepoRequest{
-				Name:               &repoName,
-				Owner:              &owner,
-				Description:        github.String(d.Get("description").(string)),
-				Private:            github.Bool(isPrivate),
-				IncludeAllBranches: github.Bool(includeAllBranches),
-			}
-
-			repo, _, err := client.Repositories.CreateFromTemplate(ctx,
-				templateRepoOwner,
-				templateRepo,
-				&templateRepoReq,
-			)
+			templateID, err := getRepositoryIDForOwner(templateRepo, templateRepoOwner, meta)
 			if err != nil {
 				return err
 			}
 
-			d.SetId(*repo.Name)
+			owner, _, err := client.Organizations.Get(ctx, meta.(*Owner).name)
+			if err != nil {
+				return err
+			}
+
+			var mutation struct {
+				CloneTemplateRepository struct {
+					Repository struct {
+						Name string
+					}
+				} `graphql:"cloneTemplateRepository(input: $input)"`
+			}
+
+			includeAllBranches := githubv4.Boolean(templateConfigMap["include_all_branches"].(bool))
+			description := githubv4.String(d.Get("description").(string))
+			err = graphql.Mutate(ctx, &mutation, githubv4.CloneTemplateRepositoryInput{
+				Name:               githubv4.String(d.Get("name").(string)),
+				OwnerID:            githubv4.ID(owner.NodeID),
+				Description:        &description,
+				RepositoryID:       templateID,
+				Visibility:         effectiveVisibility,
+				IncludeAllBranches: &includeAllBranches,
+			}, nil)
+			if err != nil {
+				return err
+			}
+
+			d.SetId(mutation.CloneTemplateRepository.Repository.Name)
 		}
 	} else {
 		// Create without a repository template

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -1515,6 +1515,56 @@ func TestAccGithubRepositoryVisibility(t *testing.T) {
 		})
 	})
 
+	t.Run("sets internal visibility for repositories created by a template", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "internal" {
+				name       = "tf-acc-test-visibility-internal-%s"
+				visibility = "internal"
+				template {
+					owner      = "%s"
+					repository = "%s"
+				}
+			}
+		`, randomID, testOrganization, "terraform-template-module")
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_repository.internal", "visibility",
+				"internal",
+			),
+			resource.TestCheckResourceAttr(
+				"github_repository.internal", "internal",
+				"true",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+
 	t.Run("sets private visibility for repositories created by a template", func(t *testing.T) {
 
 		config := fmt.Sprintf(`

--- a/github/util_v4_repository.go
+++ b/github/util_v4_repository.go
@@ -8,7 +8,7 @@ import (
 	"github.com/shurcooL/githubv4"
 )
 
-func getRepositoryID(name string, meta interface{}) (githubv4.ID, error) {
+func getRepositoryIDForOwner(name string, owner string, meta interface{}) (githubv4.ID, error) {
 
 	// Interpret `name` as a node ID
 	exists, nodeIDerr := repositoryNodeIDExists(name, meta)
@@ -29,7 +29,7 @@ func getRepositoryID(name string, meta interface{}) (githubv4.ID, error) {
 		} `graphql:"repository(owner:$owner, name:$name)"`
 	}
 	variables := map[string]interface{}{
-		"owner": githubv4.String(meta.(*Owner).name),
+		"owner": githubv4.String(owner),
 		"name":  githubv4.String(name),
 	}
 	ctx := context.Background()
@@ -44,6 +44,10 @@ func getRepositoryID(name string, meta interface{}) (githubv4.ID, error) {
 	}
 
 	return query.Repository.ID, nil
+}
+
+func getRepositoryID(name string, meta interface{}) (githubv4.ID, error) {
+	return getRepositoryIDForOwner(name, meta.(*Owner).name, meta)
 }
 
 func repositoryNodeIDExists(name string, meta interface{}) (bool, error) {

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -19,7 +19,7 @@ resource "github_repository" "example" {
   name        = "example"
   description = "My awesome codebase"
 
-  visibility = "public"
+  visibility = "internal"
 
   template {
     owner                = "github"


### PR DESCRIPTION

Previously, when creating a repository from a template, it sets the visibility to either `Public` or `Private` and then edits the repo settings later to ensure the visibility is correct. Now it sets the `Visibility` parameter instead.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #925

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* See #2151

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* See #2151

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [x] No

----

