### PR TITLE
fix: improve error handling and define delete file options

### DIFF
--- a/github/resource_github_repository_file.go
+++ b/github/resource_github_repository_file.go
@@ -460,16 +460,9 @@ func resourceGithubRepositoryFileDelete(d *schema.ResourceData, meta interface{}
 
 	var branch string
 
-	message := fmt.Sprintf("Delete %s", file)
-
-	if commitMessage, hasCommitMessage := d.GetOk("commit_message"); hasCommitMessage {
-		message = commitMessage.(string)
-	}
-
-	sha := d.Get("sha").(string)
-	opts := &github.RepositoryContentFileOptions{
-		Message: &message,
-		SHA:     &sha,
+	opts, err := resourceGithubRepositoryFileOptions(d)
+	if err != nil {
+		return err
 	}
 
 	if b, ok := d.GetOk("branch"); ok {
@@ -503,9 +496,9 @@ func resourceGithubRepositoryFileDelete(d *schema.ResourceData, meta interface{}
 		opts.Branch = &branch
 	}
 
-	_, _, err := client.Repositories.DeleteFile(ctx, owner, repo, file, opts)
+	_, _, err = client.Repositories.DeleteFile(ctx, owner, repo, file, opts)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return nil

--- a/github/resource_github_repository_file.go
+++ b/github/resource_github_repository_file.go
@@ -465,6 +465,11 @@ func resourceGithubRepositoryFileDelete(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
+	if *opts.Message == fmt.Sprintf("Add %s", file) {
+		m := fmt.Sprintf("Delete %s", file)
+		opts.Message = &m
+	}
+
 	if b, ok := d.GetOk("branch"); ok {
 		log.Printf("[DEBUG] Using explicitly set branch: %s", b.(string))
 		if err := checkRepositoryBranchExists(client, owner, repo, b.(string)); err != nil {

--- a/github/resource_github_repository_file_test.go
+++ b/github/resource_github_repository_file_test.go
@@ -12,8 +12,6 @@ import (
 
 func TestAccGithubRepositoryFile(t *testing.T) {
 
-	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-
 	t.Run("creates and manages files", func(t *testing.T) {
 
 		config := fmt.Sprintf(`
@@ -33,7 +31,7 @@ func TestAccGithubRepositoryFile(t *testing.T) {
 				commit_author  = "Terraform User"
 				commit_email   = "terraform@example.com"
 			}
-		`, randomID)
+		`, acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum))
 		check := resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(
 				"github_repository_file.test", "content",
@@ -111,7 +109,7 @@ func TestAccGithubRepositoryFile(t *testing.T) {
 				commit_email        = "terraform@example.com"
 			}
 
-		`, randomID)
+		`, acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum))
 
 		check := resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(
@@ -202,7 +200,7 @@ func TestAccGithubRepositoryFile(t *testing.T) {
 				commit_author  = "Terraform User"
 				commit_email   = "terraform@example.com"
 			}
-		`, randomID)
+		`, acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum))
 
 		check := resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(
@@ -280,7 +278,7 @@ func TestAccGithubRepositoryFile(t *testing.T) {
 				commit_email      = "terraform@example.com"
 				autocreate_branch = false
 			}
-		`, randomID)
+		`, acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum))
 
 		check := resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2735

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* currently deleting `github_repository_file` fails silently
* when deleting`github_repository_file` then incomplete `RepositoryContentFileOptions` is passed to github sdk. This means that deletion commit is not signed and in case there is a ruleset requiring signed commits, this delete commit will fail silently
* currently when all tests are executed for `TestAccGithubRepositoryFile` they fail with duplicate repository name

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* deletion of `github_repository_file` no longer fails silently, but if there is an error, it is retruned
* proper `RepositoryContentFileOptions` is passed to sdk call to `DeleteFile` (same as for create and update methods). This way commits are signed
* each `TestAccGithubRepositoryFile` test execution creates new repository specific for given test

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

