### PR TITLE
feat: Add `github_organization_repositories` data source

### DIFF
--- a/github/data_source_github_organization_repositories.go
+++ b/github/data_source_github_organization_repositories.go
@@ -1,0 +1,77 @@
+package github
+
+import (
+	"github.com/google/go-github/v66/github"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceGithubOrganizationRepositories() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGithubOrganizationRepositoriesRead,
+		Schema: map[string]*schema.Schema{
+			"repositories": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"repo_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"node_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"archived": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"visibility": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGithubOrganizationRepositoriesRead(d *schema.ResourceData, meta interface{}) error {
+	org := meta.(*Owner).name
+	client3 := meta.(*Owner).v3client
+	ctx := meta.(*Owner).StopContext
+
+	options := github.RepositoryListByOrgOptions{
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+	var allRepositories []map[string]interface{}
+	for {
+		repositories, resp, err := client3.Repositories.ListByOrg(ctx, org, &options)
+		if err != nil {
+			return err
+		}
+		for _, repository := range repositories {
+			repo := make(map[string]interface{})
+			repo["repo_id"] = repository.GetID()
+			repo["node_id"] = repository.GetNodeID()
+			repo["name"] = repository.GetName()
+			repo["archived"] = repository.GetArchived()
+			repo["visibility"] = repository.GetVisibility()
+			allRepositories = append(allRepositories, repo)
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		options.Page = resp.NextPage
+	}
+
+	d.SetId(org)
+	d.Set("repositories", allRepositories)
+
+	return nil
+}

--- a/github/data_source_github_organization_repositories_test.go
+++ b/github/data_source_github_organization_repositories_test.go
@@ -1,0 +1,71 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccGithubOrganizationRepositoriesDataSource(t *testing.T) {
+	t.Run("manages repositories", func(t *testing.T) {
+		config := `
+			resource "github_repository" "test1" {
+			  name = "test1"
+			}
+
+			resource "github_repository" "test2" {
+			  name       = "test2"
+			  archived   = true
+			  depends_on = [github_repository.test1]
+			}
+		 `
+
+		config2 := config + `
+			data "github_organization_repositories" "all" {}
+		`
+
+		const resourceName = "data.github_organization_repositories.all"
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(resourceName, "webhooks.#", "2"),
+			resource.TestCheckResourceAttr(resourceName, "webhooks.0.name", "test1"),
+			resource.TestCheckResourceAttr(resourceName, "webhooks.0.archived", "false"),
+			resource.TestCheckResourceAttr(resourceName, "webhooks.0.visibility", "private"),
+			resource.TestCheckResourceAttrSet(resourceName, "webhooks.0.repo_id"),
+			resource.TestCheckResourceAttrSet(resourceName, "webhooks.0.node_id"),
+			resource.TestCheckResourceAttr(resourceName, "webhooks.1.name", "test2"),
+			resource.TestCheckResourceAttr(resourceName, "webhooks.1.archived", "true"),
+			resource.TestCheckResourceAttr(resourceName, "webhooks.1.visibility", "private"),
+			resource.TestCheckResourceAttrSet(resourceName, "webhooks.1.repo_id"),
+			resource.TestCheckResourceAttrSet(resourceName, "webhooks.1.node_id"),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  resource.ComposeTestCheckFunc(),
+					},
+					{
+						Config: config2,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+}

--- a/github/provider.go
+++ b/github/provider.go
@@ -232,6 +232,7 @@ func Provider() *schema.Provider {
 			"github_organization_custom_role":                                       dataSourceGithubOrganizationCustomRole(),
 			"github_organization_external_identities":                               dataSourceGithubOrganizationExternalIdentities(),
 			"github_organization_ip_allow_list":                                     dataSourceGithubOrganizationIpAllowList(),
+			"github_organization_repositories":                                      dataSourceGithubOrganizationRepositories(),
 			"github_organization_team_sync_groups":                                  dataSourceGithubOrganizationTeamSyncGroups(),
 			"github_organization_teams":                                             dataSourceGithubOrganizationTeams(),
 			"github_organization_webhooks":                                          dataSourceGithubOrganizationWebhooks(),

--- a/website/docs/d/organization_repositories.html.markdown
+++ b/website/docs/d/organization_repositories.html.markdown
@@ -1,0 +1,31 @@
+---
+layout: "github"
+page_title: "GitHub: github_organization_repositories"
+description: |-
+  Read details of all repositories of an organization.
+---
+
+# github\_organization\_repositories
+
+Use this data source to retrieve all repositories of the organization.
+
+## Example Usage
+
+To retrieve *all* repositories of the organization:
+
+```hcl
+data "github_organization_repositories" "all" {}
+```
+
+## Attributes Reference
+
+* `repository` - An Array of GitHub repositories.  Each `repository` block consists of the fields documented below.
+___
+
+The `repository` block consists of:
+
+ * `repo_id` - GitHub ID for the repository.
+ * `node_id` - The Node ID of the repository.
+ * `name` - The name of the repository.
+ * `archived` - Whether the repository is archived.
+ * `visibility` - Whether the repository is public, private or internal.


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2484 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

_see issue_

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* There exists a new `github_organization_repositories` data source providing details about all repositories in an organization
  - The set of details returned is kept small for now (both to gauge an understanding of whether this can make it into the provider and to not unnecessarily blow up the API from the get-go)

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

