### PR TITLE
chore(Actions): Skip to run "Add issue to project" workflow on the forks

### DIFF
--- a/.github/workflows/add_to_octokit_project.yml
+++ b/.github/workflows/add_to_octokit_project.yml
@@ -11,6 +11,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     continue-on-error: true
+    if: ${{ github.repository == 'integrations/terraform-provider-github' }}
     steps:
       - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e #v1.0.2
         with:


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #INaN

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Workflow to add issue/PR to the project is unnecessarily  triggered on the forks 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* workflow  to add issue/PR to the project only runs on `integrations/terraform-provider-github` repository 

### Pull request checklist
- [ ] Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

