### PR TITLE
feat: allow filtering on permission in repo collaborator datasource

### DIFF
--- a/github/data_source_github_collaborators.go
+++ b/github/data_source_github_collaborators.go
@@ -138,11 +138,11 @@ func dataSourceGithubCollaboratorsRead(d *schema.ResourceData, meta interface{})
 		},
 	}
 
-	permissionIdString := permission
-	if len(permissionIdString) == 0 {
-		permissionIdString = "any"
+	if len(permission) == 0 {
+		d.SetId(fmt.Sprintf("%s/%s/%s", owner, repo, affiliation))
+	} else {
+		d.SetId(fmt.Sprintf("%s/%s/%s/%s", owner, repo, affiliation, permission))
 	}
-	d.SetId(fmt.Sprintf("%s/%s/%s/%s", owner, repo, affiliation, permissionIdString))
 	err := d.Set("owner", owner)
 	if err != nil {
 		return err

--- a/github/data_source_github_collaborators_test.go
+++ b/github/data_source_github_collaborators_test.go
@@ -33,6 +33,32 @@ func TestAccGithubCollaboratorsDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccGithubCollaboratorsDataSource_withPermission(t *testing.T) {
+	if err := testAccCheckOrganization(); err != nil {
+		t.Skipf("Skipping because %s.", err.Error())
+	}
+
+	dsn := "data.github_collaborators.test"
+	repoName := fmt.Sprintf("tf-acc-test-collab-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckGithubCollaboratorsDataSourcePermissionConfig(repoName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dsn, "collaborator.#"),
+					resource.TestCheckResourceAttr(dsn, "affiliation", "all"),
+					resource.TestCheckResourceAttr(dsn, "permission", "admin"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckGithubCollaboratorsDataSourceConfig(repo string) string {
 	return fmt.Sprintf(`
 resource "github_repository" "test" {
@@ -42,6 +68,19 @@ resource "github_repository" "test" {
 data "github_collaborators" "test" {
   owner      = "%s"
   repository = "${github_repository.test.name}"
+}
+`, repo, testOwner)
+}
+func testAccCheckGithubCollaboratorsDataSourcePermissionConfig(repo string) string {
+	return fmt.Sprintf(`
+resource "github_repository" "test" {
+  name = "%s"
+}
+
+data "github_collaborators" "test" {
+  owner      = "%s"
+  repository = "${github_repository.test.name}"
+  permission = "admin"
 }
 `, repo, testOwner)
 }

--- a/website/docs/d/collaborators.html.markdown
+++ b/website/docs/d/collaborators.html.markdown
@@ -26,6 +26,8 @@ data "github_collaborators" "test" {
 
  * `affiliation` - (Optional) Filter collaborators returned by their affiliation. Can be one of: `outside`, `direct`, `all`.  Defaults to `all`.
 
+ * `permission` - (Optional) Filter collaborators returned by their permission. Can be one of: `pull`, `triage`, `push`, `maintain`, `admin`.  Defaults to not doing any filtering on permission.
+
 ## Attributes Reference
 
  * `collaborator` - An Array of GitHub collaborators.  Each `collaborator` block consists of the fields documented below.


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2381

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* It was not possible to filter on `permission` for the [`github_collaborators`](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/collaborators) datasource before this change

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* It is now possible to filter on `permission` for the [`github_collaborators`](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/collaborators) datasource

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No
    - Worth noting is that I've changed the internal ID of the datasource to include the new `permission` argument if it is set [here](https://github.com/integrations/terraform-provider-github/pull/2382/files#diff-a177fd7eae43548088cdfa3133f154ec7fa07d4c2ed8786f7eaf01d9aa39ec63L127-R145). I don't think this counts as a breaking change since the ID only changes if the ID is the `permission` is actually set. Omitting it will default to the same ID as before this change
----

