### PR TITLE
Feat/env public key

### DIFF
--- a/github/data_source_github_actions_environment_public_key.go
+++ b/github/data_source_github_actions_environment_public_key.go
@@ -1,0 +1,89 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceGithubActionsEnvironmentPublicKey() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGithubActionsEnvironmentPublicKeyRead,
+
+		Schema: map[string]*schema.Schema{
+			"full_name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"name"},
+			},
+			"name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"full_name"},
+			},
+			"environment": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceGithubActionsEnvironmentPublicKeyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
+	var repoName string
+
+	envName := d.Get("environment").(string)
+	escapedEnvName := url.PathEscape(envName)
+
+	if fullName, ok := d.GetOk("full_name"); ok {
+		var err error
+		owner, repoName, err = splitRepoFullName(fullName.(string))
+		if err != nil {
+			return err
+		}
+	}
+
+	if name, ok := d.GetOk("name"); ok {
+		repoName = name.(string)
+	}
+
+	if repoName == "" {
+		return fmt.Errorf("one of %q or %q has to be provided", "full_name", "name")
+	}
+
+	repo, _, err := client.Repositories.Get(context.TODO(), owner, repoName)
+	if err != nil {
+		return err
+	}
+
+	publicKey, _, err := client.Actions.GetEnvPublicKey(context.TODO(), int(repo.GetID()), escapedEnvName)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(publicKey.GetKeyID())
+	err = d.Set("key_id", publicKey.GetKeyID())
+	if err != nil {
+		return err
+	}
+	err = d.Set("key", publicKey.GetKey())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/github/data_source_github_actions_environment_public_key_test.go
+++ b/github/data_source_github_actions_environment_public_key_test.go
@@ -1,0 +1,65 @@
+package github
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccGithubActionsEnvironmentPublicKeyDataSource(t *testing.T) {
+
+	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+	t.Run("queries a repository environment public key without error", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name = "tf-acc-test-%[1]s"
+				auto_init = true
+			}
+
+			resource "github_repository_environment" "test" {
+				repository = github_repository.test.name
+				name = "tf-acc-test-%[1]s"
+			}
+
+			data "github_actions_environment_public_key" "test" {
+				repository = github_repository.test.name
+				environment = github_repository_environment.test.name
+			}`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttrSet(
+				"data.github_actions_environment_public_key.test", "key",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
+}

--- a/github/data_source_github_actions_environment_public_key_test.go
+++ b/github/data_source_github_actions_environment_public_key_test.go
@@ -22,12 +22,12 @@ func TestAccGithubActionsEnvironmentPublicKeyDataSource(t *testing.T) {
 
 			resource "github_repository_environment" "test" {
 				repository = github_repository.test.name
-				name = "tf-acc-test-%[1]s"
+				environment = "tf-acc-test-%[1]s"
 			}
 
 			data "github_actions_environment_public_key" "test" {
 				repository = github_repository.test.name
-				environment = github_repository_environment.test.name
+				environment = github_repository_environment.test.environment
 			}`, randomID)
 
 		check := resource.ComposeTestCheckFunc(

--- a/github/provider.go
+++ b/github/provider.go
@@ -197,6 +197,7 @@ func Provider() *schema.Provider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"github_actions_environment_public_key":                                 dataSourceGithubActionsEnvironmentPublicKey(),
 			"github_actions_environment_secrets":                                    dataSourceGithubActionsEnvironmentSecrets(),
 			"github_actions_environment_variables":                                  dataSourceGithubActionsEnvironmentVariables(),
 			"github_actions_organization_oidc_subject_claim_customization_template": dataSourceGithubActionsOrganizationOIDCSubjectClaimCustomizationTemplate(),

--- a/website/docs/d/actions_environment_public_key.html.markdown
+++ b/website/docs/d/actions_environment_public_key.html.markdown
@@ -1,0 +1,31 @@
+---
+layout: "github"
+page_title: "GitHub: github_actions_environment_public_key"
+description: |-
+  Get information on a GitHub Actions Environment Public Key.
+---
+
+# github_actions_environment_public_key
+
+Use this data source to retrieve information about a GitHub Actions public key of a specific environment. This data source is required to be used with other GitHub secrets interactions.
+Note that the provider `token` must have admin rights to a repository to retrieve the action public keys of it's environments.
+
+
+## Example Usage
+
+```hcl
+data "github_actions_environment_public_key" "example" {
+  repository = "example_repo"
+  environment = "example_environment"
+}
+```
+
+## Argument Reference
+
+ * `repository` - (Required) Name of the repository to get public key from.
+ * `environment` - (Required) Name of the environment to get public key from.
+
+## Attributes Reference
+
+ * `key_id` - ID of the key that has been retrieved.
+ * `key`    - Actual key retrieved.

--- a/website/github.erb
+++ b/website/github.erb
@@ -14,6 +14,9 @@
           <a href="#">Data Sources</a>
           <ul class="nav nav-visible">
             <li>
+              <a href="/docs/providers/github/d/actions_environment_public_key.html">actions_environment_public_key</a>
+            </li>
+            <li>
               <a href="/docs/providers/github/d/actions_environment_secrets.html">actions_environment_secrets</a>
             </li>
             <li>
@@ -335,7 +338,7 @@
               <a href="/docs/providers/github/r/repository_environment_secret.html">github_repository_environment_secret</a>
             </li>
             <li>
-              <a href="/docs/providers/github/r/repository_environment_variable.html">github_repository_environment_variable</a>              
+              <a href="/docs/providers/github/r/repository_environment_variable.html">github_repository_environment_variable</a>
             </li>
             <li>
               <a href="/docs/providers/github/r/repository_file.html">github_repository_file</a>


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #1769 (it was closed but never resolved)

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* there are multiple data source implementations to get the public key used for secrets encryption, e.g.
  * `github_actions_public_key` for a repository's public key
  * `github_actions_organization_public_key` for an organization's public key
* there is no data source to get the public key of a specific environment of a repository (which might be used to encrypt values for the `github_repository_environment_secret` resource).

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* implements the missing data source `github_actions_environment_public_key`

```hcl
data "github_actions_environment_public_key" "test" {
  repository = "repo-name"
  environment = "env-name"
}
```

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
