### PR TITLE
fix: imported custom property type

### DIFF
--- a/github/resource_github_repository_custom_property_test.go
+++ b/github/resource_github_repository_custom_property_test.go
@@ -13,7 +13,7 @@ func TestAccGithubRepositoryCustomProperty(t *testing.T) {
 	t.Skip("You need an org with custom properties already setup as described in the variables below") // TODO: at the time of writing org_custom_properties are not supported by this terraform provider, so cant be setup in the test itself for now
 	singleSelectPropertyName := "single-select"                                                        // Needs to be a of type single_select, and have "option1" as an option
 	multiSelectPropertyName := "multi-select"                                                          // Needs to be a of type multi_select, and have "option1" and "option2" as an options
-	trueFlasePropertyName := "true-false"                                                              // Needs to be a of type true_false
+	trueFalsePropertyName := "true-false"                                                              // Needs to be a of type true_false
 	stringPropertyName := "string"                                                                     // Needs to be a of type string
 
 	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
@@ -47,6 +47,12 @@ func TestAccGithubRepositoryCustomProperty(t *testing.T) {
 					{
 						Config: config,
 						Check:  check,
+					},
+					{
+						ResourceName:      "github_repository_custom_property.test",
+						ImportStateId:     fmt.Sprintf(`%s:tf-acc-test-%s:%s`, testOrganization, randomID, singleSelectPropertyName),
+						ImportState:       true,
+						ImportStateVerify: true,
 					},
 				},
 			})
@@ -96,6 +102,12 @@ func TestAccGithubRepositoryCustomProperty(t *testing.T) {
 						Config: config,
 						Check:  checkWithOwner,
 					},
+					{
+						ResourceName:      "github_repository_custom_property.test",
+						ImportStateId:     fmt.Sprintf(`%s:tf-acc-test-%s:%s`, testOrganization, randomID, multiSelectPropertyName),
+						ImportState:       true,
+						ImportStateVerify: true,
+					},
 				},
 			})
 		}
@@ -126,10 +138,10 @@ func TestAccGithubRepositoryCustomProperty(t *testing.T) {
 				property_type = "true_false"
 				property_value = ["true"]
 			}
-		`, randomID, trueFlasePropertyName)
+		`, randomID, trueFalsePropertyName)
 
 		checkWithOwner := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr("github_repository_custom_property.test", "property_name", trueFlasePropertyName),
+			resource.TestCheckResourceAttr("github_repository_custom_property.test", "property_name", trueFalsePropertyName),
 			resource.TestCheckResourceAttr("github_repository_custom_property.test", "property_value.#", "1"),
 			resource.TestCheckResourceAttr("github_repository_custom_property.test", "property_value.0", "true"),
 		)
@@ -142,6 +154,12 @@ func TestAccGithubRepositoryCustomProperty(t *testing.T) {
 					{
 						Config: config,
 						Check:  checkWithOwner,
+					},
+					{
+						ResourceName:      "github_repository_custom_property.test",
+						ImportStateId:     fmt.Sprintf(`%s:tf-acc-test-%s:%s`, testOrganization, randomID, trueFalsePropertyName),
+						ImportState:       true,
+						ImportStateVerify: true,
 					},
 				},
 			})
@@ -189,6 +207,12 @@ func TestAccGithubRepositoryCustomProperty(t *testing.T) {
 					{
 						Config: config,
 						Check:  checkWithOwner,
+					},
+					{
+						ResourceName:      "github_repository_custom_property.test",
+						ImportStateId:     fmt.Sprintf(`%s:tf-acc-test-%s:%s`, testOrganization, randomID, stringPropertyName),
+						ImportState:       true,
+						ImportStateVerify: true,
 					},
 				},
 			})


### PR DESCRIPTION
Imported custom properties currently default the type to null. This causes the state to then update with the real type value, which triggers a forced replacement. This fetches the type from the organization property schema and adds it on import.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2639

----

### Before the change?

* An imported custom property resource's `property_type` is set to null, which causes the configuration to trigger a forced replacement of the resource.

### After the change?

* The property type is fetched from the organisation schema and set correctly, preventing the resource replacement.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

