### PR TITLE
feat: add data sources github_actions_remove_token and github_actions_organization_remove_token 

### DIFF
--- a/github/data_source_github_actions_organization_remove_token.go
+++ b/github/data_source_github_actions_organization_remove_token.go
@@ -1,0 +1,49 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceGithubActionsOrganizationRemoveToken() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGithubActionsOrganizationRemoveTokenRead,
+
+		Schema: map[string]*schema.Schema{
+			"token": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"expires_at": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceGithubActionsOrganizationRemoveTokenRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
+
+	log.Printf("[DEBUG] Creating a GitHub Actions organization remove token for %s", owner)
+	token, _, err := client.Actions.CreateOrganizationRemoveToken(context.TODO(), owner)
+	if err != nil {
+		return fmt.Errorf("error creating a GitHub Actions organization remove token for %s: %s", owner, err)
+	}
+
+	d.SetId(owner)
+	err = d.Set("token", token.Token)
+	if err != nil {
+		return err
+	}
+	err = d.Set("expires_at", token.ExpiresAt.Unix())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/github/data_source_github_actions_organization_remove_token_test.go
+++ b/github/data_source_github_actions_organization_remove_token_test.go
@@ -1,0 +1,49 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccGithubActionsOrganizationRemoveTokenDataSource(t *testing.T) {
+
+	t.Run("get an organization remove token without error", func(t *testing.T) {
+
+		config := `
+			data "github_actions_organization_remove_token" "test" {
+			}
+		`
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttrSet("data.github_actions_organization_remove_token.test", "token"),
+			resource.TestCheckResourceAttrSet("data.github_actions_organization_remove_token.test", "expires_at"),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
+}

--- a/github/data_source_github_actions_registration_token_test.go
+++ b/github/data_source_github_actions_registration_token_test.go
@@ -18,6 +18,7 @@ func TestAccGithubActionsRegistrationTokenDataSource(t *testing.T) {
 			resource "github_repository" "test" {
 			  name = "tf-acc-test-%[1]s"
 				auto_init = true
+				vulnerability_alerts = true
 			}
 
 			data "github_actions_registration_token" "test" {

--- a/github/data_source_github_actions_remove_token.go
+++ b/github/data_source_github_actions_remove_token.go
@@ -35,10 +35,10 @@ func dataSourceGithubActionsRemoveTokenRead(d *schema.ResourceData, meta interfa
 	owner := meta.(*Owner).name
 	repoName := d.Get("repository").(string)
 
-	log.Printf("[DEBUG] Creating a GitHub Actions repository registration token for %s/%s", owner, repoName)
-	token, _, err := client.Actions.CreateRegistrationToken(context.TODO(), owner, repoName)
+	log.Printf("[DEBUG] Creating a GitHub Actions repository remove token for %s/%s", owner, repoName)
+	token, _, err := client.Actions.CreateRemoveToken(context.TODO(), owner, repoName)
 	if err != nil {
-		return fmt.Errorf("error creating a GitHub Actions repository registration token for %s/%s: %s", owner, repoName, err)
+		return fmt.Errorf("error creating a GitHub Actions repository remove token for %s/%s: %s", owner, repoName, err)
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", owner, repoName))
@@ -49,9 +49,6 @@ func dataSourceGithubActionsRemoveTokenRead(d *schema.ResourceData, meta interfa
 	err = d.Set("expires_at", token.ExpiresAt.Unix())
 	if err != nil {
 		return err
-	}
-	if token.Token != nil {
-		log.Printf("tokenoutput: %s", *token.Token)
 	}
 
 	return nil

--- a/github/data_source_github_actions_remove_token.go
+++ b/github/data_source_github_actions_remove_token.go
@@ -1,0 +1,49 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceGithubActionsRemoveToken() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGithubActionsRemoveTokenRead,
+
+		Schema: map[string]*schema.Schema{
+			"token": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"expires_at": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceGithubActionsRemoveTokenRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
+
+	log.Printf("[DEBUG] Creating a GitHub Actions organization remove token for %s", owner)
+	token, _, err := client.Actions.CreateOrganizationRemoveToken(context.TODO(), owner)
+	if err != nil {
+		return fmt.Errorf("error creating a GitHub Actions organization remove token for %s: %s", owner, err)
+	}
+
+	d.SetId(owner)
+	err = d.Set("token", token.Token)
+	if err != nil {
+		return err
+	}
+	err = d.Set("expires_at", token.ExpiresAt.Unix())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/github/data_source_github_actions_remove_token_test.go
+++ b/github/data_source_github_actions_remove_token_test.go
@@ -1,0 +1,49 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccGithubActionsRemoveTokenDataSource(t *testing.T) {
+
+	t.Run("get an organization remove token without error", func(t *testing.T) {
+
+		config := `
+			data "github_actions_remove_token" "test" {
+			}
+		`
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttrSet("data.github_actions_remove_token.test", "token"),
+			resource.TestCheckResourceAttrSet("data.github_actions_remove_token.test", "expires_at"),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+
+	})
+}

--- a/github/data_source_github_actions_remove_token_test.go
+++ b/github/data_source_github_actions_remove_token_test.go
@@ -18,6 +18,7 @@ func TestAccGithubActionsRemoveTokenDataSource(t *testing.T) {
 			resource "github_repository" "test" {
 			  name = "tf-acc-test-%[1]s"
 				auto_init = true
+				vulnerability_alerts = true
 			}
 
 			data "github_actions_remove_token" "test" {

--- a/github/data_source_github_actions_remove_token_test.go
+++ b/github/data_source_github_actions_remove_token_test.go
@@ -1,21 +1,32 @@
 package github
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccGithubActionsRemoveTokenDataSource(t *testing.T) {
 
-	t.Run("get an organization remove token without error", func(t *testing.T) {
+	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
-		config := `
-			data "github_actions_remove_token" "test" {
+	t.Run("get a repository remove token without error", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+			  name = "tf-acc-test-%[1]s"
+				auto_init = true
 			}
-		`
+
+			data "github_actions_remove_token" "test" {
+				repository = github_repository.test.id
+			}
+		`, randomID)
 
 		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr("data.github_actions_remove_token.test", "repository", fmt.Sprintf("tf-acc-test-%s", randomID)),
 			resource.TestCheckResourceAttrSet("data.github_actions_remove_token.test", "token"),
 			resource.TestCheckResourceAttrSet("data.github_actions_remove_token.test", "expires_at"),
 		)

--- a/github/provider.go
+++ b/github/provider.go
@@ -203,7 +203,7 @@ func Provider() *schema.Provider {
 			"github_actions_organization_oidc_subject_claim_customization_template": dataSourceGithubActionsOrganizationOIDCSubjectClaimCustomizationTemplate(),
 			"github_actions_organization_public_key":                                dataSourceGithubActionsOrganizationPublicKey(),
 			"github_actions_organization_registration_token":                        dataSourceGithubActionsOrganizationRegistrationToken(),
-			"github_actions_organization_registration_tokens":                       dataSourceGithubActionsOrganizationRemoveToken(),
+			"github_actions_organization_remove_token":                              dataSourceGithubActionsOrganizationRemoveToken(),
 			"github_actions_organization_secrets":                                   dataSourceGithubActionsOrganizationSecrets(),
 			"github_actions_organization_variables":                                 dataSourceGithubActionsOrganizationVariables(),
 			"github_actions_public_key":                                             dataSourceGithubActionsPublicKey(),

--- a/github/provider.go
+++ b/github/provider.go
@@ -203,6 +203,7 @@ func Provider() *schema.Provider {
 			"github_actions_organization_oidc_subject_claim_customization_template": dataSourceGithubActionsOrganizationOIDCSubjectClaimCustomizationTemplate(),
 			"github_actions_organization_public_key":                                dataSourceGithubActionsOrganizationPublicKey(),
 			"github_actions_organization_registration_token":                        dataSourceGithubActionsOrganizationRegistrationToken(),
+			"github_actions_organization_registration_tokens":                       dataSourceGithubActionsOrganizationRemoveToken(),
 			"github_actions_organization_secrets":                                   dataSourceGithubActionsOrganizationSecrets(),
 			"github_actions_organization_variables":                                 dataSourceGithubActionsOrganizationVariables(),
 			"github_actions_public_key":                                             dataSourceGithubActionsPublicKey(),

--- a/github/provider.go
+++ b/github/provider.go
@@ -208,6 +208,7 @@ func Provider() *schema.Provider {
 			"github_actions_organization_variables":                                 dataSourceGithubActionsOrganizationVariables(),
 			"github_actions_public_key":                                             dataSourceGithubActionsPublicKey(),
 			"github_actions_registration_token":                                     dataSourceGithubActionsRegistrationToken(),
+			"github_actions_remove_token":                                           dataSourceGithubActionsRemoveToken(),
 			"github_actions_repository_oidc_subject_claim_customization_template":   dataSourceGithubActionsRepositoryOIDCSubjectClaimCustomizationTemplate(),
 			"github_actions_secrets":                                                dataSourceGithubActionsSecrets(),
 			"github_actions_variables":                                              dataSourceGithubActionsVariables(),

--- a/website/docs/d/actions_organization_remove_token.html.markdown
+++ b/website/docs/d/actions_organization_remove_token.html.markdown
@@ -5,7 +5,7 @@ description: |-
   Get a GitHub Actions organization remove token.
 ---
 
-# actions_regmove_token
+# actions_remove_token
 
 Use this data source to retrieve a GitHub Actions organization remove token. This token can then be used to remove a self-hosted runner.
 

--- a/website/docs/d/actions_organization_remove_token.html.markdown
+++ b/website/docs/d/actions_organization_remove_token.html.markdown
@@ -1,0 +1,24 @@
+---
+layout: "github"
+page_title: "GitHub: actions_organization_remove_token"
+description: |-
+  Get a GitHub Actions organization remove token.
+---
+
+# actions_regmove_token
+
+Use this data source to retrieve a GitHub Actions organization remove token. This token can then be used to register a self-hosted runner.
+
+## Example Usage
+
+```hcl
+data "github_actions_organization_remove_token" "example" {
+}
+```
+
+## Argument Reference
+
+## Attributes Reference
+
+ * `token` - The token that has been retrieved.
+ * `expires_at` - The token expiration date.

--- a/website/docs/d/actions_organization_remove_token.html.markdown
+++ b/website/docs/d/actions_organization_remove_token.html.markdown
@@ -7,7 +7,7 @@ description: |-
 
 # actions_regmove_token
 
-Use this data source to retrieve a GitHub Actions organization remove token. This token can then be used to register a self-hosted runner.
+Use this data source to retrieve a GitHub Actions organization remove token. This token can then be used to remove a self-hosted runner.
 
 ## Example Usage
 

--- a/website/docs/d/actions_remove_token.html.markdown
+++ b/website/docs/d/actions_remove_token.html.markdown
@@ -1,0 +1,27 @@
+---
+layout: "github"
+page_title: "GitHub: actions_remove_token"
+description: |-
+  Get a GitHub Actions repository registration token.
+---
+
+# actions_remove_token
+
+Use this data source to retrieve a GitHub Actions repository registration token. This token can then be used to register a self-hosted runner.
+
+## Example Usage
+
+```hcl
+data "github_actions_remove_token" "example" {
+  repository = "example_repo"
+}
+```
+
+## Argument Reference
+
+ * `repository` - (Required) Name of the repository to get a GitHub Actions registration token for.
+
+## Attributes Reference
+
+ * `token` - The token that has been retrieved.
+ * `expires_at` - The token expiration date.

--- a/website/docs/d/actions_remove_token.html.markdown
+++ b/website/docs/d/actions_remove_token.html.markdown
@@ -7,7 +7,7 @@ description: |-
 
 # actions_remove_token
 
-Use this data source to retrieve a GitHub Actions repository registration token. This token can then be used to register a self-hosted runner.
+Use this data source to retrieve a GitHub Actions repository registration token. This token can then be used to remove a self-hosted runner.
 
 ## Example Usage
 

--- a/website/docs/d/actions_remove_token.html.markdown
+++ b/website/docs/d/actions_remove_token.html.markdown
@@ -2,12 +2,12 @@
 layout: "github"
 page_title: "GitHub: actions_remove_token"
 description: |-
-  Get a GitHub Actions repository registration token.
+  Get a GitHub Actions repository remove token.
 ---
 
 # actions_remove_token
 
-Use this data source to retrieve a GitHub Actions repository registration token. This token can then be used to remove a self-hosted runner.
+Use this data source to retrieve a GitHub Actions repository remove token. This token can then be used to remove a self-hosted runner.
 
 ## Example Usage
 
@@ -19,7 +19,7 @@ data "github_actions_remove_token" "example" {
 
 ## Argument Reference
 
- * `repository` - (Required) Name of the repository to get a GitHub Actions registration token for.
+ * `repository` - (Required) Name of the repository to get a GitHub Actions remove token for.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2696

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Data source `github_actions_remove_token `didn't exist
* Data Source `github_actions_organization_remove_token `didn't exist
* Test for `github_actions_registration_token `does not work, because for new repo creation `vulnerability_alerts `is automatically activated, which is not reflected in tests, leading to immediate drift

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Data source `github_actions_remove_token `lets you create a self-hosted runner remove token at the repository level
* Data source `github_actions_organization_remove_token `lets you create a self-hosted runner remove token at the organization level
* Implemented tests for `github_actions_remove_token `and `github_actions_organization_remove_token `similar to tests for `github_actions_registration_token `and `github_actions_organization_registration_token`
* Fixed test for `github_actions_registration_token`, by registering of test repo with activated vulnerability alerts
* Added documentation similar to `github_actions_registration_token `and `github_actions_organization_registration_token`

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

