### PR TITLE
feat: Updated repo collaborators to support ignoring teams

### DIFF
--- a/github/resource_github_repository_collaborators_test.go
+++ b/github/resource_github_repository_collaborators_test.go
@@ -14,17 +14,8 @@ import (
 )
 
 func TestAccGithubRepositoryCollaborators(t *testing.T) {
-
 	inOrgUser := os.Getenv("GITHUB_IN_ORG_USER")
 	inOrgUser2 := os.Getenv("GITHUB_IN_ORG_USER2")
-
-	if inOrgUser == "" || inOrgUser2 == "" {
-		t.Skip("set inOrgUser and inOrgUser2 to unskip this test run")
-	}
-
-	if inOrgUser == testOwnerFunc() || inOrgUser2 == testOwnerFunc() {
-		t.Skip("inOrgUser and inOrgUser2 can't be same as owner")
-	}
 
 	config := Config{BaseURL: "https://api.github.com/", Owner: testOwnerFunc(), Token: testToken}
 	meta, err := config.Meta()
@@ -32,12 +23,19 @@ func TestAccGithubRepositoryCollaborators(t *testing.T) {
 		t.Fatalf("failed to return meta without error: %s", err.Error())
 	}
 
-	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-
 	t.Run("creates collaborators without error", func(t *testing.T) {
+		if inOrgUser == "" {
+			t.Skip("set inOrgUser to unskip this test run")
+		}
 
+		if inOrgUser == testOwnerFunc() {
+			t.Skip("inOrgUser can't be same as owner")
+		}
+
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		conn := meta.(*Owner).v3client
 		repoName := fmt.Sprintf("tf-acc-test-%s", randomID)
+		teamName := fmt.Sprintf("tf-acc-test-team-%s", randomID)
 
 		individualConfig := fmt.Sprintf(`
 			resource "github_repository" "test" {
@@ -64,7 +62,7 @@ func TestAccGithubRepositoryCollaborators(t *testing.T) {
 			}
 
 			resource "github_team" "test" {
-				name = "test"
+				name = "%s"
 			}
 
 			resource "github_repository_collaborators" "test_repo_collaborators" {
@@ -79,7 +77,7 @@ func TestAccGithubRepositoryCollaborators(t *testing.T) {
 					permission = "pull"
 				}
 			}
-		`, repoName, inOrgUser)
+		`, repoName, teamName, inOrgUser)
 
 		testCase := func(t *testing.T, mode, config string, testCheck func(state *terraform.State) error) {
 			resource.Test(t, resource.TestCase{
@@ -192,9 +190,19 @@ func TestAccGithubRepositoryCollaborators(t *testing.T) {
 	})
 
 	t.Run("updates collaborators without error", func(t *testing.T) {
+		if inOrgUser == "" || inOrgUser2 == "" {
+			t.Skip("set inOrgUser and inOrgUser2 to unskip this test run")
+		}
 
+		if inOrgUser == testOwnerFunc() || inOrgUser2 == testOwnerFunc() {
+			t.Skip("inOrgUser or inOrgUser2 can't be same as owner")
+		}
+
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		conn := meta.(*Owner).v3client
 		repoName := fmt.Sprintf("tf-acc-test-%s", randomID)
+		team0Name := fmt.Sprintf("tf-acc-test-team-0-%s", randomID)
+		team1Name := fmt.Sprintf("tf-acc-test-team-1-%s", randomID)
 
 		individualConfig := fmt.Sprintf(`
 			resource "github_repository" "test" {
@@ -237,12 +245,12 @@ func TestAccGithubRepositoryCollaborators(t *testing.T) {
 				visibility = "private"
 			}
 
-			resource "github_team" "test" {
-				name = "test"
+			resource "github_team" "test_0" {
+				name = "%s"
 			}
 
-			resource "github_team" "test2" {
-				name = "test2"
+			resource "github_team" "test_1" {
+				name = "%s"
 			}
 
 			resource "github_repository_collaborators" "test_repo_collaborators" {
@@ -265,7 +273,7 @@ func TestAccGithubRepositoryCollaborators(t *testing.T) {
 					permission = "pull"
 				}
 			}
-		`, repoName, inOrgUser, inOrgUser2)
+		`, repoName, team0Name, team1Name, inOrgUser, inOrgUser2)
 
 		orgConfigUpdate := fmt.Sprintf(`
 			resource "github_repository" "test" {
@@ -274,12 +282,12 @@ func TestAccGithubRepositoryCollaborators(t *testing.T) {
 				visibility = "private"
 			}
 
-			resource "github_team" "test" {
-				name = "test"
+			resource "github_team" "test_0" {
+				name = "%s"
 			}
 
-			resource "github_team" "test2" {
-				name = "test2"
+			resource "github_team" "test_1" {
+				name = "%s"
 			}
 
 			resource "github_repository_collaborators" "test_repo_collaborators" {
@@ -290,11 +298,11 @@ func TestAccGithubRepositoryCollaborators(t *testing.T) {
 					permission = "push"
 				}
 				team {
-					team_id   = github_team.test.id
+					team_id   = github_team.test_0.id
 					permission = "push"
 				}
 			}
-		`, repoName, inOrgUser)
+		`, repoName, team0Name, team1Name, inOrgUser)
 
 		testCase := func(t *testing.T, mode, config, configUpdate string, testCheck func(state *terraform.State) error) {
 			resource.Test(t, resource.TestCase{
@@ -319,9 +327,7 @@ func TestAccGithubRepositoryCollaborators(t *testing.T) {
 		t.Run("with an individual account", func(t *testing.T) {
 			check := resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttrSet("github_repository_collaborators.test_repo_collaborators", "user.#"),
-				resource.TestCheckResourceAttrSet("github_repository_collaborators.test_repo_collaborators", "team.#"),
 				resource.TestCheckResourceAttr("github_repository_collaborators.test_repo_collaborators", "user.#", "1"),
-				resource.TestCheckResourceAttr("github_repository_collaborators.test_repo_collaborators", "team.#", "0"),
 				func(state *terraform.State) error {
 					owner := meta.(*Owner).name
 
@@ -364,7 +370,7 @@ func TestAccGithubRepositoryCollaborators(t *testing.T) {
 				func(state *terraform.State) error {
 					owner := testOrganizationFunc()
 
-					teamAttrs := state.RootModule().Resources["github_team.test"].Primary.Attributes
+					teamAttrs := state.RootModule().Resources["github_team.test_0"].Primary.Attributes
 					collaborators := state.RootModule().Resources["github_repository_collaborators.test_repo_collaborators"].Primary
 					for name, val := range collaborators.Attributes {
 						if strings.HasPrefix(name, "user.") && strings.HasSuffix(name, ".username") && val != inOrgUser {
@@ -411,9 +417,18 @@ func TestAccGithubRepositoryCollaborators(t *testing.T) {
 	})
 
 	t.Run("removes collaborators without error", func(t *testing.T) {
+		if inOrgUser == "" || inOrgUser2 == "" {
+			t.Skip("set inOrgUser and inOrgUser2 to unskip this test run")
+		}
 
+		if inOrgUser == testOwnerFunc() || inOrgUser2 == testOwnerFunc() {
+			t.Skip("inOrgUser or inOrgUser2 can't be same as owner")
+		}
+
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		conn := meta.(*Owner).v3client
 		repoName := fmt.Sprintf("tf-acc-test-%s", randomID)
+		teamName := fmt.Sprintf("tf-acc-test-team-%s", randomID)
 
 		individualConfig := fmt.Sprintf(`
 			resource "github_repository" "test" {
@@ -448,7 +463,7 @@ func TestAccGithubRepositoryCollaborators(t *testing.T) {
 			}
 
 			resource "github_team" "test" {
-				name = "test"
+				name = "%s"
 			}
 
 			resource "github_repository_collaborators" "test_repo_collaborators" {
@@ -467,7 +482,7 @@ func TestAccGithubRepositoryCollaborators(t *testing.T) {
 					permission = "pull"
 				}
 			}
-		`, repoName, inOrgUser, inOrgUser2)
+		`, repoName, teamName, inOrgUser, inOrgUser2)
 
 		orgConfigUpdate := fmt.Sprintf(`
 			resource "github_repository" "test" {
@@ -477,9 +492,9 @@ func TestAccGithubRepositoryCollaborators(t *testing.T) {
 			}
 
 			resource "github_team" "test" {
-				name = "test"
+				name = "%s"
 			}
-		`, repoName)
+		`, repoName, teamName)
 
 		testCase := func(t *testing.T, mode, config, configUpdate string, testCheck func(state *terraform.State) error) {
 			resource.Test(t, resource.TestCase{
@@ -542,6 +557,120 @@ func TestAccGithubRepositoryCollaborators(t *testing.T) {
 				},
 			)
 			testCase(t, organization, orgConfig, orgConfigUpdate, check)
+		})
+	})
+
+	t.Run("does not churn on team slug", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("tf-acc-test-%s", randomID)
+		team0Name := fmt.Sprintf("tf-acc-test-team-0-%s", randomID)
+		team1Name := fmt.Sprintf("tf-acc-test-team-1-%s", randomID)
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name = "%s"
+				auto_init = true
+				visibility = "private"
+			}
+
+			resource "github_team" "test_0" {
+				name = "%s"
+			}
+
+			resource "github_team" "test_1" {
+				name = "%s"
+			}
+
+			resource "github_repository_collaborators" "test_repo_collaborators" {
+				repository = "${github_repository.test.name}"
+
+				team {
+					team_id   = github_team.test_0.id
+					permission = "pull"
+				}
+
+				team {
+					team_id = github_team.test_1.name
+					permission = "pull"
+				}
+			}
+		`, repoName, team0Name, team1Name)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { skipUnlessMode(t, organization) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttrSet("github_repository_collaborators.test_repo_collaborators", "team.#"),
+						resource.TestCheckResourceAttr("github_repository_collaborators.test_repo_collaborators", "team.#", "2"),
+					),
+				},
+				{
+					Config:             config,
+					ExpectNonEmptyPlan: false,
+				},
+			},
+		})
+	})
+
+	t.Run("ignores specified teams", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("tf-acc-test-%s", randomID)
+		team0Name := fmt.Sprintf("tf-acc-test-team-0-%s", randomID)
+		team1Name := fmt.Sprintf("tf-acc-test-team-1-%s", randomID)
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name = "%s"
+				auto_init = true
+				visibility = "private"
+			}
+
+			resource "github_team" "test_0" {
+				name = "%s"
+			}
+
+			resource "github_team_repository" "some_team_repo" {
+				team_id    = github_team.test_0.id
+				repository = github_repository.test.name
+			}
+
+			resource "github_team" "test_1" {
+				name = "%s"
+			}
+
+			resource "github_repository_collaborators" "test_repo_collaborators" {
+				repository = "${github_repository.test.name}"
+
+				team {
+					team_id   = github_team.test_1.id
+					permission = "pull"
+				}
+
+				ignore_team {
+					team_id = github_team.test_0.id
+				}
+			}
+		`, repoName, team0Name, team1Name)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { skipUnlessMode(t, organization) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttrSet("github_repository_collaborators.test_repo_collaborators", "team.#"),
+						resource.TestCheckResourceAttr("github_repository_collaborators.test_repo_collaborators", "team.#", "1"),
+					),
+				},
+				{
+					Config:             config,
+					ExpectNonEmptyPlan: false,
+				},
+			},
 		})
 	})
 }

--- a/website/docs/r/repository_collaborators.html.markdown
+++ b/website/docs/r/repository_collaborators.html.markdown
@@ -14,10 +14,10 @@ github_team_repository or they will fight over what your policy should be.
 
 This resource allows you to manage all collaborators for repositories in your
 organization or personal account. For organization repositories, collaborators can
-have explicit (and differing levels of) read, write, or administrator access to 
-specific repositories, without giving the user full organization membership. 
+have explicit (and differing levels of) read, write, or administrator access to
+specific repositories, without giving the user full organization membership.
 For personal repositories, collaborators can only be granted write
-(implicitly includes read) permission. 
+(implicitly includes read) permission.
 
 When applied, an invitation will be sent to the user to become a collaborators
 on a repository. When destroyed, either the invitation will be cancelled or the
@@ -31,7 +31,7 @@ Further documentation on GitHub collaborators:
 - [Adding outside collaborators to your personal repositories](https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/managing-access-to-your-personal-repositories)
 - [Adding outside collaborators to repositories in your organization](https://help.github.com/articles/adding-outside-collaborators-to-repositories-in-your-organization/)
 - [Converting an organization member to an outside collaborators](https://help.github.com/articles/converting-an-organization-member-to-an-outside-collaborator/)
- 
+
 ## Example Usage
 
 ```hcl
@@ -52,7 +52,7 @@ resource "github_repository_collaborators" "some_repo_collaborators" {
     permission = "admin"
     username  = "SomeUser"
   }
-  
+
   team {
     permission = "pull"
     team_id = github_team.some_team.slug
@@ -64,9 +64,10 @@ resource "github_repository_collaborators" "some_repo_collaborators" {
 
 The following arguments are supported:
 
-* `repository` - (Required) The GitHub repository
-* `user` - (Optional) List of users
-* `team` - (Optional) List of teams
+* `repository` - (Required) The GitHub repository.
+* `user` - (Optional) List of users to grant access to the repository.
+* `team` - (Optional) List of teams to grant access to the repository.
+* `ignore_team` - (Optional) List of teams to ignore when checking for repository access. This supports ignoring teams granted access at an organizational level.
 
 The `user` block supports:
 
@@ -77,16 +78,20 @@ The `user` block supports:
 
 The `team` block supports:
 
-* `team_id` - (Required) The GitHub team id or the GitHub team slug
+* `team_id` - (Required) The GitHub team id or the GitHub team slug.
 * `permission` - (Optional) The permission of the outside collaborators for the repository.
   Must be one of `pull`, `triage`, `push`, `maintain`, `admin` or the name of an existing [custom repository role](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-peoples-access-to-your-organization-with-roles/managing-custom-repository-roles-for-an-organization) within the organisation. Defaults to `pull`.
   Must be `push` for personal repositories. Defaults to `push`.
+
+The `team_ignore` block supports:
+
+* `team_id` - (Required) The GitHub team id or the GitHub team slug.
 
 ## Attribute Reference
 
 In addition to the above arguments, the following attributes are exported:
 
-* `invitation_ids` - Map of usernames to invitation ID for any users added as part of creation of this resource to 
+* `invitation_ids` - Map of usernames to invitation ID for any users added as part of creation of this resource to
   be used in [`github_user_invitation_accepter`](./user_invitation_accepter.html).
 
 ## Import


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2470

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- Using a team slug for `github_repository_collaborators` would result in churn
- There is no way to manage repository collaborators for an organization that has organization roles defined without specifying these teams as part of the `github_repository_collaborators` resource (which works but is technically incorrect).

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Using a team slug for `github_repository_collaborators` does not churn
- You can use the `team_ignore` block on a `github_repository_collaborators` resource to ignore organization managed teams.    
  - Due to the lack of flag in the GitHub API this can't be cheaply powered by a `ignore_org_teams` resource flag, as that would take multiple API calls and an increase in required permissions.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

