### PR TITLE
fix state for required workflow on organization rules

### DIFF
--- a/github/respository_rules_utils.go
+++ b/github/respository_rules_utils.go
@@ -524,6 +524,29 @@ func flattenRules(rules []*github.RepositoryRule, org bool) []interface{} {
 			rule["do_not_enforce_on_create"] = params.DoNotEnforceOnCreate
 			rulesMap[v.Type] = []map[string]interface{}{rule}
 
+		case "workflows":
+			var params github.RequiredWorkflowsRuleParameters
+
+			err := json.Unmarshal(*v.Parameters, &params)
+			if err != nil {
+				log.Printf("[INFO] Unexpected error unmarshalling rule %s with parameters: %v",
+					v.Type, v.Parameters)
+			}
+
+			requiredWorkflowsSlice := make([]map[string]interface{}, 0)
+			for _, workflow := range params.RequiredWorkflows {
+				requiredWorkflowsSlice = append(requiredWorkflowsSlice, map[string]interface{}{
+					"repository_id": workflow.RepositoryID,
+					"path":          workflow.Path,
+					"ref":           workflow.Ref,
+				})
+			}
+
+			rule := make(map[string]interface{})
+			rule["workflows"] = requiredWorkflowsSlice
+			rule["do_not_enforce_on_create"] = params.DoNotEnforceOnCreate
+			rulesMap[v.Type] = []map[string]interface{}{rule}
+
 		case "merge_queue":
 			var params github.MergeQueueRuleParameters
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2657

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->
The required_workflows section inside a GitHub organization_ruleset was not correctly saved in the Terraform state. This caused drift or prevented proper detection of the current configuration.


### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The flattenRules function has been updated to handle the workflows rule type properly, parsing and flattening the required workflow structure (repository ID, path, and ref). A new test was added to validate updates to required workflows in an organization ruleset, confirming the state is now correctly stored and updated.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

