### PR TITLE
Fixed renaming if the branch names are identical

### DIFF
--- a/github/resource_github_branch_default.go
+++ b/github/resource_github_branch_default.go
@@ -148,13 +148,10 @@ func resourceGithubBranchDefaultUpdate(d *schema.ResourceData, meta interface{})
 			return err
 		}
 
-		// We don't want to rename branch if its already the default branch
-		if defaultBranch == *repository.DefaultBranch {
-			return nil
-		}
-
-		if _, _, err := client.Repositories.RenameBranch(ctx, owner, repoName, *repository.DefaultBranch, defaultBranch); err != nil {
-			return err
+		if defaultBranch != *repository.DefaultBranch {
+			if _, _, err := client.Repositories.RenameBranch(ctx, owner, repoName, *repository.DefaultBranch, defaultBranch); err != nil {
+				return err
+			}
 		}
 	} else {
 		repository := &github.Repository{

--- a/github/resource_github_branch_default.go
+++ b/github/resource_github_branch_default.go
@@ -147,6 +147,12 @@ func resourceGithubBranchDefaultUpdate(d *schema.ResourceData, meta interface{})
 		if err != nil {
 			return err
 		}
+
+		// We don't want to rename branch if its already the default branch
+		if defaultBranch == *repository.DefaultBranch {
+			return nil
+		}
+
 		if _, _, err := client.Repositories.RenameBranch(ctx, owner, repoName, *repository.DefaultBranch, defaultBranch); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #1904

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

Applying a default branch rule on a repository that already has a default branch with the same name returns a http error 422 causing the `tf apply` to fail. This is because we call the `RenameBranch` api trying to rename `main` to `main`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

We validate that the branch being renamed is different from the current default before we try and rename it

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

