### PR TITLE
DOCS: Code section for github_organization_ruleset is not formatted as hcl

### DIFF
--- a/website/docs/r/organization_ruleset.html.markdown
+++ b/website/docs/r/organization_ruleset.html.markdown
@@ -13,7 +13,7 @@ This resource allows you to create and manage rulesets on the organization level
 
 ## Example Usage
 
-```
+```hcl
 resource "github_organization_ruleset" "example" {
   name        = "example"
   target      = "branch"


### PR DESCRIPTION
There is no open issue for that but just have a look at 
[https://registry.terraform.io/providers/integrations/github/latest/docs/resources/release](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/release)

----

### Before the change?
The code section within this page is centered:
<img width="1160" alt="Screenshot 2024-12-20 at 09 36 07" src="https://github.com/user-attachments/assets/0e083eb0-5535-46d8-89f3-6654c880d28c" />

### After the change?
The code highlighting should be enabled and the formatting should be like everywhere else. This is an image for reference of another section:
<img width="1099" alt="Screenshot 2024-12-20 at 09 37 40" src="https://github.com/user-attachments/assets/9a9a6930-785d-4edd-ad57-8daca32ba70f" />


### Pull request checklist
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
- [ ] Yes
- [X] No
