### PR TITLE
Add branch pattern example to repository_ruleset documentation

### DIFF
--- a/website/docs/r/repository_ruleset.html.markdown
+++ b/website/docs/r/repository_ruleset.html.markdown
@@ -27,7 +27,7 @@ resource "github_repository_ruleset" "example" {
 
   conditions {
     ref_name {
-      include = ["~ALL"]
+      include = ["~ALL", "ref/heads/main"]
       exclude = []
     }
   }


### PR DESCRIPTION
The pattern can be confusing since Github API and UI differ in this point. This is just a clarification for the documentation.

See also: https://github.com/orgs/community/discussions/119797
See also: https://docs.github.com/en/rest/repos/rules#create-a-repository-ruleset

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Intuitively, the user would use the simple branch pattern `main` oder `feat-*` to include or exclude branches in the ruleset. The provider will crash with a 402 when applying the change:

```
Error: POST https://api.github.com/repos/ORG/REPO/rulesets: 422 Validation Failed [{Resource: Field: Code: Message:Invalid target patterns: 'main'}]
```

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The documentation suggests to use the required pattern, e.g. `ref/heads/main`, in this case.

See also the example in https://docs.github.com/en/rest/repos/rules#create-a-repository-ruleset which uses this pattern.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

