### PR TITLE
Adds remove_team_request option to team settings

### DIFF
--- a/github/resource_github_team_settings.go
+++ b/github/resource_github_team_settings.go
@@ -83,6 +83,12 @@ func resourceGithubTeamSettings() *schema.Resource {
 							Default:     false,
 							Description: "whether to notify the entire team when at least one member is also assigned to the pull request.",
 						},
+						"remove_team_request": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     true,
+							Description: "whether to remove the team request when a member is assigned to the pull request.",
+						},
 					},
 				},
 			},
@@ -180,11 +186,12 @@ func resourceGithubTeamSettingsUpdate(d *schema.ResourceData, meta interface{}) 
 			}
 
 			return graphql.Mutate(ctx, &mutation, UpdateTeamReviewAssignmentInput{
-				TeamID:                           d.Id(),
-				ReviewRequestDelegation:          true,
-				ReviewRequestDelegationAlgorithm: settings["algorithm"].(string),
-				ReviewRequestDelegationCount:     settings["member_count"].(int),
-				ReviewRequestDelegationNotifyAll: settings["notify"].(bool),
+				TeamID:                             d.Id(),
+				ReviewRequestDelegation:            true,
+				ReviewRequestDelegationAlgorithm:   settings["algorithm"].(string),
+				ReviewRequestDelegationCount:       settings["member_count"].(int),
+				ReviewRequestDelegationNotifyAll:   settings["notify"].(bool),
+				ReviewRequestDelegationTeamRequest: settings["remove_team_request"].(bool),
 			}, nil)
 		}
 	}
@@ -256,21 +263,23 @@ func resolveTeamIDs(idOrSlug string, meta *Owner, ctx context.Context) (nodeId s
 }
 
 type UpdateTeamReviewAssignmentInput struct {
-	ClientMutationID                 string `json:"clientMutationId,omitempty"`
-	TeamID                           string `graphql:"id" json:"id"`
-	ReviewRequestDelegation          bool   `graphql:"enabled" json:"enabled"`
-	ReviewRequestDelegationAlgorithm string `graphql:"algorithm" json:"algorithm"`
-	ReviewRequestDelegationCount     int    `graphql:"teamMemberCount" json:"teamMemberCount"`
-	ReviewRequestDelegationNotifyAll bool   `graphql:"notifyTeam" json:"notifyTeam"`
+	ClientMutationID                   string `json:"clientMutationId,omitempty"`
+	TeamID                             string `graphql:"id" json:"id"`
+	ReviewRequestDelegation            bool   `graphql:"enabled" json:"enabled"`
+	ReviewRequestDelegationAlgorithm   string `graphql:"algorithm" json:"algorithm"`
+	ReviewRequestDelegationCount       int    `graphql:"teamMemberCount" json:"teamMemberCount"`
+	ReviewRequestDelegationNotifyAll   bool   `graphql:"notifyTeam" json:"notifyTeam"`
+	ReviewRequestDelegationTeamRequest bool   `graphql:"removeTeamRequest" json:"removeTeamRequest"`
 }
 
 func defaultTeamReviewAssignmentSettings(id string) UpdateTeamReviewAssignmentInput {
 	return UpdateTeamReviewAssignmentInput{
-		TeamID:                           id,
-		ReviewRequestDelegation:          false,
-		ReviewRequestDelegationAlgorithm: "ROUND_ROBIN",
-		ReviewRequestDelegationCount:     1,
-		ReviewRequestDelegationNotifyAll: true,
+		TeamID:                             id,
+		ReviewRequestDelegation:            false,
+		ReviewRequestDelegationAlgorithm:   "ROUND_ROBIN",
+		ReviewRequestDelegationCount:       1,
+		ReviewRequestDelegationNotifyAll:   true,
+		ReviewRequestDelegationTeamRequest: true,
 	}
 }
 

--- a/github/resource_github_team_settings_test.go
+++ b/github/resource_github_team_settings_test.go
@@ -84,6 +84,7 @@ func TestCanUpdateTeamSettings(t *testing.T) {
 					algorithm = "ROUND_ROBIN"
 					member_count = 1
 					notify = true
+					remove_team_request = true
 				}
 			}
 		`, randomID)
@@ -111,6 +112,12 @@ func TestCanUpdateTeamSettings(t *testing.T) {
 				resource.TestCheckResourceAttr(
 					"github_team_settings.test", "review_request_delegation.0.notify",
 					"false",
+				),
+			),
+			"remove_team_request": resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr(
+					"github_team_settings.test", "review_request_delegation.0.remove_team_request",
+					"true",
 				),
 			),
 		}
@@ -141,6 +148,12 @@ func TestCanUpdateTeamSettings(t *testing.T) {
 							`notify = true`,
 							`notify = false`, 1),
 						Check: checks["notify"],
+					},
+					{
+						Config: strings.Replace(config,
+							`remove_team_request = false`,
+							`remove_team_request = true`, 1),
+						Check: checks["remove_team_request"],
 					},
 				},
 			})
@@ -180,6 +193,7 @@ func TestCannotUseReviewSettingsIfDisabled(t *testing.T) {
 					algorithm = "ROUND_ROBIN"
 					member_count = 1
 					notify = true
+					remove_team_request = true
 				}
 			}
 		`, randomID)

--- a/website/docs/r/team_settings.html.markdown
+++ b/website/docs/r/team_settings.html.markdown
@@ -48,6 +48,7 @@ The following arguments are supported:
 * `algorithm` - (Optional) The algorithm to use when assigning pull requests to team members. Supported values are `ROUND_ROBIN` and `LOAD_BALANCE`. Default value is `ROUND_ROBIN`
 * `member_count` - (Optional) The number of team members to assign to a pull request
 * `notify` - (Optional) whether to notify the entire team when at least one member is also assigned to the pull request
+* `remove_team_request` - (Optional) whether to remove the team request when a member is assigned to the pull request.
 
 
 ## Import


### PR DESCRIPTION
Introduces a new boolean option `remove_team_request` to the team settings schema. This option allows automatic removal of team requests when a member is assigned to a pull request. Updates related functions and tests to support this new option.

Enhances team review assignment functionality.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2479
----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* 

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

