### PR TITLE
feat: Add data sources for listing GitHub App installations in an organization

### DIFF
--- a/github/data_source_github_organization_app_installations.go
+++ b/github/data_source_github_organization_app_installations.go
@@ -1,0 +1,91 @@
+package github
+
+import (
+	"context"
+
+	"github.com/google/go-github/v66/github"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceGithubOrganizationAppInstallations() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGithubOrganizationAppInstallationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"installations": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"slug": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"node_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"app_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGithubOrganizationAppInstallationsRead(d *schema.ResourceData, meta interface{}) error {
+	owner := meta.(*Owner).name
+
+	client := meta.(*Owner).v3client
+	ctx := context.Background()
+
+	options := &github.ListOptions{
+		PerPage: 100,
+	}
+
+	results := make([]map[string]interface{}, 0)
+	for {
+		appInstallations, resp, err := client.Organizations.ListInstallations(ctx, owner, options)
+		if err != nil {
+			return err
+		}
+
+		results = append(results, flattenGitHubAppInstallations(appInstallations.Installations)...)
+		if resp.NextPage == 0 {
+			break
+		}
+
+		options.Page = resp.NextPage
+	}
+
+	d.SetId(owner)
+	err := d.Set("installations", results)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func flattenGitHubAppInstallations(orgAppInstallations []*github.Installation) []map[string]interface{} {
+	results := make([]map[string]interface{}, 0)
+
+	if orgAppInstallations == nil {
+		return results
+	}
+
+	for _, appInstallation := range orgAppInstallations {
+		result := make(map[string]interface{})
+
+		result["slug"] = appInstallation.AppSlug
+		result["node_id"] = appInstallation.NodeID
+		result["app_id"] = appInstallation.AppID
+
+		results = append(results, result)
+	}
+
+	return results
+}

--- a/github/data_source_github_organization_app_installations_test.go
+++ b/github/data_source_github_organization_app_installations_test.go
@@ -1,0 +1,43 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccGithubOrganizationAppInstallations(t *testing.T) {
+	t.Run("queries without error", func(t *testing.T) {
+		config := `data "github_organization_app_installations" "test" {}`
+
+		check := resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttrSet("data.github_organization_app_installations.test", "installations.0.slug"),
+			resource.TestCheckResourceAttrSet("data.github_organization_app_installations.test", "installations.0.node_id"),
+			resource.TestCheckResourceAttrSet("data.github_organization_app_installations.test", "installations.0.app_id"),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			t.Skip("individual account not supported for this operation")
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+}

--- a/github/provider.go
+++ b/github/provider.go
@@ -236,6 +236,7 @@ func Provider() *schema.Provider {
 			"github_organization_team_sync_groups":                                  dataSourceGithubOrganizationTeamSyncGroups(),
 			"github_organization_teams":                                             dataSourceGithubOrganizationTeams(),
 			"github_organization_webhooks":                                          dataSourceGithubOrganizationWebhooks(),
+			"github_organization_app_installations":                                 dataSourceGithubOrganizationAppInstallations(),
 			"github_ref":                                                            dataSourceGithubRef(),
 			"github_release":                                                        dataSourceGithubRelease(),
 			"github_repositories":                                                   dataSourceGithubRepositories(),


### PR DESCRIPTION
This PR introduces a new data source, **_github_app_installations_**, to enable listing all installed GitHub Apps within an organization. This addition enhances integration with existing resources such as github_app_installation_repository, providing better automation and management capabilities for GitHub App permissions.

What's New?
New Data Source: github_app_installations
Allows fetching all installed GitHub Apps in an organization:

`data "github_organization_app_installations" "all_apps" {}
`

Example Use Case:
This data source can be integrated with the github_app_installation_repository resource to manage app permissions on specific repositories:

```
# Local value to find the correct app installation by slug
locals {
  # Find the index of the desired app by its slug
  app_index = index(
    data.github_organization_app_installations.all_apps.installations[*].slug,
    "desired-app-name"  # Replace with your actual app slug
  )
  
  # Get the app_id using the found index
  app_id = data.github_organization_app_installations.all_apps[local.app_index].app_id
}

# Link the repository to the app installation
resource "github_app_installation_repository" "some_app_repo" {
  installation_id = local.app_id
  repository     = github_repository.some_repo.name
}
```

API Reference: https://docs.github.com/en/rest/orgs/orgs?apiVersion=2022-11-28#list-app-installations-for-an-organization

Related Issue: https://github.com/integrations/terraform-provider-github/issues/2570
