### PR TITLE
Updates makefile to handle missing the LC_UUID command and dydl errors when running make

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -24,11 +24,11 @@ lint:
 	golangci-lint run ./...
 
 test:
-	go test ./...
+	CGO_ENABLED=0 go test ./...
 	# commenting this out for release tooling, please run testacc instead
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
+	TF_ACC=1 CGO_ENABLED=0 go test $(TEST) -v $(TESTARGS) -timeout 120m
 
 test-compile:
 	@if [ "$(TEST)" = "./..." ]; then \
@@ -36,7 +36,7 @@ test-compile:
 		echo "  make test-compile TEST=./$(PKG_NAME)"; \
 		exit 1; \
 	fi
-	go test -c $(TEST) $(TESTARGS)
+	CGO_ENABLED=0 go test -c $(TEST) $(TESTARGS)
 
 vet:
 	@echo "go vet ."


### PR DESCRIPTION

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves https://github.com/integrations/terraform-provider-github/issues/2773

----

### Before the change?

Running tests using `make test` would fail

### After the change?

The tests no longer fail with a `dyld` error

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

