### PR TITLE
Fix: Graceful handling of 404 errors in github_emu_group_mapping resource

### DIFF
--- a/github/resource_github_emu_group_mapping.go
+++ b/github/resource_github_emu_group_mapping.go
@@ -85,6 +85,11 @@ func resourceGithubEMUGroupMappingRead(d *schema.ResourceData, meta interface{})
 
 	group, resp, err := client.Teams.GetExternalGroup(ctx, orgName, id64)
 	if err != nil {
+		if resp != nil && resp.StatusCode == 404 {
+			// If the group is not found, remove it from state
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2384

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->
* The resourceGithubEMUGroupMappingRead function was not handling 404 errors correctly when an EMU external group ID was deleted outside of Terraform. This caused Terraform to fail with an error instead of gracefully removing the resource from the state.

```hcl
Terraform planned the following actions, but then encountered a problem:

  # module.teams.github_team.this["testusers"] will be destroyed
  # (because key ["testusers"] is not in for_each map)
  - resource "github_team" "this" {
      - create_default_maintainer = false -> null
      - description               = "Updated: 2024-09-10T20:04:15Z" -> null
      - id                        = "12345678" -> null
      - members_count             = 5 -> null
      - name                      = "testusers" -> null
      - node_id                   = "T_XXXXXXXXXXXXX" -> null
      - privacy                   = "closed" -> null
      - slug                      = "testusers" -> null
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 0 to change, 1 to destroy.

╷
│ Error: GET https://api.github.com/orgs/MY-EMU-ORG/external-group/123456: 404 Not Found []
│ 
│   with module.teams.github_emu_group_mapping.this["testusers"],
│   on modules/teams/main.tf line 15, in resource "github_emu_group_mapping" "this":
│   15: resource "github_emu_group_mapping" "this" {
```

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
* The resourceGithubEMUGroupMappingRead function now properly handles 404 errors by removing the resource from Terraform's state when the EMU external group id is not found.
* Added a check for 404 status code in the API response.
* If a 404 is encountered, the resource ID is set to an empty string, effectively removing it from Terraform's state.

```hcl
Terraform will perform the following actions:

  # module.teams.github_team.this["testusers"] will be destroyed
  # (because key ["testusers"] is not in for_each map)
  - resource "github_team" "this" {
      - create_default_maintainer = false -> null
      - description               = "Updated: 2024-09-12T01:04:25Z" -> null
      - id                        = "123456778" -> null
      - members_count             = 0 -> null
      - name                      = "testusers" -> null
      - node_id                   = "T_XXXXXXXXXXXX" -> null
      - privacy                   = "closed" -> null
      - slug                      = "testusers" -> null
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Changes to Outputs:
  ~ teams                                = {
      ~ github_emu_group_mapping = {
          - testusers           = {
              - group_id  = 123456
              - id        = "teams/testusers/external-groups"
              - team_slug = "testusers"
            }
            # (12 unchanged attributes hidden)
        }
      ~ github_teams             = {
          - testusers           = {
              - create_default_maintainer = false
              - description               = "Updated: 2024-09-12T01:04:25Z"
              - id                        = "12345678"
              - ldap_dn                   = ""
              - members_count             = 0
              - name                      = "testusers"
              - node_id                   = "T_XXXXXXXXXXXXXXX"
              - parent_team_id            = ""
              - parent_team_read_id       = ""
              - parent_team_read_slug     = ""
              - privacy                   = "closed"
              - slug                      = "testusers"
            }
            # (12 unchanged attributes hidden)
        }
      ~ idp_groups               = {
          - testusers           = {
              - group_id   = 123456
              - group_name = "TestUsers"
              - updated_at = "2024-09-12T01:04:25Z"
            }
            # (12 unchanged attributes hidden)
        }
    }
```
### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [X] No

----

