### PR TITLE
fix: ensure baseUrl is not already prefixed (#2616)

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"time"
+	"strings"
 
 	"github.com/go-jose/go-jose/v3"
 	"github.com/go-jose/go-jose/v3/jwt"
@@ -31,7 +32,7 @@ func GenerateOAuthTokenFromApp(baseURL, appID, appInstallationID, pemData string
 }
 
 func getInstallationAccessToken(baseURL string, jwt string, installationID string) (string, error) {
-	if baseURL != "https://api.github.com/" && !GHECDataResidencyMatch.MatchString(baseURL) {
+	if baseURL != "https://api.github.com/" && !GHECDataResidencyMatch.MatchString(baseURL) && !strings.HasSuffix(baseURL, "api/v3/") {
 		baseURL += "api/v3/"
 	}
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2616

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* For self-hosted github (i.e with host different than https://api.github.com/) in the [`NewRESTClient`](https://github.com/integrations/terraform-provider-github/blob/6008909a212294e332cb23f3bbaf1089e0d9ed1e/github/config.go#L105) func the `api/v3/` suffix is automatically added. However in the `getInstallationAccessToken` the same check is done. This results in have a double suffix and thus break the api call

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Not add the suffix if it is already added

### Pull request checklist
-  [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

