### PR TITLE
Clarify repository description in webhook schema

### DIFF
--- a/github/resource_github_repository_webhook.go
+++ b/github/resource_github_repository_webhook.go
@@ -40,7 +40,7 @@ func resourceGithubRepositoryWebhook() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "The repository of the webhook.",
+				Description: "The repository name of the webhook, not including the organization, which will be inferred.",
 			},
 			"events": {
 				Type:        schema.TypeSet,


### PR DESCRIPTION
Updated the description for the repository field to clarify that it refers to the repository name only.
----

### Before the change?
Ambiguous documentation information.
<!-- Please describe the current behavior that you are modifying. -->

* 

### After the change?
Clarifies the underlying behaviour of the provider
<!-- Please describe the behavior or changes that are being added by this PR. -->

* 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

