### PR TITLE
fix: Do not ignore file deletion errors

### DIFF
--- a/github/resource_github_repository_file.go
+++ b/github/resource_github_repository_file.go
@@ -505,7 +505,7 @@ func resourceGithubRepositoryFileDelete(d *schema.ResourceData, meta interface{}
 
 	_, _, err := client.Repositories.DeleteFile(ctx, owner, repo, file, opts)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Resource: `github_repository_file`

When deleting a file errors (such as `409 Could not delete file: Changes must be made through a pull request`) should not be silently ignored leaving the file undeleted from the repo but deleted from the state

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

Resource github_repository_file ignores any errors when deleting files which results in inconsistencies

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Resource github_repository_file stops on errors if any when deleting files

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

