### PR TITLE
Fix documented block name for ignored collaborator teams

### DIFF
--- a/website/docs/r/repository_collaborators.html.markdown
+++ b/website/docs/r/repository_collaborators.html.markdown
@@ -83,7 +83,7 @@ The `team` block supports:
   Must be one of `pull`, `triage`, `push`, `maintain`, `admin` or the name of an existing [custom repository role](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-peoples-access-to-your-organization-with-roles/managing-custom-repository-roles-for-an-organization) within the organisation. Defaults to `pull`.
   Must be `push` for personal repositories. Defaults to `push`.
 
-The `team_ignore` block supports:
+The `ignore_team` block supports:
 
 * `team_id` - (Required) The GitHub team id or the GitHub team slug.
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2550

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The documentation incorrectly refers to a block named team_ignore in github_repository_collaborators. This block does not exist and will not validate/plan/apply.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Corrects the docs to refer to ignore_team which is the correct block name.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

