### PR TITLE
[Feature] add environment secret import

### DIFF
--- a/github/resource_github_actions_environment_secret.go
+++ b/github/resource_github_actions_environment_secret.go
@@ -20,7 +20,7 @@ func resourceGithubActionsEnvironmentSecret() *schema.Resource {
 		Read:   resourceGithubActionsEnvironmentSecretRead,
 		Delete: resourceGithubActionsEnvironmentSecretDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceGithubActionsSecretImport,
+			State: resourceGithubActionsEnvironmentSecretImport,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/github/resource_github_actions_environment_secret.go
+++ b/github/resource_github_actions_environment_secret.go
@@ -3,9 +3,11 @@ package github
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/google/go-github/v65/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -17,6 +19,9 @@ func resourceGithubActionsEnvironmentSecret() *schema.Resource {
 		Create: resourceGithubActionsEnvironmentSecretCreateOrUpdate,
 		Read:   resourceGithubActionsEnvironmentSecretRead,
 		Delete: resourceGithubActionsEnvironmentSecretDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceGithubActionsSecretImport,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"repository": {
@@ -209,6 +214,42 @@ func resourceGithubActionsEnvironmentSecretDelete(d *schema.ResourceData, meta i
 	_, err = client.Actions.DeleteEnvSecret(ctx, int(repo.GetID()), escapedEnvName, secretName)
 
 	return err
+}
+
+func resourceGithubActionsEnvironmentSecretImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
+	ctx := context.Background()
+
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid ID specified: supplied ID must be written as <repository>/<environment>/<secret_name>")
+	}
+
+	d.SetId(buildThreePartID(parts[0], parts[1], parts[2]))
+
+	repoName, envName, secretName, err := parseThreePartID(d.Id(), "repository", "environment", "secret_name")
+	if err != nil {
+		return nil, err
+	}
+
+	repo, _, err := client.Repositories.Get(ctx, owner, repoName)
+
+	secret, _, err := client.Actions.GetEnvSecret(ctx, int(repo.GetID()), escapedEnvName, secretName)
+	if err != nil {
+		return nil, err
+	}
+
+	d.Set("repository", repoName)
+	d.Set("secret_name", secretName)
+	d.Set("environment", envName)
+
+	// encrypted_value or plaintext_value can not be imported
+
+	d.Set("created_at", secret.CreatedAt.String())
+	d.Set("updated_at", secret.UpdatedAt.String())
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func getEnvironmentPublicKeyDetails(repoID int64, envName string, meta interface{}) (keyId, pkValue string, err error) {

--- a/website/docs/r/actions_environment_secret.html.markdown
+++ b/website/docs/r/actions_environment_secret.html.markdown
@@ -57,18 +57,24 @@ resource "github_actions_environment_secret" "test_secret" {
 
 The following arguments are supported:
 
-
-* `repository`              - (Required) Name of the repository.
-* `environment`             - (Required) Name of the environment.
-* `secret_name`             - (Required) Name of the secret.
-* `encrypted_value`         - (Optional) Encrypted value of the secret using the GitHub public key in Base64 format.
-* `plaintext_value`         - (Optional) Plaintext value of the secret to be encrypted.
+- `repository` - (Required) Name of the repository.
+- `environment` - (Required) Name of the environment.
+- `secret_name` - (Required) Name of the secret.
+- `encrypted_value` - (Optional) Encrypted value of the secret using the GitHub public key in Base64 format.
+- `plaintext_value` - (Optional) Plaintext value of the secret to be encrypted.
 
 ## Attributes Reference
 
-* `created_at`      - Date of actions_environment_secret creation.
-* `updated_at`      - Date of actions_environment_secret update.
+- `created_at` - Date of actions_environment_secret creation.
+- `updated_at` - Date of actions_environment_secret update.
 
 ## Import
 
-This resource does not support importing. If you'd like to help contribute it, please visit our [GitHub page](https://github.com/integrations/terraform-provider-github)!
+This resource can be imported using an ID made up of the `repository`, `environment` and `secret_name`:
+
+```
+$ terraform import github_actions_secret.example_secret <repository>/<environment>/<secret_name>
+```
+
+NOTE: the implementation is limited in that it won't fetch the value of the
+`plaintext_value` or `encrypted_value` fields when importing. You may need to ignore changes for these as a workaround.


### PR DESCRIPTION
Resolves #2461 

----

### Before the change?
After I run an import command

```
Error: Configuration for import target does not exist

The configuration for the given import <module>.github_actions_environment_secret.<name> <repository>/<environment>/<secret_name> does not exist. All target instances must have an associated configuration to be imported.
```

* 

### After the change?
I should be able to run:
 ```
Terraform import '<module>.github_actions_environment_secret.<name> <repository>/<environment>/<secret_name>'
```
 or use and import block
```tf
import {
    to = <module>.github_actions_environment_secret.<name> <repository>/<environment>/<secret_name>
    id = "<repository>/<environment>/<secret_name>"
}
```

* 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
No

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

