### PR TITLE
fix: Ignore changes to attributes

### DIFF
--- a/github/resource_github_repository_file.go
+++ b/github/resource_github_repository_file.go
@@ -122,24 +122,27 @@ func resourceGithubRepositoryFile() *schema.Resource {
 				Default:     false,
 			},
 			"autocreate_branch": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Automatically create the branch if it could not be found. Subsequent reads if the branch is deleted will occur from 'autocreate_branch_source_branch'",
-				Default:     false,
+				Type:             schema.TypeBool,
+				Optional:         true,
+				Description:      "Automatically create the branch if it could not be found. Subsequent reads if the branch is deleted will occur from 'autocreate_branch_source_branch'",
+				Default:          false,
+				DiffSuppressFunc: autoBranchDiffSuppressFunc,
 			},
 			"autocreate_branch_source_branch": {
-				Type:         schema.TypeString,
-				Default:      "main",
-				Optional:     true,
-				Description:  "The branch name to start from, if 'autocreate_branch' is set. Defaults to 'main'.",
-				RequiredWith: []string{"autocreate_branch"},
+				Type:             schema.TypeString,
+				Default:          "main",
+				Optional:         true,
+				Description:      "The branch name to start from, if 'autocreate_branch' is set. Defaults to 'main'.",
+				RequiredWith:     []string{"autocreate_branch"},
+				DiffSuppressFunc: autoBranchDiffSuppressFunc,
 			},
 			"autocreate_branch_source_sha": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				Description:  "The commit hash to start from, if 'autocreate_branch' is set. Defaults to the tip of 'autocreate_branch_source_branch'. If provided, 'autocreate_branch_source_branch' is ignored.",
-				RequiredWith: []string{"autocreate_branch"},
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				Description:      "The commit hash to start from, if 'autocreate_branch' is set. Defaults to the tip of 'autocreate_branch_source_branch'. If provided, 'autocreate_branch_source_branch' is ignored.",
+				RequiredWith:     []string{"autocreate_branch"},
+				DiffSuppressFunc: autoBranchDiffSuppressFunc,
 			},
 		},
 	}
@@ -506,4 +509,14 @@ func resourceGithubRepositoryFileDelete(d *schema.ResourceData, meta interface{}
 	}
 
 	return nil
+}
+
+func autoBranchDiffSuppressFunc(k, _, _ string, d *schema.ResourceData) bool {
+	if !d.Get("autocreate_branch").(bool) {
+		switch k {
+		case "autocreate_branch", "autocreate_branch_source_branch", "autocreate_branch_source_sha":
+			return true
+		}
+	}
+	return false
 }

--- a/github/resource_github_repository_file_test.go
+++ b/github/resource_github_repository_file_test.go
@@ -17,13 +17,13 @@ func TestAccGithubRepositoryFile(t *testing.T) {
 	t.Run("creates and manages files", func(t *testing.T) {
 
 		config := fmt.Sprintf(`
-
+	
 			resource "github_repository" "test" {
 				name                 = "tf-acc-test-%s"
 				auto_init            = true
 				vulnerability_alerts = true
 			}
-
+	
 			resource "github_repository_file" "test" {
 				repository     = github_repository.test.name
 				branch         = "main"
@@ -34,7 +34,6 @@ func TestAccGithubRepositoryFile(t *testing.T) {
 				commit_email   = "terraform@example.com"
 			}
 		`, randomID)
-
 		check := resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(
 				"github_repository_file.test", "content",
@@ -60,6 +59,9 @@ func TestAccGithubRepositoryFile(t *testing.T) {
 			resource.TestCheckResourceAttrSet(
 				"github_repository_file.test", "commit_sha",
 			),
+			resource.TestCheckNoResourceAttr("github_repository_file.test", "autocreate_branch"),
+			resource.TestCheckNoResourceAttr("github_repository_file.test", "autocreate_branch_source_branch"),
+			resource.TestCheckNoResourceAttr("github_repository_file.test", "autocreate_branch_source_sha"),
 		)
 
 		testCase := func(t *testing.T, mode string) {
@@ -132,6 +134,9 @@ func TestAccGithubRepositoryFile(t *testing.T) {
 			resource.TestCheckResourceAttrSet(
 				"github_repository_file.test", "commit_sha",
 			),
+			resource.TestCheckNoResourceAttr("github_repository_file.test", "autocreate_branch"),
+			resource.TestCheckNoResourceAttr("github_repository_file.test", "autocreate_branch_source_branch"),
+			resource.TestCheckNoResourceAttr("github_repository_file.test", "autocreate_branch_source_sha"),
 		)
 
 		testCase := func(t *testing.T, mode string) {
@@ -224,6 +229,9 @@ func TestAccGithubRepositoryFile(t *testing.T) {
 			resource.TestCheckResourceAttrSet(
 				"github_repository_file.test", "commit_sha",
 			),
+			resource.TestCheckNoResourceAttr("github_repository_file.test", "autocreate_branch"),
+			resource.TestCheckNoResourceAttr("github_repository_file.test", "autocreate_branch_source_branch"),
+			resource.TestCheckNoResourceAttr("github_repository_file.test", "autocreate_branch_source_sha"),
 		)
 
 		testCase := func(t *testing.T, mode string) {
@@ -261,7 +269,7 @@ func TestAccGithubRepositoryFile(t *testing.T) {
 				auto_init            = true
 				vulnerability_alerts = true
 			}
-
+	
 			resource "github_repository_file" "test" {
 				repository        = github_repository.test.name
 				branch            = "does/not/exist"
@@ -299,6 +307,9 @@ func TestAccGithubRepositoryFile(t *testing.T) {
 			resource.TestCheckResourceAttrSet(
 				"github_repository_file.test", "commit_sha",
 			),
+			resource.TestCheckResourceAttr("github_repository_file.test", "autocreate_branch", "true"),
+			resource.TestCheckResourceAttr("github_repository_file.test", "autocreate_branch_source_branch", "main"),
+			resource.TestCheckResourceAttrSet("github_repository_file.test", "autocreate_branch_source_sha"),
 		)
 
 		testCase := func(t *testing.T, mode string) {


### PR DESCRIPTION
When a `github_repository_file` resource was created with a provider version older than 6.3.0 the new attributes added in that version causes a new commit to be created when there should be no changes to the file.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2400 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

On an existing resource the github_repository_file is updated due to new attributes.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

On an existing resource the github_repository_file is note updated due to new attributes. 

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [] Yes
- [x] No

----

I have tested this against a resource created using the older provider version, then using this codebase built locally.
Output of test run

```
TF_ACC=1 go test -v ./... -run "^TestAccGithubRepositoryFile$"
?       github.com/integrations/terraform-provider-github/v6    [no test files]
=== RUN   TestAccGithubRepositoryFile
=== RUN   TestAccGithubRepositoryFile/creates_and_manages_files
=== RUN   TestAccGithubRepositoryFile/creates_and_manages_files/with_an_anonymous_account
    resource_github_repository_file_test.go:81: anonymous account not supported for this operation
=== RUN   TestAccGithubRepositoryFile/creates_and_manages_files/with_an_individual_account
=== RUN   TestAccGithubRepositoryFile/creates_and_manages_files/with_an_organization_account
=== RUN   TestAccGithubRepositoryFile/can_be_configured_to_overwrite_files_on_create
=== RUN   TestAccGithubRepositoryFile/can_be_configured_to_overwrite_files_on_create/with_an_anonymous_account
    resource_github_repository_file_test.go:162: anonymous account not supported for this operation
=== RUN   TestAccGithubRepositoryFile/can_be_configured_to_overwrite_files_on_create/with_an_individual_account
=== RUN   TestAccGithubRepositoryFile/can_be_configured_to_overwrite_files_on_create/with_an_organization_account
=== RUN   TestAccGithubRepositoryFile/creates_and_manages_files_on_default_branch_if_branch_is_omitted
=== RUN   TestAccGithubRepositoryFile/creates_and_manages_files_on_default_branch_if_branch_is_omitted/with_an_anonymous_account
    resource_github_repository_file_test.go:251: anonymous account not supported for this operation
=== RUN   TestAccGithubRepositoryFile/creates_and_manages_files_on_default_branch_if_branch_is_omitted/with_an_individual_account
=== RUN   TestAccGithubRepositoryFile/creates_and_manages_files_on_default_branch_if_branch_is_omitted/with_an_organization_account
=== RUN   TestAccGithubRepositoryFile/creates_and_manages_files_on_auto_created_branch_if_branch_does_not_exist
=== RUN   TestAccGithubRepositoryFile/creates_and_manages_files_on_auto_created_branch_if_branch_does_not_exist/with_an_anonymous_account
    resource_github_repository_file_test.go:335: anonymous account not supported for this operation
=== RUN   TestAccGithubRepositoryFile/creates_and_manages_files_on_auto_created_branch_if_branch_does_not_exist/with_an_individual_account
=== RUN   TestAccGithubRepositoryFile/creates_and_manages_files_on_auto_created_branch_if_branch_does_not_exist/with_an_organization_account
--- PASS: TestAccGithubRepositoryFile (131.83s)
    --- PASS: TestAccGithubRepositoryFile/creates_and_manages_files (27.28s)
        --- SKIP: TestAccGithubRepositoryFile/creates_and_manages_files/with_an_anonymous_account (0.00s)
        --- PASS: TestAccGithubRepositoryFile/creates_and_manages_files/with_an_individual_account (13.75s)
        --- PASS: TestAccGithubRepositoryFile/creates_and_manages_files/with_an_organization_account (13.53s)
    --- PASS: TestAccGithubRepositoryFile/can_be_configured_to_overwrite_files_on_create (31.28s)
        --- SKIP: TestAccGithubRepositoryFile/can_be_configured_to_overwrite_files_on_create/with_an_anonymous_account (0.00s)
        --- PASS: TestAccGithubRepositoryFile/can_be_configured_to_overwrite_files_on_create/with_an_individual_account (15.87s)
        --- PASS: TestAccGithubRepositoryFile/can_be_configured_to_overwrite_files_on_create/with_an_organization_account (15.41s)
    --- PASS: TestAccGithubRepositoryFile/creates_and_manages_files_on_default_branch_if_branch_is_omitted (39.36s)
        --- SKIP: TestAccGithubRepositoryFile/creates_and_manages_files_on_default_branch_if_branch_is_omitted/with_an_anonymous_account (0.00s)
        --- PASS: TestAccGithubRepositoryFile/creates_and_manages_files_on_default_branch_if_branch_is_omitted/with_an_individual_account (19.96s)
        --- PASS: TestAccGithubRepositoryFile/creates_and_manages_files_on_default_branch_if_branch_is_omitted/with_an_organization_account (19.40s)
    --- PASS: TestAccGithubRepositoryFile/creates_and_manages_files_on_auto_created_branch_if_branch_does_not_exist (33.91s)
        --- SKIP: TestAccGithubRepositoryFile/creates_and_manages_files_on_auto_created_branch_if_branch_does_not_exist/with_an_anonymous_account (0.00s)
        --- PASS: TestAccGithubRepositoryFile/creates_and_manages_files_on_auto_created_branch_if_branch_does_not_exist/with_an_individual_account (16.75s)
        --- PASS: TestAccGithubRepositoryFile/creates_and_manages_files_on_auto_created_branch_if_branch_does_not_exist/with_an_organization_account (17.16s)
PASS
ok      github.com/integrations/terraform-provider-github/v6/github     132.904s
```
