### PR TITLE
fix(github_repository_file): Commit detail changes should not do empty commits

### DIFF
--- a/examples/repository_file/README.md
+++ b/examples/repository_file/README.md
@@ -1,0 +1,24 @@
+# Repository File
+
+This provides a template for managing [repository files](https://docs.github.com/en/repositories/working-with-files/managing-files).
+
+This example will also create or update a file in the specified `repository`. See https://www.terraform.io/docs/providers/github/index.html for details on configuring [`providers.tf`](./providers.tf) accordingly.
+
+Alternatively, you may use variables passed via the command line or `auto.tfvars`:
+
+```tfvars
+organization = ""
+github_token = ""
+
+repository     = ""
+file           = ""
+content        = ""
+branch         = ""
+commit_author  = ""
+commit_message = ""
+commit_email   = ""
+```
+
+```console
+terraform apply
+```

--- a/examples/repository_file/main.tf
+++ b/examples/repository_file/main.tf
@@ -1,0 +1,11 @@
+resource "github_repository_file" "this" {
+  repository = var.repository
+  file       = var.file
+  content    = var.content
+
+  branch = var.branch
+
+  commit_author  = var.commit_author
+  commit_message = var.commit_message
+  commit_email   = var.commit_email
+}

--- a/examples/repository_file/providers.tf
+++ b/examples/repository_file/providers.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    github = {
+      source = "integrations/github"
+    }
+  }
+}
+
+provider "github" {
+  owner = var.organization
+  token = var.github_token
+}

--- a/examples/repository_file/variables.tf
+++ b/examples/repository_file/variables.tf
@@ -1,0 +1,43 @@
+variable "organization" {
+  description = "GitHub organization used to configure the provider"
+  type        = string
+}
+
+variable "github_token" {
+  description = "GitHub access token used to configure the provider"
+  type        = string
+}
+
+variable "repository" {
+  description = "The name of the repository"
+  type        = string
+}
+
+variable "file" {
+  description = "The name of the file to create"
+  type        = string
+}
+variable "content" {
+  description = "The content of the file to create"
+  type        = string
+}
+variable "branch" {
+  description = "The branch to create the file in"
+  type        = string
+  default     = "main"
+}
+variable "commit_author" {
+  description = "The name of the author of the commit"
+  type        = string
+  default     = ""
+}
+variable "commit_message" {
+  description = "The message of the commit"
+  type        = string
+  default     = ""
+}
+variable "commit_email" {
+  description = "The email of the author of the commit"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
When terraform changes any field related to how commits are done (email, commit message, etc), it pushes an unexpected empty commit to the repo.

This is specially relevant when importing an existing file into terraform, where the commit message you put in terraform will likely be different from the commit that pushed the file originally. In that sense, importing a file will always mean eventually doing empty commits for each file you imported.

The expected behaviour is just updating the state and avoid doing those empty commits. Otherwise, each empty commit can run any CI that might be configured, notifications, etc.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #689

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* When any of  `commit_sha`, `commit_author`, `commit_email` or `commit_message` changed, it did a empty commit

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Now, it checks which fields have changes and only commits if there are changes in any other field

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

