### PR TITLE
chore(actions): Disable to run "Issue/PR response" workflow on forks

### DIFF
--- a/.github/workflows/immediate-response.yml
+++ b/.github/workflows/immediate-response.yml
@@ -11,7 +11,9 @@ on:
       - opened
 jobs:
   respond-to-issue:
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && github.actor != 'githubactions[bot]' && github.actor != 'octokitbot' }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && 
+      github.actor != 'githubactions[bot]' && github.actor != 'octokitbot' && 
+      github.repository == 'integrations/terraform-provider-github' }}
     runs-on: ubuntu-latest
     steps:
       - name: Determine issue or PR number


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2857

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* "Issue/PR response" workflow always runs on forks if not to disable it on Actions tab

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* ✅ Adds condition to run "Issue/PR response" workflow only on `integrations/terraform-provider-github` repository, but to skip run on forks

### Pull request checklist
- [ ] Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

