### PR TITLE
Return the error when deleting a file

### DIFF
--- a/github/resource_github_repository_file.go
+++ b/github/resource_github_repository_file.go
@@ -504,11 +504,7 @@ func resourceGithubRepositoryFileDelete(d *schema.ResourceData, meta interface{}
 	}
 
 	_, _, err := client.Repositories.DeleteFile(ctx, owner, repo, file, opts)
-	if err != nil {
-		return nil
-	}
-
-	return nil
+	return err
 }
 
 func autoBranchDiffSuppressFunc(k, _, _ string, d *schema.ResourceData) bool {


### PR DESCRIPTION
There is currently an issue when destroying the github_repository_file resource. If the action fails because of permissions, or because there is a protected branch, or any of the above, the error gets silenced.


Resolves #2464

----

### Before the change?

* Delete a github_repository_file would be successful even if the API call failed. 

### After the change?

* A failed API call will not mark the apply as being successful 


### Does this introduce a breaking change?

- [x] No (unless people are expecting that bad behavior). 
