### PR TITLE
Mark `repository` as required in `github_repository_ruleset`

### DIFF
--- a/github/resource_github_repository_ruleset.go
+++ b/github/resource_github_repository_ruleset.go
@@ -39,8 +39,8 @@ func resourceGithubRepositoryRuleset() *schema.Resource {
 			},
 			"repository": {
 				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Name of the repository to apply rulset to.",
+				Required:    true,
+				Description: "Name of the repository to apply ruleset to.",
 			},
 			"enforcement": {
 				Type:         schema.TypeString,

--- a/website/docs/r/repository_ruleset.html.markdown
+++ b/website/docs/r/repository_ruleset.html.markdown
@@ -64,11 +64,11 @@ resource "github_repository_ruleset" "example" {
 
 * `target` - (Required) (String) Possible values are `branch` and `tag`.
 
+* `repository` - (Required) (String) Name of the repository to apply ruleset to.
+
 * `bypass_actors` - (Optional) (Block List) The actors that can bypass the rules in this ruleset. (see [below for nested schema](#bypass_actors))
 
 * `conditions` - (Optional) (Block List, Max: 1) Parameters for a repository ruleset ref name condition. (see [below for nested schema](#conditions))
-
-* `repository` - (Optional) (String) Name of the repository to apply rulset to.
 
 #### Rules ####
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

GitHub API marks the [`repository` parameter as `required`](https://docs.github.com/en/rest/repos/rules?apiVersion=2022-11-28#create-a-repository-ruleset). Plus, not specifying it results in a malformed API request as the [SDK uses it to construct the URL](https://github.com/google/go-github/blob/233fe03e1797ce6115cd121312ce1bff2f258f4c/github/repos_rules.go#L106).

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Unspecified `repository` results in an API call to a non-existent endpoint - `https://api.github.com/repos/<owner>//rulesets`.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Unspecified `repository` should fail validation.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

