### PR TITLE
Use the correct `update_allows_fetch_and_merge` parameter in the rules mapping

### DIFF
--- a/github/respository_rules_utils.go
+++ b/github/respository_rules_utils.go
@@ -209,7 +209,7 @@ func expandRules(input []interface{}, org bool) []*github.RepositoryRule {
 
 	if v, ok := rulesMap["update"].(bool); ok && v {
 		params := github.UpdateAllowsFetchAndMergeRuleParameters{}
-		if fetchAndMerge, ok := rulesMap["update"].(bool); ok && fetchAndMerge {
+		if fetchAndMerge, ok := rulesMap["update_allows_fetch_and_merge"].(bool); ok && fetchAndMerge {
 			params.UpdateAllowsFetchAndMerge = true
 		} else {
 			params.UpdateAllowsFetchAndMerge = false


### PR DESCRIPTION
Previously the `update` parameter was used to set the `update_allows_fetch_and_merge` value.
Based on the documentation it should be `update_allows_fetch_and_merge` in case when `update` is set to true

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2463

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* When the `update` parameter is set to true - `update_allows_fetch_and_merge` also was set to true automatically, even if we have `update_allows_fetch_and_merge: false` in our rules

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* When the `update` parameter is set to true -  `update_allows_fetch_and_merge` would be set based on the rule we defined in `update_allows_fetch_and_merge`

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

