### PR TITLE
docs: make it clear in the docs that write_delay_ms affects graphql calls

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -116,7 +116,7 @@ The following arguments are supported in the `provider` block:
   * `installation_id` - (Required) This is the ID of the GitHub App installation. It can sourced from the `GITHUB_APP_INSTALLATION_ID` environment variable.
   * `pem_file` - (Required) This is the contents of the GitHub App private key PEM file. It can also be sourced from the `GITHUB_APP_PEM_FILE` environment variable and may use `\n` instead of actual new lines.
 
-* `write_delay_ms` - (Optional) The number of milliseconds to sleep in between write operations in order to satisfy the GitHub API rate limits. Defaults to 1000ms or 1 second if not provided.
+* `write_delay_ms` - (Optional) The number of milliseconds to sleep in between write operations in order to satisfy the GitHub API rate limits. Note that requests to the GraphQL API are implemented as ``POST`` requests under the hood, so this setting affects those calls as well. Defaults to 1000ms or 1 second if not provided.
 
 * `retry_delay_ms` - (Optional) Amount of time in milliseconds to sleep in between requests to GitHub API after an error response. Defaults to 1000ms or 1 second if not provided, the max_retries must be set to greater than zero.
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

While trying to make the [`github_organization` datasource](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/organization) faster I noticed that each call to the GraphQL API was heavily throttled, with the provider sleeping exactly 1s in between each call. Doing some digging I've come to the conclusion that the [`write_delay_ms`](https://registry.terraform.io/providers/integrations/github/latest/docs#write_delay_ms) setting in the provider is the cause, which I've also confirmed by simply changing its value and testing. After some digging it turns out that [GraphQL API:s usually use `POST` requests under the hood](https://stackoverflow.com/a/59167159). The [GitHub GraphQL client is no different](https://github.com/shurcooL/graphql/blob/ed46e5a4646634fc16cb07c3b8db389542cc8847/graphql.go#L67).

There probably is a case to be made for separating the settings for the REST and CodeQL API:s, as they are currently both using the value from `write_delay_ms`. I'll leave that as future work though, as [both of these are using the same HTTP client under the hood](https://github.com/integrations/terraform-provider-github/blob/2c5b3af1c4376e01f83cd816c1136bfbf0aa9b81/github/config.go#L143-L158), and I have no idea if breaking that apart could have some unforeseen consequences. Documenting the behavior is a step forward at least!

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* No change in functionality, only docs

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* No change in functionality, only docs

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [X] No

----

