### PR TITLE
correct grammar errors in data.github_release docs

### DIFF
--- a/website/docs/d/release.html.markdown
+++ b/website/docs/d/release.html.markdown
@@ -20,7 +20,7 @@ data "github_release" "example" {
 }
 ```
 
-To retrieve a specific release from a repository based on it's ID:
+To retrieve a specific release from a repository based on its ID:
 
 ```hcl
 data "github_release" "example" {
@@ -31,7 +31,7 @@ data "github_release" "example" {
 }
 ```
 
-Finally, to retrieve a release based on it's tag:
+Finally, to retrieve a release based on its tag:
 
 ```hcl
 data "github_release" "example" {


### PR DESCRIPTION
This corrects grammar errors in the `github_release` data source documentation by correcting the contraction "it's" ("it is") to the possessive "its."

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER
N/A
----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* [github_release data source docs](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/release) incorrectly use "it's."

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* [github_release data source docs](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/release) incorrectly use "its."

### Pull request checklist
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->
No

----

