### PR TITLE
fix: Ensure integration_id is treated as optional and nil

### DIFF
--- a/github/resource_github_organization_ruleset.go
+++ b/github/resource_github_organization_ruleset.go
@@ -250,7 +250,6 @@ func resourceGithubOrganizationRuleset() *schema.Resource {
 												"integration_id": {
 													Type:        schema.TypeInt,
 													Optional:    true,
-													Default:     0,
 													Description: "The optional integration ID that this status check must originate from.",
 												},
 											},

--- a/github/resource_github_repository_ruleset.go
+++ b/github/resource_github_repository_ruleset.go
@@ -238,7 +238,6 @@ func resourceGithubRepositoryRuleset() *schema.Resource {
 												"integration_id": {
 													Type:        schema.TypeInt,
 													Optional:    true,
-													Default:     0,
 													Description: "The optional integration ID that this status check must originate from.",
 												},
 											},

--- a/github/respository_rules_utils.go
+++ b/github/respository_rules_utils.go
@@ -310,14 +310,16 @@ func expandRules(input []interface{}, org bool) []*github.RepositoryRule {
 			requiredStatusChecksSet := requiredStatusChecksInput.(*schema.Set)
 			for _, checkMap := range requiredStatusChecksSet.List() {
 				check := checkMap.(map[string]interface{})
-				integrationID := github.Int64(int64(check["integration_id"].(int)))
 
 				params := github.RuleRequiredStatusChecks{
 					Context: check["context"].(string),
 				}
 
-				if *integrationID != 0 {
-					params.IntegrationID = integrationID
+				if v, ok := check["integration_id"].(int); ok {
+					integrationID := github.Int64(int64(v))
+					if *integrationID != 0 {
+						params.IntegrationID = integrationID
+					}
 				}
 
 				requiredStatusChecks = append(requiredStatusChecks, params)
@@ -490,14 +492,14 @@ func flattenRules(rules []*github.RepositoryRule, org bool) []interface{} {
 
 			requiredStatusChecksSlice := make([]map[string]interface{}, 0)
 			for _, check := range params.RequiredStatusChecks {
-				integrationID := int64(0)
-				if check.IntegrationID != nil {
-					integrationID = *check.IntegrationID
+
+				checkMap := make(map[string]interface{})
+				checkMap["context"] = check.Context
+				if check.IntegrationID != nil && *check.IntegrationID != 0 {
+					checkMap["integration_id"] = *check.IntegrationID
 				}
-				requiredStatusChecksSlice = append(requiredStatusChecksSlice, map[string]interface{}{
-					"context":        check.Context,
-					"integration_id": integrationID,
-				})
+
+				requiredStatusChecksSlice = append(requiredStatusChecksSlice, checkMap)
 			}
 
 			rule := make(map[string]interface{})


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2317

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The `integration_id` despite being optional was filled with `0` and expected to be filled everywhere causing API validation errors. 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The `integration_id` defualt values were removed and respective places where adapted to handle `nil` (and potential `0`) values.  

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

