### PR TITLE
chore(actions): Adds labeler Action to automatically add labels on PR:s

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,56 @@
+# Configuration for labeler - https://github.com/actions/labeler
+"Type: Breaking change":
+  - head-branch: 
+    - '^breaking/'
+    - '^breaking-'
+
+"Type: Feature":
+  - head-branch: 
+    - '^feat/'
+    - '^feat-'
+    - '^feature/'
+    - '^feature-'
+
+"Type: Bug":
+  - head-branch: 
+    - '^fix/'
+    - '^fix-'
+    - '^bugfix/'
+    - '^bugfix-'
+    - '^bug/'
+    - '^bug-'
+
+"Deprecation":
+  - head-branch:
+    - '^deprecate/'
+    - '^deprecate-'
+    - '^deprecation/'
+    - '^deprecation-'
+
+"Type: Maintenance":
+  - head-branch: 
+    - '^chore/'
+    - '^chore-'
+    - '^maintenance/'
+    - '^maintenance-'
+    - '^maint/'
+    - '^maint-'
+    - '^deps/'
+    - '^deps-'
+    - '^dependencies/'
+    - '^dependencies-'
+  - changed-files:
+    - any-glob-to-any-file: 
+      - .github/workflows/**
+      - .github/labeler.yml
+      - .github/dependabot.yml
+      - .github/release.yml
+
+"Type: Documentation":
+  - head-branch:
+    - '^docs/'
+    - '^docs-'
+    - '^doc/'
+    - '^doc-'
+  - changed-files:
+    - any-glob-to-any-file: 'website/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: Pull Request Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write # Use this if all labels already exist in the repository (i.e., pre-defined in .github/labeler.yml).
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Labeler
+        uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
+        with:
+          sync-labels: true # Whether or not to remove labels when matching files are reverted or no longer changed by the PR


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2865

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- Prior to this change a lot manual work for maintainers to set labels to get well organised release notes

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- ✅ Adds GitHub Actions workflow that runs the [labeler action](https://github.com/actions/labeler) on PR events 
- ✅ Adds configuration file defining labeling rules based on branch names and file patterns. File adds labels based on chnaged files or/and based on names of the branches (we may introduce naming convention when we see it works well).

Config can be adjusted in the future according to our workflow.

**PS** Potentially could support labeling based on PR title https://github.com/actions/labeler/issues/55

### Pull request checklist
- [ ] Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

