### PR TITLE
Archive flag doc update

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -238,7 +238,7 @@ func resourceGithubRepository() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				Description: "Specifies if the repository should be archived. `false` will unarchive a previously archived repository. Defaults to 'false'." 
+				Description: "Specifies if the repository should be archived. 'false' will unarchive a previously archived repository. Defaults to 'false'." 
 			},
 			"archive_on_destroy": {
 				Type:        schema.TypeBool,

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -238,7 +238,7 @@ func resourceGithubRepository() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				Description: "Specifies if the repository should be archived. Defaults to 'false'. NOTE Currently, the API does not support unarchiving.",
+				Description: "Specifies if the repository should be archived. `false` will unarchive a previously archived repository. Defaults to 'false'." 
 			},
 			"archive_on_destroy": {
 				Type:        schema.TypeBool,


### PR DESCRIPTION
Unarchiving is now supported by the github API. https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#update-a-repository

So the previous note about unarchiving is not true anymore


