### PR TITLE
Change support message now that we don't do the Monday/Friday thing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ This project uses [Milestones](https://github.com/integrations/terraform-provide
 
 ## Support
 
-This is a community-supported project. GitHub's SDK team triages issues and PRs each Monday and Friday. Please engage with the community via Issues for support, and PRs are always welcome!
+This is a community-supported project. GitHub's SDK team triages issues and PRs periodically. Please engage with the community via Issues for support, and PRs are always welcome!


### PR DESCRIPTION
This has been causing some confusion. Our team has been pulled into other initiatives at GitHub, and we don't get time to work on SDKs very frequently at all. We're attempting to get one day a month to review issues and PRs as well as cut new releases, and hopefully that policy will stick. 