### PR TITLE
Adds do_not_enforce_on_create option for github_repository_ruleset

### DIFF
--- a/github/resource_github_repository_ruleset.go
+++ b/github/resource_github_repository_ruleset.go
@@ -249,6 +249,12 @@ func resourceGithubRepositoryRuleset() *schema.Resource {
 										Optional:    true,
 										Description: "Whether pull requests targeting a matching branch must be tested with the latest code. This setting will not take effect unless at least one status check is enabled. Defaults to `false`.",
 									},
+									"do_not_enforce_on_create": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Description: "Allow repositories and branches to be created if a check would otherwise prohibit it.",
+										Default:     false,
+									},
 								},
 							},
 						},

--- a/github/resource_github_repository_ruleset_test.go
+++ b/github/resource_github_repository_ruleset_test.go
@@ -70,6 +70,7 @@ func TestGithubRepositoryRulesets(t *testing.T) {
 						}
 
 						strict_required_status_checks_policy = true
+						do_not_enforce_on_create             = true
 					}
 
 					non_fast_forward = true
@@ -319,6 +320,7 @@ func TestGithubRepositoryRulesets(t *testing.T) {
 						}
 
 						strict_required_status_checks_policy = true
+						do_not_enforce_on_create             = true
 					}
 
 					non_fast_forward = true

--- a/github/respository_rules_utils.go
+++ b/github/respository_rules_utils.go
@@ -324,9 +324,11 @@ func expandRules(input []interface{}, org bool) []*github.RepositoryRule {
 			}
 		}
 
+		doNotEnforceOnCreate := requiredStatusMap["do_not_enforce_on_create"].(bool)
 		params := &github.RequiredStatusChecksRuleParameters{
 			RequiredStatusChecks:             requiredStatusChecks,
 			StrictRequiredStatusChecksPolicy: requiredStatusMap["strict_required_status_checks_policy"].(bool),
+			DoNotEnforceOnCreate:             &doNotEnforceOnCreate,
 		}
 		rulesSlice = append(rulesSlice, github.NewRequiredStatusChecksRule(params))
 	}
@@ -503,6 +505,7 @@ func flattenRules(rules []*github.RepositoryRule, org bool) []interface{} {
 			rule := make(map[string]interface{})
 			rule["required_check"] = requiredStatusChecksSlice
 			rule["strict_required_status_checks_policy"] = params.StrictRequiredStatusChecksPolicy
+			rule["do_not_enforce_on_create"] = params.DoNotEnforceOnCreate
 			rulesMap[v.Type] = []map[string]interface{}{rule}
 		}
 	}

--- a/website/docs/r/repository_ruleset.html.markdown
+++ b/website/docs/r/repository_ruleset.html.markdown
@@ -175,6 +175,8 @@ The `rules` block supports the following:
 
 * `strict_required_status_checks_policy` - (Optional) (Boolean) Whether pull requests targeting a matching branch must be tested with the latest code. This setting will not take effect unless at least one status check is enabled. Defaults to `false`.
 
+* `do_not_enforce_on_create` - (Optional) (Boolean) Allow repositories and branches to be created if a check would otherwise prohibit it. Defaults to `false`.
+
 #### rules.required_status_checks.required_check ####
 
 * `context` - (Required) (String) The status check context name that must be present on the commit.


### PR DESCRIPTION
Optional attribute added to rules.required_status_checks.
Resolves #2360

----

### Before the change?

* The option to allow repositories and branches to be created without enforcing status checks were prohibited by default, and would substitute the value of this configuration from the repo to always be false. It was not available for repository and organization rulesets.

### After the change?

* Now it has the option to disable enforce status checks on creation of a new branch/repo, manageable through the provider and do not overwriting the configuration in the ruleset without being shown in terraform plan/apply.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
- [ ] Yes
- [x] No

----
