### PR TITLE
docs: Adds do_not_enforce_on_create option for github_repository_ruleset docs

### DIFF
--- a/github/resource_github_organization_ruleset_test.go
+++ b/github/resource_github_organization_ruleset_test.go
@@ -252,7 +252,6 @@ func TestGithubOrganizationRulesets(t *testing.T) {
 						}
 
 						strict_required_status_checks_policy = true
-
 						do_not_enforce_on_create             = true
 					}
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Optional attribute added to rules.required_status_checks.
Resolves #2656

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The option to allow repositories and branches to be created without enforcing status checks were prohibited by default, and would substitute the value of this configuration from the repo to always be false. It was not available for organization rulesets in the schema, which lead to a panic.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Now it has the option to enable/disable enforce status checks on creation of a new branch/repo, manageable through the provider and without overwriting the configuration in the ruleset without being shown in terraform plan/apply.
* Defining required checks will no longer result in a panic, as the schema now provides a default value instead of nil.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

