### PR TITLE
fix: Fixed team data source detailed repos

### DIFF
--- a/github/data_source_github_team.go
+++ b/github/data_source_github_team.go
@@ -43,9 +43,10 @@ func dataSourceGithubTeam() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"repositories": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Deprecated: "Use repositories_detailed instead.",
+				Type:       schema.TypeList,
+				Computed:   true,
+				Elem:       &schema.Schema{Type: schema.TypeString},
 			},
 			"repositories_detailed": {
 				Type:     schema.TypeList,
@@ -54,6 +55,10 @@ func dataSourceGithubTeam() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"repo_id": {
 							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"repo_name": {
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 						"role_name": {
@@ -168,7 +173,7 @@ func dataSourceGithubTeamRead(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 
-		repositories_detailed = make([]interface{}, 0, resultsPerPage) //removed this from the loop
+		repositories_detailed = make([]interface{}, 0, resultsPerPage) // removed this from the loop
 
 		for {
 			repository, resp, err := client.Teams.ListTeamReposByID(ctx, orgId, team.GetID(), &options.ListOptions)
@@ -180,6 +185,7 @@ func dataSourceGithubTeamRead(d *schema.ResourceData, meta interface{}) error {
 				repositories = append(repositories, v.GetName())
 				repositories_detailed = append(repositories_detailed, map[string]interface{}{
 					"repo_id":   v.GetID(),
+					"repo_name": v.GetName(),
 					"role_name": v.GetRoleName(),
 				})
 			}

--- a/website/docs/d/team.html.markdown
+++ b/website/docs/d/team.html.markdown
@@ -33,5 +33,5 @@ data "github_team" "example" {
 * `privacy` - the team's privacy type.
 * `permission` - the team's permission level.
 * `members` - List of team members (list of GitHub usernames). Not returned if `summary_only = true`
-* `repositories` - List of team repositories (list of repo names). Not returned if `summary_only = true`
-* `repositories_detailed` - List of team repositories (list of `repo_id` and [`role_name`](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository#permission)). Not returned if `summary_only = true`
+* `repositories` - (**DEPRECATED**) List of team repositories (list of repo names). Not returned if `summary_only = true`
+* `repositories_detailed` - List of team repositories (each item comprises of `repo_id`, `repo_name` & [`role_name`](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository#permission)). Not returned if `summary_only = true`


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2496

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The `github_team` data source didn't have a way to correlate the repo `role` with the `name`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The `github_team` data source `repositories_detailed` attribute now has the repo name

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

