### PR TITLE
feat: github_organization_ruleset - support do_not_enforce_on_create for required workflows

### DIFF
--- a/github/resource_github_organization_ruleset.go
+++ b/github/resource_github_organization_ruleset.go
@@ -454,6 +454,12 @@ func resourceGithubOrganizationRuleset() *schema.Resource {
 											},
 										},
 									},
+									"do_not_enforce_on_create": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Default:     false,
+										Description: "Whether or not to allow repository and branch creation without the required workflows passing.",
+									},
 								},
 							},
 						},

--- a/github/resource_github_organization_ruleset_test.go
+++ b/github/resource_github_organization_ruleset_test.go
@@ -21,7 +21,6 @@ func TestGithubOrganizationRulesets(t *testing.T) {
 	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
 	t.Run("Creates and updates organization rulesets without errors", func(t *testing.T) {
-
 		config := fmt.Sprintf(`
 			resource "github_organization_ruleset" "test" {
 				name        = "test-%s"
@@ -63,6 +62,7 @@ func TestGithubOrganizationRulesets(t *testing.T) {
 					}
 
 					required_workflows {
+						do_not_enforce_on_create = true
 						required_workflow {
 							path          = "path/to/workflow.yaml"
 							repository_id = 1234
@@ -116,11 +116,9 @@ func TestGithubOrganizationRulesets(t *testing.T) {
 		t.Run("with an enterprise account", func(t *testing.T) {
 			testCase(t, enterprise)
 		})
-
 	})
 
 	t.Run("Updates a ruleset name without error", func(t *testing.T) {
-
 		oldRSName := fmt.Sprintf(`ruleset-%[1]s`, randomID)
 		newRSName := fmt.Sprintf(`%[1]s-renamed`, randomID)
 
@@ -175,11 +173,9 @@ func TestGithubOrganizationRulesets(t *testing.T) {
 		t.Run("with an enterprise account", func(t *testing.T) {
 			testCase(t, enterprise)
 		})
-
 	})
 
 	t.Run("Imports rulesets without error", func(t *testing.T) {
-
 		config := fmt.Sprintf(`
 			resource "github_organization_ruleset" "test" {
 				name        = "test-%s"
@@ -257,7 +253,5 @@ func TestGithubOrganizationRulesets(t *testing.T) {
 		t.Run("with an enterprise account", func(t *testing.T) {
 			testCase(t, enterprise)
 		})
-
 	})
-
 }

--- a/github/respository_rules_utils.go
+++ b/github/respository_rules_utils.go
@@ -374,8 +374,10 @@ func expandRules(input []interface{}, org bool) []*github.RepositoryRule {
 			}
 		}
 
+		doNotEnforceOnCreate := requiredWorkflowsMap["do_not_enforce_on_create"].(bool)
 		params := &github.RequiredWorkflowsRuleParameters{
-			RequiredWorkflows: requiredWorkflows,
+			DoNotEnforceOnCreate: doNotEnforceOnCreate,
+			RequiredWorkflows:    requiredWorkflows,
 		}
 		rulesSlice = append(rulesSlice, github.NewRequiredWorkflowsRule(params))
 	}

--- a/website/docs/r/organization_ruleset.html.markdown
+++ b/website/docs/r/organization_ruleset.html.markdown
@@ -165,6 +165,8 @@ The `rules` block supports the following:
 
 * `required_workflow` - (Required) (Block Set, Min: 1) Actions workflows that are required. Multiple can be defined. (see [below for nested schema](#rules.required_workflows.required_workflow))
 
+* `do_not_enforce_on_create` - (Optional) (Boolean) Whether or not to allow repository and branch creation without the required workflows passing.
+
 #### rules.required_workflows.required_workflow ####
 
 * `repository_id` - (Required) (Number) The ID of the repository. Names, full names and repository URLs are not supported.


### PR DESCRIPTION

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2771

----

### Before the change?
* Terraform provider does not support the `do_not_enforce_on_create` field for required workflows.

### After the change?
* Terraform provider supports the `do_not_enforce_on_create` field for required workflows.

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [X] No

----

