### PR TITLE
Allowing  parallel_requests to be set on github.com

### DIFF
--- a/github/provider.go
+++ b/github/provider.go
@@ -298,8 +298,8 @@ func init() {
 			"Defaults to 1000ms or 1s if not set, the max_retries must be set to greater than zero.",
 		"parallel_requests": "Allow the provider to make parallel API calls to GitHub. " +
 			"You may want to set it to true when you have a private Github Enterprise without strict rate limits. " +
-			"Although, it is not possible to enable this setting on github.com " +
-			"because we enforce the respect of github.com's best practices to avoid hitting abuse rate limits" +
+			"While it is possible to enable this setting on github.com, " +
+			"github.com's best practices recommend using serialization to avoid hitting abuse rate limits" +
 			"Defaults to false if not set",
 		"retryable_errors": "Allow the provider to retry after receiving an error status code, the max_retries should be set for this to work" +
 			"Defaults to [500, 502, 503, 504]",
@@ -427,9 +427,6 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 
 		parallelRequests := d.Get("parallel_requests").(bool)
 
-		if parallelRequests && isGithubDotCom {
-			return nil, wrapErrors([]error{fmt.Errorf("parallel_requests cannot be true when connecting to public github")})
-		}
 		log.Printf("[DEBUG] Setting parallel_requests to %t", parallelRequests)
 
 		config := Config{


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #567 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* `parallel_requests` was explicitly disabled on github.com

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* `parallel_requests` is no longer explicitly disabled on github.com

To [paraphrase](https://github.com/integrations/terraform-provider-github/issues/567#issuecomment-2993829965) the rationale behind the change
> With ~300 repositories, `parallel_requests = false` terraform plan -parallelism=30 68.65s user 23.16s system 19% cpu **7:46.27** total
> 
> With ~300 repositories, `parallel_requests = true` terraform plan -parallelism=30 44.51s user 14.47s system 105% cpu **55.640** total
> 
> With ~300 repositories, `parallel_requests = true`, lower parallelism terraform plan -parallelism=10 51.69s user 17.67s system 72% cpu **1:35.17** total
> 
> A significant reduction in plan time.
> 
> Of course, investigating the reason why it was implemented in such a manner, I've come across [#145](https://github.com/integrations/terraform-provider-github/pull/145) and the linked [official docs](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#dealing-with-abuse-rate-limits) that say the following:
> 
> ```
> To avoid exceeding secondary rate limits, you should make requests serially instead of concurrently. To achieve this, you can implement a queue system for requests.
> ```
> 
> That being said, given that it makes such a massive difference, and this recommendation is specifically about the REST API (**and a bunch of resources now interact with the GraphQL API instead which have more generous secondary rate limits**)
### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features) - **N/A**
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

