### PR TITLE
Fix `github_external_groups` doc title 

### DIFF
--- a/website/docs/d/external_groups.html.markdown
+++ b/website/docs/d/external_groups.html.markdown
@@ -5,7 +5,7 @@ description: |-
   Retrieve external groups belonging to an organization.
 ---
 
-# github\_external\_group
+# github\_external\_groups
 
 Use this data source to retrieve external groups belonging to an organization.
 


### PR DESCRIPTION
This pull request includes a small change to the `website/docs/d/external_groups.html.markdown` file. The change corrects the header to match with the correct data resource
https://github.com/integrations/terraform-provider-github/blob/4cb547429acbcd948b8313ad10bf070c1d9e50d8/github/provider.go#L228

* [`website/docs/d/external_groups.html.markdown`](diffhunk://#diff-dab427574c6b95f745f8208ffbca2e6940a2f0a7b8d27d68fb283b1a9470c12eL8-R8): Corrected the header from `github_external_group` to `github_external_groups` to match the content description.

Error in terraform
![image](https://github.com/user-attachments/assets/2aa9a509-803a-4fd9-afc2-d40ce324fafd)

In docs:
![image](https://github.com/user-attachments/assets/32767bf5-606c-4b7e-b09f-fff984eea55b)
