### PR TITLE
Adding a computed attribute for the repository owner to the github_repository

### DIFF
--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -22,13 +22,20 @@ func dataSourceGithubRepository() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
-				ConflictsWith: []string{"name"},
+				ConflictsWith: []string{"name", "owner"},
 			},
 			"name": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
 				ConflictsWith: []string{"full_name"},
+			},
+			"owner": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"full_name"},
+				Description:   "Owner of the repository. If not provided, the provider's default owner is used.",
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -359,6 +366,9 @@ func dataSourceGithubRepositoryRead(ctx context.Context, d *schema.ResourceData,
 	}
 	if name, ok := d.GetOk("name"); ok {
 		repoName = name.(string)
+	}
+	if ownerName, ok := d.GetOk("owner"); ok {
+		owner = ownerName.(string)
 	}
 
 	if repoName == "" {

--- a/github/data_source_github_repository_test.go
+++ b/github/data_source_github_repository_test.go
@@ -379,4 +379,179 @@ EOT
 			},
 		})
 	})
+
+	t.Run("queries a repository using owner and name", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name = "tf-acc-%s"
+			}
+
+			data "github_repository" "test" {
+				name  = github_repository.test.name
+				owner = "%s"
+			}
+		`, randomID, testOrganization)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"data.github_repository.test", "owner",
+				testOrganization,
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			testCase(t, anonymous)
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+
+	t.Run("validates conflicts between full_name, name, and owner", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name = "tf-acc-%[1]s"
+				vulnerability_alerts = true
+			}
+		`, randomID)
+
+		// Test invalid combinations
+		invalidConfigs := []string{
+			// full_name with name
+			fmt.Sprintf(`
+				resource "github_repository" "test" {
+					name                 = "tf-acc-%[1]s"
+					vulnerability_alerts = true
+				}
+
+				data "github_repository" "test" {
+					full_name = "%[2]s/tf-acc-%[1]s"
+					name     = "tf-acc-%[1]s"
+				}
+			`, randomID, testOrganization),
+			// full_name with owner
+			fmt.Sprintf(`
+				resource "github_repository" "test" {
+					name = "tf-acc-%[1]s"
+				}
+
+				data "github_repository" "test" {
+					full_name = "%[2]s/tf-acc-%[1]s"
+					owner    = "%[2]s"
+				}
+			`, randomID, testOrganization),
+			// full_name with both name and owner
+			fmt.Sprintf(`
+				resource "github_repository" "test" {
+					name = "tf-acc-%[1]s"
+				}
+
+				data "github_repository" "test" {
+					full_name = "%[2]s/tf-acc-%[1]s"
+					name     = "tf-acc-%[1]s"
+					owner    = "%[2]s"
+				}
+			`, randomID, testOrganization),
+		}
+
+		// Test valid combinations
+		validConfigs := []string{
+			// Just full_name
+			fmt.Sprintf(`
+				resource "github_repository" "test" {
+					name = "tf-acc-%[1]s"
+				}
+
+				data "github_repository" "test" {
+					full_name = "%[2]s/tf-acc-%[1]s"
+				}
+			`, randomID, testOrganization),
+			// Just name (uses provider owner)
+			fmt.Sprintf(`
+				resource "github_repository" "test" {
+					name = "tf-acc-%[1]s"
+				}
+
+				data "github_repository" "test" {
+					name = "tf-acc-%[1]s"
+				}
+			`, randomID),
+			// name with owner
+			fmt.Sprintf(`
+				resource "github_repository" "test" {
+					name = "tf-acc-%[1]s"
+				}
+
+				data "github_repository" "test" {
+					name  = "tf-acc-%[1]s"
+					owner = "%[2]s"
+				}
+			`, randomID, testOrganization),
+		}
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					// Create the repository first
+					{
+						Config: config,
+					},
+					// Test that invalid configs fail
+					{
+						Config:      invalidConfigs[0],
+						ExpectError: regexp.MustCompile("(?i)conflicts with"),
+					},
+					{
+						Config:      invalidConfigs[1],
+						ExpectError: regexp.MustCompile("(?i)conflicts with"),
+					},
+					{
+						Config:      invalidConfigs[2],
+						ExpectError: regexp.MustCompile("(?i)conflicts with"),
+					},
+					// Test that valid configs succeed
+					{
+						Config: validConfigs[0],
+					},
+					{
+						Config: validConfigs[1],
+					},
+					{
+						Config: validConfigs[2],
+					},
+				},
+			})
+		}
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
 }

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -412,6 +412,11 @@ func resourceGithubRepository() *schema.Resource {
 				Computed:    true,
 				Description: "A string of the form 'orgname/reponame'.",
 			},
+			"owner": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The owner of the repository.",
+			},
 			"html_url": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -832,6 +837,9 @@ func resourceGithubRepositoryRead(ctx context.Context, d *schema.ResourceData, m
 	_ = d.Set("topics", flattenStringList(repo.Topics))
 	_ = d.Set("node_id", repo.GetNodeID())
 	_ = d.Set("repo_id", repo.GetID())
+	if repo.Owner != nil {
+		_ = d.Set("owner", repo.Owner.GetLogin())
+	}
 
 	// TODO: Validate this behavior as I can see these fields being returned even when archived
 	// GitHub API doesn't respond following parameters when repository is archived

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -894,6 +894,53 @@ resource "github_repository" "test" {
 	// 	})
 	// })
 
+	t.Run("creates repository and returns owner field", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name        = "tf-acc-test-owner-%[1]s"
+				description = "Terraform acceptance tests %[1]s"
+			}
+		`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttrSet(
+				"github_repository.test", "owner",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+
+}
+
+func TestAccGithubRepositoryPages(t *testing.T) {
+	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
 	t.Run("manages the legacy pages feature for a repository", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		testRepoName := fmt.Sprintf("%slegacy-pages-%s", testResourcePrefix, randomID)

--- a/website/docs/d/repository.html.markdown
+++ b/website/docs/d/repository.html.markdown
@@ -25,6 +25,8 @@ The following arguments are supported:
 
 * `full_name` - (Optional) Full name of the repository (in `org/name` format).
 
+* `owner` - (Optional) Owner of the repository. If not provided, the provider's default owner is used.
+
 ## Attributes Reference
 
 * `node_id` - the Node ID of the repository.

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -222,6 +222,8 @@ The following additional attributes are exported:
 
 * `full_name` - A string of the form "orgname/reponame".
 
+* `owner` - The owner of the repository.
+
 * `html_url` - URL to the repository on the web.
 
 * `ssh_clone_url` - URL that can be provided to `git clone` to clone the repository via SSH.
@@ -250,3 +252,4 @@ Repositories can be imported using the `name`, e.g.
 ```shell
 terraform import github_repository.terraform myrepo
 ```
+


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2503

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The repository owner has to either be parsed out of the `full_name`, or passed around as a separate variable.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Repository owner is now a computed field in both the repository resource and data source.
* The data source can be queried by `name` + `owner` when using anonymous auth. `full_name` will also still work.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

