### PR TITLE
feat: Add file path protection to rulesets

### DIFF
--- a/github/resource_github_repository_ruleset.go
+++ b/github/resource_github_repository_ruleset.go
@@ -409,6 +409,24 @@ func resourceGithubRepositoryRuleset() *schema.Resource {
 								},
 							},
 						},
+						"file_path_restriction": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							MaxItems:    1,
+							Description: "Prevent commits that include changes in specified file paths from being pushed to the commit graph.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"restricted_file_paths": {
+										Type:        schema.TypeList,
+										Required:    true,
+										Description: "The file paths that are restricted from being pushed to the commit graph.",
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/website/docs/r/repository_ruleset.html.markdown
+++ b/website/docs/r/repository_ruleset.html.markdown
@@ -101,6 +101,8 @@ The `rules` block supports the following:
 
 * `tag_name_pattern` - (Optional) (Block List, Max: 1) Parameters to be used for the tag_name_pattern rule. This rule only applies to repositories within an enterprise, it cannot be applied to repositories owned by individuals or regular organizations. Conflicts with `branch_name_pattern` as it only applied to rulesets with target `tag`. (see [below for nested schema](#rules.tag_name_pattern))
 
+* `file_path_restriction` -(Optional) (Block List, Max 1) Parameters to be used for the file_path_restriction rule. When enabled restricts access to files within the repository. (See [Below for nested schema](#rules.file_path_restriction))
+
 * `update` - (Optional) (Boolean) Only allow users with bypass permission to update matching refs.
   
 * `update_allows_fetch_and_merge` - (Optional) (Boolean) Branch can pull changes from its upstream repository. This is only applicable to forked repositories. Requires `update` to be set to `true`. Note: behaviour is affected by a known bug on the GitHub side which may cause issues when using this parameter.
@@ -191,6 +193,10 @@ The `rules` block supports the following:
 
 * `negate` - (Optional) (Boolean) If true, the rule will fail if the pattern matches.
 
+
+#### rules.file_path_restriction ####
+
+* `restricted_file_paths` - (Required) (String) The file paths that are restricted from being pushed to the commit graph.
 
 
 #### bypass_actors ####


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2371 

----

I have not been able to add tests as this feature is only available with paid plans. I will look to add tests that can be run when under an Enterprise when I am back in the office and have access to do this. Here is the [doc](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets) that shows the push type rules are restricted.

<img width="677" alt="image" src="https://github.com/user-attachments/assets/ea62d291-003e-4730-828a-9e9c89eaf0c4">


### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Rules could not be added to rulesets to protect pushes to specific files

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* rules can now be added to rulesets to prevent pushes to named files

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

