### PR TITLE
Fixed incorrect secrets creation on externally updated secret

### DIFF
--- a/github/resource_github_actions_environment_secret.go
+++ b/github/resource_github_actions_environment_secret.go
@@ -154,41 +154,7 @@ func resourceGithubActionsEnvironmentSecretRead(d *schema.ResourceData, meta int
 		return err
 	}
 
-	if err = d.Set("encrypted_value", d.Get("encrypted_value")); err != nil {
-		return err
-	}
-	if err = d.Set("plaintext_value", d.Get("plaintext_value")); err != nil {
-		return err
-	}
-	if err = d.Set("created_at", secret.CreatedAt.String()); err != nil {
-		return err
-	}
-
-	// This is a drift detection mechanism based on timestamps.
-	//
-	// If we do not currently store the "updated_at" field, it means we've only
-	// just created the resource and the value is most likely what we want it to
-	// be.
-	//
-	// If the resource is changed externally in the meantime then reading back
-	// the last update timestamp will return a result different than the
-	// timestamp we've persisted in the state. In that case, we can no longer
-	// trust that the value (which we don't see) is equal to what we've declared
-	// previously.
-	//
-	// The only solution to enforce consistency between is to mark the resource
-	// as deleted (unset the ID) in order to fix potential drift by recreating
-	// the resource.
-	if updatedAt, ok := d.GetOk("updated_at"); ok && updatedAt != secret.UpdatedAt.String() {
-		log.Printf("[INFO] The environment secret %s has been externally updated in GitHub", d.Id())
-		d.SetId("")
-	} else if !ok {
-		if err = d.Set("updated_at", secret.UpdatedAt.String()); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return readMaybeDriftedSecret(d, secret)
 }
 
 func resourceGithubActionsEnvironmentSecretDelete(d *schema.ResourceData, meta interface{}) error {

--- a/github/resource_github_actions_secret.go
+++ b/github/resource_github_actions_secret.go
@@ -130,41 +130,7 @@ func resourceGithubActionsSecretRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	if err = d.Set("encrypted_value", d.Get("encrypted_value")); err != nil {
-		return err
-	}
-	if err = d.Set("plaintext_value", d.Get("plaintext_value")); err != nil {
-		return err
-	}
-	if err = d.Set("created_at", secret.CreatedAt.String()); err != nil {
-		return err
-	}
-
-	// This is a drift detection mechanism based on timestamps.
-	//
-	// If we do not currently store the "updated_at" field, it means we've only
-	// just created the resource and the value is most likely what we want it to
-	// be.
-	//
-	// If the resource is changed externally in the meantime then reading back
-	// the last update timestamp will return a result different than the
-	// timestamp we've persisted in the state. In that case, we can no longer
-	// trust that the value (which we don't see) is equal to what we've declared
-	// previously.
-	//
-	// The only solution to enforce consistency between is to mark the resource
-	// as deleted (unset the ID) in order to fix potential drift by recreating
-	// the resource.
-	if updatedAt, ok := d.GetOk("updated_at"); ok && updatedAt != secret.UpdatedAt.String() {
-		log.Printf("[INFO] The secret %s has been externally updated in GitHub", d.Id())
-		d.SetId("")
-	} else if !ok {
-		if err = d.Set("updated_at", secret.UpdatedAt.String()); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return readMaybeDriftedSecret(d, secret)
 }
 
 func resourceGithubActionsSecretDelete(d *schema.ResourceData, meta interface{}) error {

--- a/github/resource_github_codespaces_organization_secret.go
+++ b/github/resource_github_codespaces_organization_secret.go
@@ -159,15 +159,6 @@ func resourceGithubCodespacesOrganizationSecretRead(d *schema.ResourceData, meta
 		return err
 	}
 
-	if err = d.Set("encrypted_value", d.Get("encrypted_value")); err != nil {
-		return err
-	}
-	if err = d.Set("plaintext_value", d.Get("plaintext_value")); err != nil {
-		return err
-	}
-	if err = d.Set("created_at", secret.CreatedAt.String()); err != nil {
-		return err
-	}
 	if err = d.Set("visibility", secret.Visibility); err != nil {
 		return err
 	}
@@ -199,31 +190,7 @@ func resourceGithubCodespacesOrganizationSecretRead(d *schema.ResourceData, meta
 		return err
 	}
 
-	// This is a drift detection mechanism based on timestamps.
-	//
-	// If we do not currently store the "updated_at" field, it means we've only
-	// just created the resource and the value is most likely what we want it to
-	// be.
-	//
-	// If the resource is changed externally in the meantime then reading back
-	// the last update timestamp will return a result different than the
-	// timestamp we've persisted in the state. In that case, we can no longer
-	// trust that the value (which we don't see) is equal to what we've declared
-	// previously.
-	//
-	// The only solution to enforce consistency between is to mark the resource
-	// as deleted (unset the ID) in order to fix potential drift by recreating
-	// the resource.
-	if updatedAt, ok := d.GetOk("updated_at"); ok && updatedAt != secret.UpdatedAt.String() {
-		log.Printf("[WARN] The secret %s has been externally updated in GitHub", d.Id())
-		d.SetId("")
-	} else if !ok {
-		if err = d.Set("updated_at", secret.UpdatedAt.String()); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return readMaybeDriftedSecret(d, secret)
 }
 
 func resourceGithubCodespacesOrganizationSecretDelete(d *schema.ResourceData, meta interface{}) error {

--- a/github/resource_github_codespaces_secret.go
+++ b/github/resource_github_codespaces_secret.go
@@ -129,41 +129,7 @@ func resourceGithubCodespacesSecretRead(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	if err = d.Set("encrypted_value", d.Get("encrypted_value")); err != nil {
-		return err
-	}
-	if err = d.Set("plaintext_value", d.Get("plaintext_value")); err != nil {
-		return err
-	}
-	if err = d.Set("created_at", secret.CreatedAt.String()); err != nil {
-		return err
-	}
-
-	// This is a drift detection mechanism based on timestamps.
-	//
-	// If we do not currently store the "updated_at" field, it means we've only
-	// just created the resource and the value is most likely what we want it to
-	// be.
-	//
-	// If the resource is changed externally in the meantime then reading back
-	// the last update timestamp will return a result different than the
-	// timestamp we've persisted in the state. In that case, we can no longer
-	// trust that the value (which we don't see) is equal to what we've declared
-	// previously.
-	//
-	// The only solution to enforce consistency between is to mark the resource
-	// as deleted (unset the ID) in order to fix potential drift by recreating
-	// the resource.
-	if updatedAt, ok := d.GetOk("updated_at"); ok && updatedAt != secret.UpdatedAt.String() {
-		log.Printf("[WARN] The secret %s has been externally updated in GitHub", d.Id())
-		d.SetId("")
-	} else if !ok {
-		if err = d.Set("updated_at", secret.UpdatedAt.String()); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return readMaybeDriftedSecret(d, secret)
 }
 
 func resourceGithubCodespacesSecretDelete(d *schema.ResourceData, meta interface{}) error {

--- a/github/resource_github_codespaces_user_secret.go
+++ b/github/resource_github_codespaces_user_secret.go
@@ -143,16 +143,6 @@ func resourceGithubCodespacesUserSecretRead(d *schema.ResourceData, meta interfa
 		return err
 	}
 
-	if err = d.Set("encrypted_value", d.Get("encrypted_value")); err != nil {
-		return err
-	}
-	if err = d.Set("plaintext_value", d.Get("plaintext_value")); err != nil {
-		return err
-	}
-	if err = d.Set("created_at", secret.CreatedAt.String()); err != nil {
-		return err
-	}
-
 	selectedRepositoryIDs := []int64{}
 
 	opt := &github.ListOptions{
@@ -178,31 +168,7 @@ func resourceGithubCodespacesUserSecretRead(d *schema.ResourceData, meta interfa
 		return err
 	}
 
-	// This is a drift detection mechanism based on timestamps.
-	//
-	// If we do not currently store the "updated_at" field, it means we've only
-	// just created the resource and the value is most likely what we want it to
-	// be.
-	//
-	// If the resource is changed externally in the meantime then reading back
-	// the last update timestamp will return a result different than the
-	// timestamp we've persisted in the state. In that case, we can no longer
-	// trust that the value (which we don't see) is equal to what we've declared
-	// previously.
-	//
-	// The only solution to enforce consistency between is to mark the resource
-	// as deleted (unset the ID) in order to fix potential drift by recreating
-	// the resource.
-	if updatedAt, ok := d.GetOk("updated_at"); ok && updatedAt != secret.UpdatedAt.String() {
-		log.Printf("[WARN] The secret %s has been externally updated in GitHub", d.Id())
-		d.SetId("")
-	} else if !ok {
-		if err = d.Set("updated_at", secret.UpdatedAt.String()); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return readMaybeDriftedSecret(d, secret)
 }
 
 func resourceGithubCodespacesUserSecretDelete(d *schema.ResourceData, meta interface{}) error {

--- a/github/resource_github_dependabot_organization_secret.go
+++ b/github/resource_github_dependabot_organization_secret.go
@@ -159,15 +159,6 @@ func resourceGithubDependabotOrganizationSecretRead(d *schema.ResourceData, meta
 		return err
 	}
 
-	if err = d.Set("encrypted_value", d.Get("encrypted_value")); err != nil {
-		return err
-	}
-	if err = d.Set("plaintext_value", d.Get("plaintext_value")); err != nil {
-		return err
-	}
-	if err = d.Set("created_at", secret.CreatedAt.String()); err != nil {
-		return err
-	}
 	if err = d.Set("visibility", secret.Visibility); err != nil {
 		return err
 	}
@@ -199,31 +190,7 @@ func resourceGithubDependabotOrganizationSecretRead(d *schema.ResourceData, meta
 		return err
 	}
 
-	// This is a drift detection mechanism based on timestamps.
-	//
-	// If we do not currently store the "updated_at" field, it means we've only
-	// just created the resource and the value is most likely what we want it to
-	// be.
-	//
-	// If the resource is changed externally in the meantime then reading back
-	// the last update timestamp will return a result different than the
-	// timestamp we've persisted in the state. In that case, we can no longer
-	// trust that the value (which we don't see) is equal to what we've declared
-	// previously.
-	//
-	// The only solution to enforce consistency between is to mark the resource
-	// as deleted (unset the ID) in order to fix potential drift by recreating
-	// the resource.
-	if updatedAt, ok := d.GetOk("updated_at"); ok && updatedAt != secret.UpdatedAt.String() {
-		log.Printf("[WARN] The secret %s has been externally updated in GitHub", d.Id())
-		d.SetId("")
-	} else if !ok {
-		if err = d.Set("updated_at", secret.UpdatedAt.String()); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return readMaybeDriftedSecret(d, secret)
 }
 
 func resourceGithubDependabotOrganizationSecretDelete(d *schema.ResourceData, meta interface{}) error {

--- a/github/resource_github_dependabot_secret.go
+++ b/github/resource_github_dependabot_secret.go
@@ -140,31 +140,7 @@ func resourceGithubDependabotSecretRead(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	// This is a drift detection mechanism based on timestamps.
-	//
-	// If we do not currently store the "updated_at" field, it means we've only
-	// just created the resource and the value is most likely what we want it to
-	// be.
-	//
-	// If the resource is changed externally in the meantime then reading back
-	// the last update timestamp will return a result different than the
-	// timestamp we've persisted in the state. In that case, we can no longer
-	// trust that the value (which we don't see) is equal to what we've declared
-	// previously.
-	//
-	// The only solution to enforce consistency between is to mark the resource
-	// as deleted (unset the ID) in order to fix potential drift by recreating
-	// the resource.
-	if updatedAt, ok := d.GetOk("updated_at"); ok && updatedAt != secret.UpdatedAt.String() {
-		log.Printf("[WARN] The secret %s has been externally updated in GitHub", d.Id())
-		d.SetId("")
-	} else if !ok {
-		if err = d.Set("updated_at", secret.UpdatedAt.String()); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return readMaybeDriftedSecret(d, secret)
 }
 
 func resourceGithubDependabotSecretDelete(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2288

----

### Before the change?

Given a plan with a resource with any secret
When the plan is applied
And the secret is externally modified
And a new plan is planned
Then the new plan results in the creation of a new secret

### After the change?

Given a plan with a resource with any secret
When the plan is applied
And the secret is externally modified
And a new plan is created
Then the plan results in the update of the existing secret

In particular, this behavior enables the use of the lifecycle meta argument to ignore changes to externally updated secrets.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

NOTE: I could not find any test that I could re-use to introduce an external change to an existing resource. Need support.

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

