### PR TITLE
Update organization security manager resource to use operations that are not deprecated

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ Setting a `processId` of 0 allows a dropdown to select the process of the provid
 
 0. Add a sleep call (e.g. `time.Sleep(10 * time.Second)`) in the [`func providerConfigure(p *schema.Provider) schema.ConfigureFunc`](https://github.com/integrations/terraform-provider-github/blob/cec7e175c50bb091feecdc96ba117067c35ee351/github/provider.go#L274C1-L274C64) before the immediate `return` call. This will allow time to connect the debugger while the provider is initializing, before any critical logic happens.
 
-0. Build the terraform provider with debug flags enabled and copy it to the appropriate bin folder with a command like `go build -gcflags="all=-N -l" -o ~/go/bin`.
+0. Build the terraform provider with debug flags enabled and copy it to the appropriate bin folder with a command like `go build -gcflags="all=-N -l" -o ~/go/bin/`.
 
 0. Create or edit a `dev.tfrc` that points toward the newly-built binary, and export the `TF_CLI_CONFIG_FILE` variable to point to it. Further instructions on this process may be found in the [Building the provider](#using-a-local-version-of-the-provider) section.
 
@@ -99,7 +99,7 @@ Manual testing should be performed on each PR opened in order to validate the pr
 Build the provider and specify the output directory:
 
 ```sh
-$ go build -gcflags="all=-N -l" -o ~/go/bin
+$ go build -gcflags="all=-N -l" -o ~/go/bin/
 ```
 
 This enables verifying your locally built provider using examples available in the `examples/` directory.

--- a/examples/organization_security_manager/README.md
+++ b/examples/organization_security_manager/README.md
@@ -1,0 +1,22 @@
+# Organization Security Manager Example
+
+This example demonstrates creating an organization security manager team.
+
+It will:
+- Create a team with the specified `team_name` in the specified `owner` organization
+- Assign the organization security manager role to the team
+
+The GitHub token must have the `admin:org` scope.
+
+```console
+export GITHUB_OWNER=my-organization
+export GITHUB_TOKEN=ghp_###
+export GITHUB_TEAM_NAME="My Security Manager Team"
+```
+
+```console
+terraform apply \
+  -var "owner=${GITHUB_OWNER}" \
+  -var "github_token=${GITHUB_TOKEN}" \
+  -var "team_name=${GITHUB_TEAM_NAME}"
+```

--- a/examples/organization_security_manager/main.tf
+++ b/examples/organization_security_manager/main.tf
@@ -1,0 +1,8 @@
+resource "github_team" "security_managers" {
+  name        = var.team_name
+  description = "A team of organization security managers"
+}
+
+resource "github_organization_security_manager" "security_managers" {
+  team_slug = github_team.security_managers.slug
+}

--- a/examples/organization_security_manager/output.tf
+++ b/examples/organization_security_manager/output.tf
@@ -1,0 +1,4 @@
+output "github_security_managers_team" {
+  description = "The organization security managers team"
+  value       = github_organization_security_manager.security_managers
+}

--- a/examples/organization_security_manager/providers.tf
+++ b/examples/organization_security_manager/providers.tf
@@ -1,0 +1,12 @@
+provider "github" {
+  owner = var.owner
+  token = var.github_token
+}
+
+terraform {
+  required_providers {
+    github = {
+      source = "integrations/github"
+    }
+  }
+}

--- a/examples/organization_security_manager/variables.tf
+++ b/examples/organization_security_manager/variables.tf
@@ -1,0 +1,14 @@
+variable "github_token" {
+  description = "GitHub access token used to configure the provider"
+  type        = string
+}
+
+variable "owner" {
+  description = "GitHub owner used to configure the provider"
+  type        = string
+}
+
+variable "team_name" {
+  description = "The name to use for the GitHub team"
+  type        = string
+}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2534

----

As of December 10, 2024 the [GitHub organization security manager REST APIs](https://docs.github.com/en/rest/orgs/security-managers) are deprecated in favor of the [organization roles REST APIs](https://docs.github.com/en/rest/orgs/organization-roles). You may read more about this change at https://gh.io/security-managers-rest-api-sunset.

This PR updates the organization security manager resource to use the organization roles REST APIs and adds an example for how to use the resource.

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The organization security manager resource use the deprecated GitHub client operations.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The organization security manager resource now uses the non-deprecated GitHub client operations.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
  - I didn't see a need to update [the existing tests](https://github.com/integrations/terraform-provider-github/blob/16872b724254fdddc3441c713b087cb4d7005f83/github/resource_github_organization_security_manager_test.go) for these changes. I'm adding an example that I used to validate the changes.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - [The documentation](https://github.com/integrations/terraform-provider-github/blob/64934361060b4ea7174b999cd5a98c30a78599b1/website/docs/r/organization_security_manager.html.markdown) doesn't need any updates. Usage remains the same.

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

