### PR TITLE
fix: Fixed org teams data lookup parent id

### DIFF
--- a/website/docs/d/organization_teams.html.markdown
+++ b/website/docs/d/organization_teams.html.markdown
@@ -36,12 +36,14 @@ ___
 
 The `team` block consists of:
 
- * `id` - the ID of the team.
- * `node_id` - the Node ID of the team.
- * `slug` - the slug of the team.
- * `name` - the team's full name.
- * `description` - the team's description.
- * `privacy` - the team's privacy type.
+ * `id` - The ID of the team.
+ * `node_id` - The Node ID of the team.
+ * `slug` - The slug of the team.
+ * `name` - The team's full name.
+ * `description` - The team's description.
+ * `privacy` - The team's privacy type.
  * `members` - List of team members. Not returned if `summary_only = true`
  * `repositories` - List of team repositories. Not returned if `summary_only = true`
- * `parent` - the parent team.
+ * `parent_team_id` - The ID of the parent team, if there is one.
+ * `parent_team_slug` - The slug of the parent team, if there is one.
+ * `parent` - (**DEPRECATED**) The parent team, use `parent_team_id` or `parent_team_slug` instead.


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2491

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The `github_organization_teams` data source `parent` attribute did not provide a usable team ID

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The `github_organization_teams` data source now has a valid `parent_team_id` attribute
* The `github_organization_teams` data source now has a `parent_team_slug` attribute
* The `github_organization_teams` data source now follows the general idiom for parent team reference

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

