### PR TITLE
Add support for 'exempt' github_repository_ruleset bypass_mode

### DIFF
--- a/github/resource_github_organization_ruleset.go
+++ b/github/resource_github_organization_ruleset.go
@@ -64,7 +64,7 @@ func resourceGithubOrganizationRuleset() *schema.Resource {
 						"bypass_mode": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"always", "pull_request"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"always", "pull_request", "exempt"}, false),
 							Description:  "When the specified actor can bypass the ruleset. pull_request means that an actor can only bypass rules on pull requests. Can be one of: `always`, `pull_request`.",
 						},
 					},

--- a/github/resource_github_repository_ruleset.go
+++ b/github/resource_github_repository_ruleset.go
@@ -69,7 +69,7 @@ func resourceGithubRepositoryRuleset() *schema.Resource {
 						"bypass_mode": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"always", "pull_request"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"always", "pull_request", "exempt"}, false),
 							Description:  "When the specified actor can bypass the ruleset. pull_request means that an actor can only bypass rules on pull requests. Can be one of: `always`, `pull_request`.",
 						},
 					}},


### PR DESCRIPTION

Resolves [#ISSUE_NUMBER](https://github.com/integrations/terraform-provider-github/issues/2755)

I'm not familiar with terraform provider development, so I'm not sure if there's anything else I'm missing, but this looked right to me.

----

### Before the change?

* Terraform provider was unable to create ruleset bypasses with bypass_mode exempt, which was [recently added to Github](https://github.blog/changelog/2025-09-10-github-ruleset-exemptions-and-repository-insights-updates/)

### After the change?

* bypass_mode exempt is now supported!

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No (I don't think so)

----

