### PR TITLE
feat(actions_permissions): sha_pinning_required

### DIFF
--- a/github/resource_github_actions_organization_permissions.go
+++ b/github/resource_github_actions_organization_permissions.go
@@ -76,6 +76,12 @@ func resourceGithubActionsOrganizationPermissions() *schema.Resource {
 					},
 				},
 			},
+			"sha_pinning_required": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Whether pinning to a specific SHA is required for all actions and reusable workflows in an organization.",
+			},
 		},
 	}
 }
@@ -147,12 +153,18 @@ func resourceGithubActionsOrganizationPermissionsCreateOrUpdate(d *schema.Resour
 	allowedActions := d.Get("allowed_actions").(string)
 	enabledRepositories := d.Get("enabled_repositories").(string)
 
+	actionsPermissions := github.ActionsPermissions{
+		AllowedActions:      &allowedActions,
+		EnabledRepositories: &enabledRepositories,
+	}
+
+	if v, ok := d.GetOk("sha_pinning_required"); ok {
+		actionsPermissions.SHAPinningRequired = github.Ptr(v.(bool))
+	}
+
 	_, _, err = client.Actions.UpdateActionsPermissions(ctx,
 		orgName,
-		github.ActionsPermissions{
-			AllowedActions:      &allowedActions,
-			EnabledRepositories: &enabledRepositories,
-		})
+		actionsPermissions)
 	if err != nil {
 		return err
 	}
@@ -277,6 +289,10 @@ func resourceGithubActionsOrganizationPermissionsRead(d *schema.ResourceData, me
 		return err
 	}
 	if err = d.Set("enabled_repositories", actionsPermissions.GetEnabledRepositories()); err != nil {
+		return err
+	}
+
+	if err = d.Set("sha_pinning_required", actionsPermissions.GetSHAPinningRequired()); err != nil {
 		return err
 	}
 

--- a/github/resource_github_actions_organization_permissions_test.go
+++ b/github/resource_github_actions_organization_permissions_test.go
@@ -46,6 +46,7 @@ func TestAccGithubActionsOrganizationPermissions(t *testing.T) {
 		enabledRepositories := "selected"
 		githubOwnedAllowed := true
 		verifiedAllowed := true
+		shaPinningRequired := true
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		repoName := fmt.Sprintf("%srepo-act-org-perm-%s", testResourcePrefix, randomID)
 
@@ -64,11 +65,12 @@ func TestAccGithubActionsOrganizationPermissions(t *testing.T) {
 					patterns_allowed     = ["actions/cache@*", "actions/checkout@*"]
 					verified_allowed     = %t
 				}
+				sha_pinning_required = %t
 				enabled_repositories_config {
 					repository_ids       = [github_repository.test.repo_id]
 				}
 			}
-		`, repoName, allowedActions, enabledRepositories, githubOwnedAllowed, verifiedAllowed)
+		`, repoName, allowedActions, enabledRepositories, githubOwnedAllowed, verifiedAllowed, shaPinningRequired)
 
 		check := resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(

--- a/github/resource_github_actions_repository_permissions.go
+++ b/github/resource_github_actions_repository_permissions.go
@@ -65,6 +65,12 @@ func resourceGithubActionsRepositoryPermissions() *schema.Resource {
 				Description:      "The GitHub repository.",
 				ValidateDiagFunc: toDiagFunc(validation.StringLenBetween(1, 100), "repository"),
 			},
+			"sha_pinning_required": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Whether pinning to a specific SHA is required for all actions and reusable workflows in a repository.",
+			},
 		},
 	}
 }
@@ -123,6 +129,10 @@ func resourceGithubActionsRepositoryPermissionsCreateOrUpdate(d *schema.Resource
 	// Only specify `allowed_actions` if actions are enabled
 	if enabled {
 		repoActionPermissions.AllowedActions = &allowedActions
+	}
+
+	if v, ok := d.GetOk("sha_pinning_required"); ok {
+		repoActionPermissions.SHAPinningRequired = github.Ptr(v.(bool))
 	}
 
 	_, _, err := client.Repositories.UpdateActionsPermissions(ctx,
@@ -207,6 +217,10 @@ func resourceGithubActionsRepositoryPermissionsRead(d *schema.ResourceData, meta
 		return err
 	}
 	if err = d.Set("repository", repoName); err != nil {
+		return err
+	}
+
+	if err = d.Set("sha_pinning_required", actionsPermissions.GetSHAPinningRequired()); err != nil {
 		return err
 	}
 

--- a/github/resource_github_actions_repository_permissions_test.go
+++ b/github/resource_github_actions_repository_permissions_test.go
@@ -49,6 +49,7 @@ func TestAccGithubActionsRepositoryPermissions(t *testing.T) {
 		allowedActions := "selected"
 		githubOwnedAllowed := true
 		verifiedAllowed := true
+		shaPinningRequired := true
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		repoName := fmt.Sprintf("%srepo-act-perms-%s", testResourcePrefix, randomID)
 
@@ -66,9 +67,10 @@ func TestAccGithubActionsRepositoryPermissions(t *testing.T) {
 					patterns_allowed     = ["actions/cache@*", "actions/checkout@*"]
 					verified_allowed     = %t
 				}
+				sha_pinning_required = %t
 				repository = github_repository.test.name
 			}
-		`, repoName, allowedActions, githubOwnedAllowed, verifiedAllowed)
+		`, repoName, allowedActions, githubOwnedAllowed, verifiedAllowed, shaPinningRequired)
 
 		check := resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

~Wait until https://github.com/google/go-github/pull/3807 is being included in the next release.~

Resolves #2869.

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The `sha_pinning_required` option for actions permissions is not supported.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The `sha_pinning_required` option actions permissions is supported.

### Pull request checklist
- [x] Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))
- [x] Tests for the changes have been added (for bug fixes / features)

<details>

<summary id="plain-text-output">See plain-text output from `make test` command.</summary>

```console
$ export TF_ACC=1
$
$ make test
==> Running unit tests on branch: [1m🌿 feat/actions_permissions_sha_pinning_required 🌿[0m...
CGO_ENABLED=0 go test ./github/... \
	-timeout=30s \
	-parallel=4 \
	-v \
	-skip '^TestAcc' \
	  \
	-count 1;
=== RUN   TestGenerateAppJWT
    apps_test.go:33: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjMwMCwiaWF0IjotNjAsImlzcyI6IjEyMzQ1Njc4OSJ9.OG05IsTgDUaTeTHrgw2BAKMMjgIIjR5Ql-O2bWSST1eRgVWJN-ZnU5MiqYYGIh99PCKySJYNtq4B4IDL7L8qltJnL6LG8M0kbk8COdHAK6EIlBzcOiMNhBAzQeHaeO82cMFJviEmzl1wA_Xlc9KaaaNdqIIeifk5NbR9Pyfe3yY
=== RUN   TestGenerateAppJWT/produces_a_properly_shaped_jwt
=== RUN   TestGenerateAppJWT/produces_a_jwt_with_expected_algorithm_and_type
=== RUN   TestGenerateAppJWT/produces_a_jwt_with_expected_claims
=== RUN   TestGenerateAppJWT/produces_a_verifiable_jwt
--- PASS: TestGenerateAppJWT (0.00s)
    --- PASS: TestGenerateAppJWT/produces_a_properly_shaped_jwt (0.00s)
    --- PASS: TestGenerateAppJWT/produces_a_jwt_with_expected_algorithm_and_type (0.00s)
    --- PASS: TestGenerateAppJWT/produces_a_jwt_with_expected_claims (0.00s)
    --- PASS: TestGenerateAppJWT/produces_a_verifiable_jwt (0.00s)
=== RUN   TestGetInstallationAccessToken
2026/01/21 14:30:41 [DEBUG] Mock server received POST request to "/app/installations/987654321/access_tokens"; headers:
map[Accept:[application/vnd.github.v3+json] Accept-Encoding:[gzip] Authorization:[Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIxMjM0NTY3ODkiLCJhdWQiOiIiLCJleHAiOjMwMCwiaWF0IjotNjB9.jpx6AFGoZzHzre79JveY_nyKop11v-bLxLEMvEDrn2wDF9S1FeX-zfTiA6Xi00Akn0Wklj7OYx0wHCvi37aiD4zjp0qPz5i5V7aMrRsWsO6eCzNfY0VLuV6pX8jlAHFfo71SvpdAMWH4in8ty5bNVUMv0NmwWdlHAQ0LLIPSxE4] Content-Length:[0] User-Agent:[Go-http-client/1.1]]
request body: ""
--- PASS: TestGetInstallationAccessToken (0.00s)
=== RUN   Test_getBaseURL
=== RUN   Test_getBaseURL/dotcom
=== PAUSE Test_getBaseURL/dotcom
=== RUN   Test_getBaseURL/dotcom_no_trailing_slash
=== PAUSE Test_getBaseURL/dotcom_no_trailing_slash
=== RUN   Test_getBaseURL/dotcom_ui
=== PAUSE Test_getBaseURL/dotcom_ui
=== RUN   Test_getBaseURL/dotcom_http_errors
=== PAUSE Test_getBaseURL/dotcom_http_errors
=== RUN   Test_getBaseURL/dotcom_with_path_errors
=== PAUSE Test_getBaseURL/dotcom_with_path_errors
=== RUN   Test_getBaseURL/ghec
=== PAUSE Test_getBaseURL/ghec
=== RUN   Test_getBaseURL/ghec_no_trailing_slash
=== PAUSE Test_getBaseURL/ghec_no_trailing_slash
=== RUN   Test_getBaseURL/ghec_ui
=== PAUSE Test_getBaseURL/ghec_ui
=== RUN   Test_getBaseURL/ghec_http_errors
=== PAUSE Test_getBaseURL/ghec_http_errors
=== RUN   Test_getBaseURL/ghec_with_path_errors
=== PAUSE Test_getBaseURL/ghec_with_path_errors
=== RUN   Test_getBaseURL/ghes
=== PAUSE Test_getBaseURL/ghes
=== RUN   Test_getBaseURL/ghes_no_trailing_slash
=== PAUSE Test_getBaseURL/ghes_no_trailing_slash
=== RUN   Test_getBaseURL/ghes_with_path_prefix
=== PAUSE Test_getBaseURL/ghes_with_path_prefix
=== RUN   Test_getBaseURL/empty_url_returns_dotcom
=== PAUSE Test_getBaseURL/empty_url_returns_dotcom
=== RUN   Test_getBaseURL/not_absolute_url_errors
=== PAUSE Test_getBaseURL/not_absolute_url_errors
=== RUN   Test_getBaseURL/invalid_url_errors
=== PAUSE Test_getBaseURL/invalid_url_errors
=== CONT  Test_getBaseURL/dotcom
=== CONT  Test_getBaseURL/invalid_url_errors
=== CONT  Test_getBaseURL/not_absolute_url_errors
=== CONT  Test_getBaseURL/ghec_no_trailing_slash
=== CONT  Test_getBaseURL/empty_url_returns_dotcom
=== CONT  Test_getBaseURL/ghec
=== CONT  Test_getBaseURL/dotcom_http_errors
=== CONT  Test_getBaseURL/ghec_ui
=== CONT  Test_getBaseURL/ghes
=== CONT  Test_getBaseURL/dotcom_no_trailing_slash
=== CONT  Test_getBaseURL/ghes_with_path_prefix
=== CONT  Test_getBaseURL/ghec_with_path_errors
=== CONT  Test_getBaseURL/ghes_no_trailing_slash
=== CONT  Test_getBaseURL/dotcom_ui
=== CONT  Test_getBaseURL/dotcom_with_path_errors
=== CONT  Test_getBaseURL/ghec_http_errors
--- PASS: Test_getBaseURL (0.00s)
    --- PASS: Test_getBaseURL/dotcom (0.00s)
    --- PASS: Test_getBaseURL/invalid_url_errors (0.00s)
    --- PASS: Test_getBaseURL/not_absolute_url_errors (0.00s)
    --- PASS: Test_getBaseURL/ghec_no_trailing_slash (0.00s)
    --- PASS: Test_getBaseURL/empty_url_returns_dotcom (0.00s)
    --- PASS: Test_getBaseURL/ghec (0.00s)
    --- PASS: Test_getBaseURL/ghec_ui (0.00s)
    --- PASS: Test_getBaseURL/dotcom_http_errors (0.00s)
    --- PASS: Test_getBaseURL/ghes (0.00s)
    --- PASS: Test_getBaseURL/dotcom_no_trailing_slash (0.00s)
    --- PASS: Test_getBaseURL/ghes_with_path_prefix (0.00s)
    --- PASS: Test_getBaseURL/ghec_with_path_errors (0.00s)
    --- PASS: Test_getBaseURL/ghes_no_trailing_slash (0.00s)
    --- PASS: Test_getBaseURL/dotcom_ui (0.00s)
    --- PASS: Test_getBaseURL/dotcom_with_path_errors (0.00s)
    --- PASS: Test_getBaseURL/ghec_http_errors (0.00s)
=== RUN   TestProvider
=== RUN   TestProvider/runs_internal_validation_without_error
=== RUN   TestProvider/has_an_implementation
--- PASS: TestProvider (0.00s)
    --- PASS: TestProvider/runs_internal_validation_without_error (0.00s)
    --- PASS: TestProvider/has_an_implementation (0.00s)
=== RUN   TestGithubActionsOrganizationSecretDriftDetectionFix
=== RUN   TestGithubActionsOrganizationSecretDriftDetectionFix/always_updates_timestamp_regardless_of_drift_detection
=== RUN   TestGithubActionsOrganizationSecretDriftDetectionFix/does_not_clear_ID_when_destroy_on_drift_is_false
--- PASS: TestGithubActionsOrganizationSecretDriftDetectionFix (0.00s)
    --- PASS: TestGithubActionsOrganizationSecretDriftDetectionFix/always_updates_timestamp_regardless_of_drift_detection (0.00s)
    --- PASS: TestGithubActionsOrganizationSecretDriftDetectionFix/does_not_clear_ID_when_destroy_on_drift_is_false (0.00s)
=== RUN   TestGithub_MigrateActionsOrganizationSecretStateV0toV1
=== RUN   TestGithub_MigrateActionsOrganizationSecretStateV0toV1/without_destroy_on_drift
2026/01/21 14:30:41 [DEBUG] GitHub Actions Organization Secret Attributes before migration: map[string]interface {}{"created_at":"2023-01-01T00:00:00Z", "id":"test-secret", "plaintext_value":"secret-value", "secret_name":"test-secret", "updated_at":"2023-01-01T00:00:00Z", "visibility":"private"}
2026/01/21 14:30:41 [DEBUG] GitHub Actions Organization Secret Attributes after migration: map[string]interface {}{"created_at":"2023-01-01T00:00:00Z", "destroy_on_drift":true, "id":"test-secret", "plaintext_value":"secret-value", "secret_name":"test-secret", "updated_at":"2023-01-01T00:00:00Z", "visibility":"private"}
=== RUN   TestGithub_MigrateActionsOrganizationSecretStateV0toV1/with_destroy_on_drift
2026/01/21 14:30:41 [DEBUG] GitHub Actions Organization Secret Attributes before migration: map[string]interface {}{"created_at":"2023-01-01T00:00:00Z", "destroy_on_drift":false, "id":"test-secret", "plaintext_value":"secret-value", "secret_name":"test-secret", "updated_at":"2023-01-01T00:00:00Z", "visibility":"private"}
2026/01/21 14:30:41 [DEBUG] GitHub Actions Organization Secret Attributes after migration: map[string]interface {}{"created_at":"2023-01-01T00:00:00Z", "destroy_on_drift":false, "id":"test-secret", "plaintext_value":"secret-value", "secret_name":"test-secret", "updated_at":"2023-01-01T00:00:00Z", "visibility":"private"}
--- PASS: TestGithub_MigrateActionsOrganizationSecretStateV0toV1 (0.00s)
    --- PASS: TestGithub_MigrateActionsOrganizationSecretStateV0toV1/without_destroy_on_drift (0.00s)
    --- PASS: TestGithub_MigrateActionsOrganizationSecretStateV0toV1/with_destroy_on_drift (0.00s)
=== RUN   TestGithubActionsOrganizationSecret_DestroyOnDrift
=== RUN   TestGithubActionsOrganizationSecret_DestroyOnDrift/destroyOnDrift_false_clears_sensitive_values_instead_of_recreating
=== RUN   TestGithubActionsOrganizationSecret_DestroyOnDrift/destroyOnDrift_true_still_recreates_resource_on_drift
=== RUN   TestGithubActionsOrganizationSecret_DestroyOnDrift/destroy_on_drift_field_defaults
=== RUN   TestGithubActionsOrganizationSecret_DestroyOnDrift/default_destroy_on_drift_is_true
--- PASS: TestGithubActionsOrganizationSecret_DestroyOnDrift (0.00s)
    --- PASS: TestGithubActionsOrganizationSecret_DestroyOnDrift/destroyOnDrift_false_clears_sensitive_values_instead_of_recreating (0.00s)
    --- PASS: TestGithubActionsOrganizationSecret_DestroyOnDrift/destroyOnDrift_true_still_recreates_resource_on_drift (0.00s)
    --- PASS: TestGithubActionsOrganizationSecret_DestroyOnDrift/destroy_on_drift_field_defaults (0.00s)
    --- PASS: TestGithubActionsOrganizationSecret_DestroyOnDrift/default_destroy_on_drift_is_true (0.00s)
=== RUN   TestGithub_MigrateActionsSecretStateV0toV1
=== RUN   TestGithub_MigrateActionsSecretStateV0toV1/without_destroy_on_drift
2026/01/21 14:30:41 [DEBUG] GitHub Actions Secret State before migration: map[string]interface {}{"created_at":"2023-01-01T00:00:00Z", "id":"test-secret", "plaintext_value":"secret-value", "repository":"test-repo", "secret_name":"test-secret", "updated_at":"2023-01-01T00:00:00Z"}
2026/01/21 14:30:41 [DEBUG] GitHub Actions Secret State after migration: map[string]interface {}{"created_at":"2023-01-01T00:00:00Z", "destroy_on_drift":true, "id":"test-secret", "plaintext_value":"secret-value", "repository":"test-repo", "secret_name":"test-secret", "updated_at":"2023-01-01T00:00:00Z"}
=== RUN   TestGithub_MigrateActionsSecretStateV0toV1/with_destroy_on_drift
2026/01/21 14:30:41 [DEBUG] GitHub Actions Secret State before migration: map[string]interface {}{"created_at":"2023-01-01T00:00:00Z", "destroy_on_drift":false, "id":"test-secret", "plaintext_value":"secret-value", "repository":"test-repo", "secret_name":"test-secret", "updated_at":"2023-01-01T00:00:00Z"}
2026/01/21 14:30:41 [DEBUG] GitHub Actions Secret State after migration: map[string]interface {}{"created_at":"2023-01-01T00:00:00Z", "destroy_on_drift":false, "id":"test-secret", "plaintext_value":"secret-value", "repository":"test-repo", "secret_name":"test-secret", "updated_at":"2023-01-01T00:00:00Z"}
--- PASS: TestGithub_MigrateActionsSecretStateV0toV1 (0.00s)
    --- PASS: TestGithub_MigrateActionsSecretStateV0toV1/without_destroy_on_drift (0.00s)
    --- PASS: TestGithub_MigrateActionsSecretStateV0toV1/with_destroy_on_drift (0.00s)
=== RUN   TestGithubActionsSecretDriftDetection
=== RUN   TestGithubActionsSecretDriftDetection/destroyOnDrift_true_causes_recreation_on_timestamp_mismatch
=== RUN   TestGithubActionsSecretDriftDetection/destroyOnDrift_false_clears_sensitive_values_instead_of_recreating
=== RUN   TestGithubActionsSecretDriftDetection/destroyOnDrift_true_still_recreates_resource_on_drift
=== RUN   TestGithubActionsSecretDriftDetection/destroyOnDrift_true_still_recreates_resource_on_drift#01
=== RUN   TestGithubActionsSecretDriftDetection/default_destroy_on_drift_is_true
=== RUN   TestGithubActionsSecretDriftDetection/no_drift_when_timestamps_match
=== RUN   TestGithubActionsSecretDriftDetection/destroy_on_drift_field_defaults
=== RUN   TestGithubActionsSecretDriftDetection/destroy_on_drift_field_properties
--- PASS: TestGithubActionsSecretDriftDetection (0.00s)
    --- PASS: TestGithubActionsSecretDriftDetection/destroyOnDrift_true_causes_recreation_on_timestamp_mismatch (0.00s)
    --- PASS: TestGithubActionsSecretDriftDetection/destroyOnDrift_false_clears_sensitive_values_instead_of_recreating (0.00s)
    --- PASS: TestGithubActionsSecretDriftDetection/destroyOnDrift_true_still_recreates_resource_on_drift (0.00s)
    --- PASS: TestGithubActionsSecretDriftDetection/destroyOnDrift_true_still_recreates_resource_on_drift#01 (0.00s)
    --- PASS: TestGithubActionsSecretDriftDetection/default_destroy_on_drift_is_true (0.00s)
    --- PASS: TestGithubActionsSecretDriftDetection/no_drift_when_timestamps_match (0.00s)
    --- PASS: TestGithubActionsSecretDriftDetection/destroy_on_drift_field_defaults (0.00s)
    --- PASS: TestGithubActionsSecretDriftDetection/destroy_on_drift_field_properties (0.00s)
=== RUN   TestGithubActionsSecretIssue964Solution
=== RUN   TestGithubActionsSecretIssue964Solution/solve_issue_964_-_prevent_recreation_when_GUI_changes_secret
    resource_github_actions_secret_test.go:557: SUCCESS: Issue #964 solved - secret with destroy_on_drift=false does not get recreated on external changes
--- PASS: TestGithubActionsSecretIssue964Solution (0.00s)
    --- PASS: TestGithubActionsSecretIssue964Solution/solve_issue_964_-_prevent_recreation_when_GUI_changes_secret (0.00s)
=== RUN   TestResourceGithubActionsSecretValidation
--- PASS: TestResourceGithubActionsSecretValidation (0.00s)
=== RUN   TestGithubBranchIsUpdatedWhenBranchChanges
--- PASS: TestGithubBranchIsUpdatedWhenBranchChanges (0.00s)
=== RUN   TestGithubBranchIsRecreatedWhenRepositoryChanges
--- PASS: TestGithubBranchIsRecreatedWhenRepositoryChanges (0.00s)
=== RUN   TestGithubBranchIsRecreatedWhenSourceBranchChanges
--- PASS: TestGithubBranchIsRecreatedWhenSourceBranchChanges (0.00s)
=== RUN   TestGithubBranchIsRecreatedWhenSourceSHAChanges
--- PASS: TestGithubBranchIsRecreatedWhenSourceSHAChanges (0.00s)
=== RUN   TestIsSAMLEnforcementError
=== RUN   TestIsSAMLEnforcementError/nil_error
=== RUN   TestIsSAMLEnforcementError/GitHub_ErrorResponse_with_SAML_enforcement
=== RUN   TestIsSAMLEnforcementError/GitHub_ErrorResponse_403_without_SAML_message
=== RUN   TestIsSAMLEnforcementError/GitHub_ErrorResponse_404
=== RUN   TestIsSAMLEnforcementError/plain_error_with_SAML_enforcement_message
=== RUN   TestIsSAMLEnforcementError/plain_error_without_SAML_message
--- PASS: TestIsSAMLEnforcementError (0.00s)
    --- PASS: TestIsSAMLEnforcementError/nil_error (0.00s)
    --- PASS: TestIsSAMLEnforcementError/GitHub_ErrorResponse_with_SAML_enforcement (0.00s)
    --- PASS: TestIsSAMLEnforcementError/GitHub_ErrorResponse_403_without_SAML_message (0.00s)
    --- PASS: TestIsSAMLEnforcementError/GitHub_ErrorResponse_404 (0.00s)
    --- PASS: TestIsSAMLEnforcementError/plain_error_with_SAML_enforcement_message (0.00s)
    --- PASS: TestIsSAMLEnforcementError/plain_error_without_SAML_message (0.00s)
=== RUN   TestEtagDiffSuppressFunction
=== RUN   TestEtagDiffSuppressFunction/different_etag_values
=== RUN   TestEtagDiffSuppressFunction/empty_to_non-empty_etag
=== RUN   TestEtagDiffSuppressFunction/non-empty_to_empty_etag
=== RUN   TestEtagDiffSuppressFunction/same_etag_values
--- PASS: TestEtagDiffSuppressFunction (0.00s)
    --- PASS: TestEtagDiffSuppressFunction/different_etag_values (0.00s)
    --- PASS: TestEtagDiffSuppressFunction/empty_to_non-empty_etag (0.00s)
    --- PASS: TestEtagDiffSuppressFunction/non-empty_to_empty_etag (0.00s)
    --- PASS: TestEtagDiffSuppressFunction/same_etag_values (0.00s)
=== RUN   TestEtagSchemaConsistency
=== RUN   TestEtagSchemaConsistency/github_branch_default
=== RUN   TestEtagSchemaConsistency/github_issue_label
=== RUN   TestEtagSchemaConsistency/github_repository_webhook
=== RUN   TestEtagSchemaConsistency/github_repository_deployment_branch_policy
=== RUN   TestEtagSchemaConsistency/github_repository_project
=== RUN   TestEtagSchemaConsistency/github_repository
=== RUN   TestEtagSchemaConsistency/github_branch
--- PASS: TestEtagSchemaConsistency (0.00s)
    --- PASS: TestEtagSchemaConsistency/github_branch_default (0.00s)
    --- PASS: TestEtagSchemaConsistency/github_issue_label (0.00s)
    --- PASS: TestEtagSchemaConsistency/github_repository_webhook (0.00s)
    --- PASS: TestEtagSchemaConsistency/github_repository_deployment_branch_policy (0.00s)
    --- PASS: TestEtagSchemaConsistency/github_repository_project (0.00s)
    --- PASS: TestEtagSchemaConsistency/github_repository (0.00s)
    --- PASS: TestEtagSchemaConsistency/github_branch (0.00s)
=== RUN   TestOrganizationPushRulesetSupport
--- PASS: TestOrganizationPushRulesetSupport (0.00s)
=== RUN   TestGithub_MigrateOrganizationWebhookStateV0toV1
=== RUN   TestGithub_MigrateOrganizationWebhookStateV0toV1/migrates_state_without_errors
2026/01/21 14:30:41 [DEBUG] GitHub Organization Webhook State before migration: map[string]interface {}{"configuration.%":"4", "configuration.content_type":"form", "configuration.insecure_ssl":"0", "configuration.secret":"blablah", "configuration.url":"https://google.co.uk/"}
2026/01/21 14:30:41 [DEBUG] GitHub Organization Webhook State after migration: map[string]interface {}{"configuration.#":"1", "configuration.0.content_type":"form", "configuration.0.insecure_ssl":"0", "configuration.0.secret":"blablah", "configuration.0.url":"https://google.co.uk/"}
--- PASS: TestGithub_MigrateOrganizationWebhookStateV0toV1 (0.00s)
    --- PASS: TestGithub_MigrateOrganizationWebhookStateV0toV1/migrates_state_without_errors (0.00s)
=== RUN   TestParseRepoName
=== RUN   TestParseRepoName/Repo_name_without_owner
=== RUN   TestParseRepoName/Repo_name_with_owner
--- PASS: TestParseRepoName (0.00s)
    --- PASS: TestParseRepoName/Repo_name_without_owner (0.00s)
    --- PASS: TestParseRepoName/Repo_name_with_owner (0.00s)
=== RUN   TestSuppressDeployKeyDiff
--- PASS: TestSuppressDeployKeyDiff (0.00s)
=== RUN   TestGithub_MigrateRepositoryStateV0toV1
=== RUN   TestGithub_MigrateRepositoryStateV0toV1/migrates_state_without_errors
2026/01/21 14:30:41 [DEBUG] GitHub Repository State before migration: map[string]interface {}{"branches.#":"1", "branches.0.name":"foobar", "branches.0.protected":"false"}
2026/01/21 14:30:41 [DEBUG] GitHub Repository State after migration: map[string]interface {}{}
--- PASS: TestGithub_MigrateRepositoryStateV0toV1 (0.00s)
    --- PASS: TestGithub_MigrateRepositoryStateV0toV1/migrates_state_without_errors (0.00s)
=== RUN   Test_expandPages
=== RUN   Test_expandPages/expand_Pages_configuration_with_workflow
=== RUN   Test_expandPages/expand_Pages_configuration_with_source
--- PASS: Test_expandPages (0.00s)
    --- PASS: Test_expandPages/expand_Pages_configuration_with_workflow (0.00s)
    --- PASS: Test_expandPages/expand_Pages_configuration_with_source (0.00s)
=== RUN   TestGithubRepositoryTopicPassesValidation
--- PASS: TestGithubRepositoryTopicPassesValidation (0.00s)
=== RUN   TestGithubRepositoryTopicFailsValidationWhenOverMaxCharacters
--- PASS: TestGithubRepositoryTopicFailsValidationWhenOverMaxCharacters (0.00s)
=== RUN   TestResourceGithubParseFullName
--- PASS: TestResourceGithubParseFullName (0.00s)
=== RUN   TestGithubRepositoryNameFailsValidationWhenOverMaxCharacters
--- PASS: TestGithubRepositoryNameFailsValidationWhenOverMaxCharacters (0.00s)
=== RUN   TestGithubRepositoryNameFailsValidationWithSpace
--- PASS: TestGithubRepositoryNameFailsValidationWithSpace (0.00s)
=== RUN   TestGithub_MigrateRepositoryWebhookStateV0toV1
=== RUN   TestGithub_MigrateRepositoryWebhookStateV0toV1/migrates_state_without_errors
2026/01/21 14:30:41 [DEBUG] GitHub Repository Webhook State before migration: map[string]interface {}{"configuration.%":"4", "configuration.content_type":"form", "configuration.insecure_ssl":"0", "configuration.secret":"blablah", "configuration.url":"https://google.co.uk/"}
2026/01/21 14:30:41 [DEBUG] GitHub Repository Webhook State after migration: map[string]interface {}{"configuration.#":"1", "configuration.0.content_type":"form", "configuration.0.insecure_ssl":"0", "configuration.0.secret":"blablah", "configuration.0.url":"https://google.co.uk/"}
--- PASS: TestGithub_MigrateRepositoryWebhookStateV0toV1 (0.00s)
    --- PASS: TestGithub_MigrateRepositoryWebhookStateV0toV1/migrates_state_without_errors (0.00s)
=== RUN   TestEtagTransport
2026/01/21 14:30:41 [DEBUG] Mock server received GET request to "/repos/test/blah"; headers:
map[Accept:[application/vnd.github.scarlet-witch-preview+json, application/vnd.github.mercy-preview+json, application/vnd.github.baptiste-preview+json, application/vnd.github.nebula-preview+json] Accept-Encoding:[gzip] If-None-Match:[something] User-Agent:[go-github/v81.0.0] X-Github-Api-Version:[2022-11-28]]
request body: ""
--- PASS: TestEtagTransport (0.00s)
=== RUN   TestRateLimitTransport_abuseLimit_get
2026/01/21 14:30:41 [DEBUG] Mock server received GET request to "/repos/test/blah"; headers:
map[Accept:[application/vnd.github.scarlet-witch-preview+json, application/vnd.github.mercy-preview+json, application/vnd.github.baptiste-preview+json, application/vnd.github.nebula-preview+json] Accept-Encoding:[gzip] User-Agent:[go-github/v81.0.0] X-Github-Api-Version:[2022-11-28]]
request body: ""
2026/01/21 14:30:41 [WARN] Abuse detection mechanism triggered, sleeping for 0s before retrying
2026/01/21 14:30:41 [DEBUG] Mock server received GET request to "/repos/test/blah"; headers:
map[Accept:[application/vnd.github.scarlet-witch-preview+json, application/vnd.github.mercy-preview+json, application/vnd.github.baptiste-preview+json, application/vnd.github.nebula-preview+json] Accept-Encoding:[gzip] User-Agent:[go-github/v81.0.0] X-Github-Api-Version:[2022-11-28]]
request body: ""
2026/01/21 14:30:41 [WARN] Abuse detection mechanism triggered, sleeping for 0s before retrying
2026/01/21 14:30:41 [DEBUG] Mock server received GET request to "/repos/test/blah"; headers:
map[Accept:[application/vnd.github.scarlet-witch-preview+json, application/vnd.github.mercy-preview+json, application/vnd.github.baptiste-preview+json, application/vnd.github.nebula-preview+json] Accept-Encoding:[gzip] User-Agent:[go-github/v81.0.0] X-Github-Api-Version:[2022-11-28]]
request body: ""
--- PASS: TestRateLimitTransport_abuseLimit_get (0.00s)
=== RUN   TestRateLimitTransport_abuseLimit_get_cancelled
2026/01/21 14:30:41 [DEBUG] Mock server received GET request to "/repos/test/blah"; headers:
map[Accept:[application/vnd.github.scarlet-witch-preview+json, application/vnd.github.mercy-preview+json, application/vnd.github.baptiste-preview+json, application/vnd.github.nebula-preview+json] Accept-Encoding:[gzip] User-Agent:[go-github/v81.0.0] X-Github-Api-Version:[2022-11-28]]
request body: ""
2026/01/21 14:30:41 [WARN] Abuse detection mechanism triggered, sleeping for 10s before retrying
--- PASS: TestRateLimitTransport_abuseLimit_get_cancelled (0.10s)
=== RUN   TestRateLimitTransport_abuseLimit_post
2026/01/21 14:30:41 [DEBUG] Mock server received POST request to "/orgs/tada/repos"; headers:
map[Accept:[application/vnd.github.baptiste-preview+json, application/vnd.github.nebula-preview+json] Accept-Encoding:[gzip] Content-Length:[45] Content-Type:[application/json] User-Agent:[go-github/v81.0.0] X-Github-Api-Version:[2022-11-28]]
request body: "{\"name\":\"radek-example-48\",\"description\":\"\"}\n"
2026/01/21 14:30:41 [WARN] Abuse detection mechanism triggered, sleeping for 0s before retrying
2026/01/21 14:30:41 [DEBUG] Mock server received POST request to "/orgs/tada/repos"; headers:
map[Accept:[application/vnd.github.baptiste-preview+json, application/vnd.github.nebula-preview+json] Accept-Encoding:[gzip] Content-Length:[45] Content-Type:[application/json] User-Agent:[go-github/v81.0.0] X-Github-Api-Version:[2022-11-28]]
request body: "{\"name\":\"radek-example-48\",\"description\":\"\"}\n"
--- PASS: TestRateLimitTransport_abuseLimit_post (0.00s)
=== RUN   TestRateLimitTransport_abuseLimit_post_error
2026/01/21 14:30:41 [DEBUG] Mock server received POST request to "/orgs/tada/repos"; headers:
map[Accept:[application/vnd.github.baptiste-preview+json, application/vnd.github.nebula-preview+json] Accept-Encoding:[gzip] Content-Length:[45] Content-Type:[application/json] User-Agent:[go-github/v81.0.0] X-Github-Api-Version:[2022-11-28]]
request body: "{\"name\":\"radek-example-48\",\"description\":\"\"}\n"
2026/01/21 14:30:41 [WARN] Abuse detection mechanism triggered, sleeping for 0s before retrying
2026/01/21 14:30:41 [DEBUG] Mock server received POST request to "/orgs/tada/repos"; headers:
map[Accept:[application/vnd.github.baptiste-preview+json, application/vnd.github.nebula-preview+json] Accept-Encoding:[gzip] Content-Length:[45] Content-Type:[application/json] User-Agent:[go-github/v81.0.0] X-Github-Api-Version:[2022-11-28]]
request body: "{\"name\":\"radek-example-48\",\"description\":\"\"}\n"
--- PASS: TestRateLimitTransport_abuseLimit_post_error (0.00s)
=== RUN   TestRateLimitTransport_smart_lock
=== RUN   TestRateLimitTransport_smart_lock/With_parallelRequests_true_it_does_not_lock_the_rate_limit_transport
=== RUN   TestRateLimitTransport_smart_lock/With_parallelRequests_true_it_should_not_unlock_the_rate_limit_transport
=== RUN   TestRateLimitTransport_smart_lock/With_parallelRequests_false_with_a_lock_present_it_should_get_stuck_waiting
=== RUN   TestRateLimitTransport_smart_lock/With_parallelRequests_false_and_a_lock_present_it_should_be_able_to_unlock_the_rate_limit_transport
--- PASS: TestRateLimitTransport_smart_lock (0.10s)
    --- PASS: TestRateLimitTransport_smart_lock/With_parallelRequests_true_it_does_not_lock_the_rate_limit_transport (0.00s)
    --- PASS: TestRateLimitTransport_smart_lock/With_parallelRequests_true_it_should_not_unlock_the_rate_limit_transport (0.00s)
    --- PASS: TestRateLimitTransport_smart_lock/With_parallelRequests_false_with_a_lock_present_it_should_get_stuck_waiting (0.10s)
    --- PASS: TestRateLimitTransport_smart_lock/With_parallelRequests_false_and_a_lock_present_it_should_be_able_to_unlock_the_rate_limit_transport (0.00s)
=== RUN   TestRetryTransport_retry_post_error
2026/01/21 14:30:42 [DEBUG] Mock server received POST request to "/orgs/tada/repos"; headers:
map[Accept:[application/vnd.github.baptiste-preview+json, application/vnd.github.nebula-preview+json] Accept-Encoding:[gzip] Content-Length:[45] Content-Type:[application/json] User-Agent:[go-github/v81.0.0] X-Github-Api-Version:[2022-11-28]]
request body: "{\"name\":\"radek-example-48\",\"description\":\"\"}\n"
2026/01/21 14:30:43 [DEBUG] Mock server received POST request to "/orgs/tada/repos"; headers:
map[Accept:[application/vnd.github.baptiste-preview+json, application/vnd.github.nebula-preview+json] Accept-Encoding:[gzip] Content-Length:[45] Content-Type:[application/json] User-Agent:[go-github/v81.0.0] X-Github-Api-Version:[2022-11-28]]
request body: "{\"name\":\"radek-example-48\",\"description\":\"\"}\n"
--- PASS: TestRetryTransport_retry_post_error (2.00s)
=== RUN   TestRetryTransport_retry_post_success
2026/01/21 14:30:44 [DEBUG] Mock server received POST request to "/orgs/tada/repos"; headers:
map[Accept:[application/vnd.github.baptiste-preview+json, application/vnd.github.nebula-preview+json] Accept-Encoding:[gzip] Content-Length:[45] Content-Type:[application/json] User-Agent:[go-github/v81.0.0] X-Github-Api-Version:[2022-11-28]]
request body: "{\"name\":\"radek-example-48\",\"description\":\"\"}\n"
2026/01/21 14:30:45 [DEBUG] Mock server received POST request to "/orgs/tada/repos"; headers:
map[Accept:[application/vnd.github.baptiste-preview+json, application/vnd.github.nebula-preview+json] Accept-Encoding:[gzip] Content-Length:[45] Content-Type:[application/json] User-Agent:[go-github/v81.0.0] X-Github-Api-Version:[2022-11-28]]
request body: "{\"name\":\"radek-example-48\",\"description\":\"\"}\n"
2026/01/21 14:30:46 [DEBUG] Mock server received POST request to "/orgs/tada/repos"; headers:
map[Accept:[application/vnd.github.baptiste-preview+json, application/vnd.github.nebula-preview+json] Accept-Encoding:[gzip] Content-Length:[45] Content-Type:[application/json] User-Agent:[go-github/v81.0.0] X-Github-Api-Version:[2022-11-28]]
request body: "{\"name\":\"radek-example-48\",\"description\":\"\"}\n"
--- PASS: TestRetryTransport_retry_post_success (2.00s)
=== RUN   TestExpandRulesBasicRules
--- PASS: TestExpandRulesBasicRules (0.00s)
=== RUN   TestFlattenRulesBasicRules
--- PASS: TestFlattenRulesBasicRules (0.00s)
=== RUN   TestExpandRulesMaxFilePathLength
--- PASS: TestExpandRulesMaxFilePathLength (0.00s)
=== RUN   TestFlattenRulesMaxFilePathLength
--- PASS: TestFlattenRulesMaxFilePathLength (0.00s)
=== RUN   TestRoundTripMaxFilePathLength
--- PASS: TestRoundTripMaxFilePathLength (0.00s)
=== RUN   TestExpandRulesMaxFileSize
--- PASS: TestExpandRulesMaxFileSize (0.00s)
=== RUN   TestFlattenRulesMaxFileSize
--- PASS: TestFlattenRulesMaxFileSize (0.00s)
=== RUN   TestExpandRulesFileExtensionRestriction
--- PASS: TestExpandRulesFileExtensionRestriction (0.00s)
=== RUN   TestFlattenRulesFileExtensionRestriction
--- PASS: TestFlattenRulesFileExtensionRestriction (0.00s)
=== RUN   TestCompletePushRulesetSupport
--- PASS: TestCompletePushRulesetSupport (0.00s)
=== RUN   TestCopilotCodeReviewRoundTrip
--- PASS: TestCopilotCodeReviewRoundTrip (0.00s)
=== RUN   Test_escapeIDPart
=== PAUSE Test_escapeIDPart
=== RUN   Test_unescapeIDPart
=== PAUSE Test_unescapeIDPart
=== RUN   Test_buildID
=== PAUSE Test_buildID
=== RUN   Test_parseID
=== PAUSE Test_parseID
=== RUN   Test_parseID2
=== PAUSE Test_parseID2
=== RUN   Test_parseID3
=== PAUSE Test_parseID3
=== RUN   TestGithubUtilRole_validation
--- PASS: TestGithubUtilRole_validation (0.00s)
=== RUN   TestGithubUtilTwoPartID
--- PASS: TestGithubUtilTwoPartID (0.00s)
=== RUN   TestGithubUtilValidateSecretName
--- PASS: TestGithubUtilValidateSecretName (0.00s)
=== RUN   TestGetRepositoryIDPositiveMatches
    util_v4_repository_test.go:183: Got expected error in testrepo8: Could not resolve to a node with the global id of 'testrepo8'Could not resolve to a Repository with the name 'testowner/testrepo8'.
    util_v4_repository_test.go:183: Got expected error in R_NOPE: Could not resolve to a node with the global id of 'testrepo8'Could not resolve to a Repository with the name 'testowner/testrepo8'.
    util_v4_repository_test.go:183: Got expected error in RkFJTCBIRVJFCg==: Could not resolve to a node with the global id of 'testrepo8'Could not resolve to a Repository with the name 'testowner/testrepo8'.
--- PASS: TestGetRepositoryIDPositiveMatches (0.00s)
=== CONT  Test_escapeIDPart
=== RUN   Test_escapeIDPart/no_separator
=== CONT  Test_parseID
=== CONT  Test_unescapeIDPart
=== PAUSE Test_escapeIDPart/no_separator
=== RUN   Test_unescapeIDPart/no_escaped_separator
=== RUN   Test_escapeIDPart/with_separator
=== PAUSE Test_unescapeIDPart/no_escaped_separator
=== PAUSE Test_escapeIDPart/with_separator
=== RUN   Test_escapeIDPart/multiple_separators
=== CONT  Test_buildID
=== RUN   Test_buildID/one_part
=== RUN   Test_unescapeIDPart/with_escaped_separator
=== RUN   Test_parseID/two_parts_expected_two
=== PAUSE Test_parseID/two_parts_expected_two
=== RUN   Test_parseID/three_parts_expected_three
=== PAUSE Test_parseID/three_parts_expected_three
=== RUN   Test_parseID/two_parts_expected_three
=== PAUSE Test_escapeIDPart/multiple_separators
=== PAUSE Test_parseID/two_parts_expected_three
=== RUN   Test_parseID/three_parts_expected_two
=== CONT  Test_parseID2
=== PAUSE Test_parseID/three_parts_expected_two
=== PAUSE Test_buildID/one_part
=== RUN   Test_buildID/two_parts
=== RUN   Test_parseID/empty_id
=== PAUSE Test_buildID/two_parts
=== RUN   Test_buildID/three_parts
=== PAUSE Test_buildID/three_parts
=== PAUSE Test_unescapeIDPart/with_escaped_separator
=== RUN   Test_buildID/part_with_unescaped_separator
=== RUN   Test_unescapeIDPart/multiple_escaped_separators
=== PAUSE Test_buildID/part_with_unescaped_separator
=== RUN   Test_parseID2/valid_two_parts
=== PAUSE Test_parseID2/valid_two_parts
=== PAUSE Test_parseID/empty_id
=== RUN   Test_parseID2/invalid_three_parts
=== PAUSE Test_unescapeIDPart/multiple_escaped_separators
=== CONT  Test_parseID3
=== PAUSE Test_parseID2/invalid_three_parts
=== RUN   Test_parseID3/valid_three_parts
=== RUN   Test_buildID/no_parts
=== PAUSE Test_buildID/no_parts
=== PAUSE Test_parseID3/valid_three_parts
=== CONT  Test_escapeIDPart/multiple_separators
=== RUN   Test_parseID3/invalid_two_parts
=== PAUSE Test_parseID3/invalid_two_parts
=== RUN   Test_parseID3/invalid_four_parts
=== CONT  Test_escapeIDPart/with_separator
=== CONT  Test_parseID/two_parts_expected_two
=== CONT  Test_escapeIDPart/no_separator
=== RUN   Test_parseID2/invalid_one_part
=== PAUSE Test_parseID2/invalid_one_part
=== PAUSE Test_parseID3/invalid_four_parts
=== CONT  Test_parseID/three_parts_expected_two
=== CONT  Test_unescapeIDPart/no_escaped_separator
=== CONT  Test_unescapeIDPart/multiple_escaped_separators
--- PASS: Test_escapeIDPart (0.00s)
    --- PASS: Test_escapeIDPart/multiple_separators (0.00s)
    --- PASS: Test_escapeIDPart/with_separator (0.00s)
    --- PASS: Test_escapeIDPart/no_separator (0.00s)
=== CONT  Test_parseID/empty_id
=== CONT  Test_buildID/one_part
=== CONT  Test_parseID/two_parts_expected_three
=== CONT  Test_buildID/part_with_unescaped_separator
=== CONT  Test_buildID/no_parts
=== CONT  Test_buildID/three_parts
=== CONT  Test_parseID2/valid_two_parts
=== CONT  Test_parseID/three_parts_expected_three
--- PASS: Test_parseID (0.00s)
    --- PASS: Test_parseID/two_parts_expected_two (0.00s)
    --- PASS: Test_parseID/three_parts_expected_two (0.00s)
    --- PASS: Test_parseID/empty_id (0.00s)
    --- PASS: Test_parseID/two_parts_expected_three (0.00s)
    --- PASS: Test_parseID/three_parts_expected_three (0.00s)
=== CONT  Test_parseID2/invalid_three_parts
=== CONT  Test_unescapeIDPart/with_escaped_separator
=== CONT  Test_parseID2/invalid_one_part
--- PASS: Test_unescapeIDPart (0.00s)
    --- PASS: Test_unescapeIDPart/no_escaped_separator (0.00s)
    --- PASS: Test_unescapeIDPart/multiple_escaped_separators (0.00s)
    --- PASS: Test_unescapeIDPart/with_escaped_separator (0.00s)
=== CONT  Test_parseID3/invalid_two_parts
--- PASS: Test_parseID2 (0.00s)
    --- PASS: Test_parseID2/valid_two_parts (0.00s)
    --- PASS: Test_parseID2/invalid_three_parts (0.00s)
    --- PASS: Test_parseID2/invalid_one_part (0.00s)
=== CONT  Test_parseID3/valid_three_parts
=== CONT  Test_buildID/two_parts
--- PASS: Test_buildID (0.00s)
    --- PASS: Test_buildID/one_part (0.00s)
    --- PASS: Test_buildID/part_with_unescaped_separator (0.00s)
    --- PASS: Test_buildID/no_parts (0.00s)
    --- PASS: Test_buildID/three_parts (0.00s)
    --- PASS: Test_buildID/two_parts (0.00s)
=== CONT  Test_parseID3/invalid_four_parts
--- PASS: Test_parseID3 (0.00s)
    --- PASS: Test_parseID3/invalid_two_parts (0.00s)
    --- PASS: Test_parseID3/valid_three_parts (0.00s)
    --- PASS: Test_parseID3/invalid_four_parts (0.00s)
PASS
ok  	github.com/integrations/terraform-provider-github/v6/github	4.738s
$
$ make testacc
==> Running acceptance tests on branch: [1m🌿 feat/actions_permissions_sha_pinning_required 🌿[0m...
TF_ACC=1 CGO_ENABLED=0 go test ./github/... -v -run '^TestAcc'   -timeout 120m -count=1
=== RUN   TestAccConfigMeta
=== RUN   TestAccConfigMeta/returns_an_anonymous_client_for_the_v3_REST_API
=== RUN   TestAccConfigMeta/returns_a_v3_REST_API_client_to_manage_individual_resources
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccConfigMeta/returns_a_v3_REST_API_client_with_max_retries
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccConfigMeta/returns_a_v4_GraphQL_API_client_to_manage_individual_resources
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccConfigMeta/returns_a_v3_REST_API_client_to_manage_organization_resources
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccConfigMeta/returns_a_v4_GraphQL_API_client_to_manage_organization_resources
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccConfigMeta (0.27s)
    --- PASS: TestAccConfigMeta/returns_an_anonymous_client_for_the_v3_REST_API (0.27s)
    --- SKIP: TestAccConfigMeta/returns_a_v3_REST_API_client_to_manage_individual_resources (0.00s)
    --- SKIP: TestAccConfigMeta/returns_a_v3_REST_API_client_with_max_retries (0.00s)
    --- SKIP: TestAccConfigMeta/returns_a_v4_GraphQL_API_client_to_manage_individual_resources (0.00s)
    --- SKIP: TestAccConfigMeta/returns_a_v3_REST_API_client_to_manage_organization_resources (0.00s)
    --- SKIP: TestAccConfigMeta/returns_a_v4_GraphQL_API_client_to_manage_organization_resources (0.00s)
=== RUN   TestAccGithubActionsEnvironmentPublicKeyDataSource
=== RUN   TestAccGithubActionsEnvironmentPublicKeyDataSource/queries_a_repository_environment_public_key_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubActionsEnvironmentPublicKeyDataSource (0.00s)
    --- SKIP: TestAccGithubActionsEnvironmentPublicKeyDataSource/queries_a_repository_environment_public_key_without_error (0.00s)
=== RUN   TestAccGithubActionsEnvironmentSecretsDataSource
=== RUN   TestAccGithubActionsEnvironmentSecretsDataSource/queries_actions_secrets_from_an_environment
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubActionsEnvironmentSecretsDataSource (0.00s)
    --- SKIP: TestAccGithubActionsEnvironmentSecretsDataSource/queries_actions_secrets_from_an_environment (0.00s)
=== RUN   TestAccGithubActionsEnvironmentVariablesDataSource
=== RUN   TestAccGithubActionsEnvironmentVariablesDataSource/queries_actions_variables_from_an_environment
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubActionsEnvironmentVariablesDataSource (0.00s)
    --- SKIP: TestAccGithubActionsEnvironmentVariablesDataSource/queries_actions_variables_from_an_environment (0.00s)
=== RUN   TestAccGithubActionsOrganizationOIDCSubjectClaimCustomizationTemplateDataSource
=== RUN   TestAccGithubActionsOrganizationOIDCSubjectClaimCustomizationTemplateDataSource/get_an_organization_oidc_subject_claim_customization_template_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubActionsOrganizationOIDCSubjectClaimCustomizationTemplateDataSource (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationOIDCSubjectClaimCustomizationTemplateDataSource/get_an_organization_oidc_subject_claim_customization_template_without_error (0.00s)
=== RUN   TestAccGithubActionsOrganizationPublicKeyDataSource
=== RUN   TestAccGithubActionsOrganizationPublicKeyDataSource/queries_an_organization_public_key_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubActionsOrganizationPublicKeyDataSource (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationPublicKeyDataSource/queries_an_organization_public_key_without_error (0.00s)
=== RUN   TestAccGithubActionsOrganizationRegistrationTokenDataSource
=== RUN   TestAccGithubActionsOrganizationRegistrationTokenDataSource/get_an_organization_registration_token_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubActionsOrganizationRegistrationTokenDataSource (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationRegistrationTokenDataSource/get_an_organization_registration_token_without_error (0.00s)
=== RUN   TestAccGithubActionsOrganizationSecretsDataSource
=== RUN   TestAccGithubActionsOrganizationSecretsDataSource/queries_organization_actions_secrets_from_a_repository
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubActionsOrganizationSecretsDataSource (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationSecretsDataSource/queries_organization_actions_secrets_from_a_repository (0.00s)
=== RUN   TestAccGithubActionsOrganizationVariablesDataSource
=== RUN   TestAccGithubActionsOrganizationVariablesDataSource/queries_actions_variables_from_an_organization
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubActionsOrganizationVariablesDataSource (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationVariablesDataSource/queries_actions_variables_from_an_organization (0.00s)
=== RUN   TestAccGithubActionsPublicKeyDataSource
=== RUN   TestAccGithubActionsPublicKeyDataSource/queries_a_repository_public_key_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubActionsPublicKeyDataSource (0.00s)
    --- SKIP: TestAccGithubActionsPublicKeyDataSource/queries_a_repository_public_key_without_error (0.00s)
=== RUN   TestAccGithubActionsRegistrationTokenDataSource
=== RUN   TestAccGithubActionsRegistrationTokenDataSource/get_a_repository_registration_token_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubActionsRegistrationTokenDataSource (0.00s)
    --- SKIP: TestAccGithubActionsRegistrationTokenDataSource/get_a_repository_registration_token_without_error (0.00s)
=== RUN   TestAccGithubActionsRepositoryOIDCSubjectClaimCustomizationTemplateDataSource
=== RUN   TestAccGithubActionsRepositoryOIDCSubjectClaimCustomizationTemplateDataSource/get_an_repository_oidc_subject_claim_customization_template_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubActionsRepositoryOIDCSubjectClaimCustomizationTemplateDataSource (0.00s)
    --- SKIP: TestAccGithubActionsRepositoryOIDCSubjectClaimCustomizationTemplateDataSource/get_an_repository_oidc_subject_claim_customization_template_without_error (0.00s)
=== RUN   TestAccGithubActionsSecretsDataSource
=== RUN   TestAccGithubActionsSecretsDataSource/queries_actions_secrets_from_a_repository
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubActionsSecretsDataSource (0.00s)
    --- SKIP: TestAccGithubActionsSecretsDataSource/queries_actions_secrets_from_a_repository (0.00s)
=== RUN   TestAccGithubActionsVariablesDataSource
=== RUN   TestAccGithubActionsVariablesDataSource/queries_actions_variables_from_a_repository
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubActionsVariablesDataSource (0.00s)
    --- SKIP: TestAccGithubActionsVariablesDataSource/queries_actions_variables_from_a_repository (0.00s)
=== RUN   TestAccGithubAppDataSource
=== RUN   TestAccGithubAppDataSource/queries_a_global_app
--- PASS: TestAccGithubAppDataSource (4.26s)
    --- PASS: TestAccGithubAppDataSource/queries_a_global_app (4.26s)
=== RUN   TestAccGithubAppTokenDataSource
=== RUN   TestAccGithubAppTokenDataSource/creates_a_application_token_without_error
--- PASS: TestAccGithubAppTokenDataSource (0.00s)
    --- PASS: TestAccGithubAppTokenDataSource/creates_a_application_token_without_error (0.00s)
=== RUN   TestAccGithubBranchProtectionRulesDataSource
=== RUN   TestAccGithubBranchProtectionRulesDataSource/queries_branch_protection_rules_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubBranchProtectionRulesDataSource/queries_branch_protection
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubBranchProtectionRulesDataSource (0.00s)
    --- SKIP: TestAccGithubBranchProtectionRulesDataSource/queries_branch_protection_rules_without_error (0.00s)
    --- SKIP: TestAccGithubBranchProtectionRulesDataSource/queries_branch_protection (0.00s)
=== RUN   TestAccGithubBranchDataSource
=== RUN   TestAccGithubBranchDataSource/queries_an_existing_branch_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubBranchDataSource (0.00s)
    --- SKIP: TestAccGithubBranchDataSource/queries_an_existing_branch_without_error (0.00s)
=== RUN   TestAccGithubCodespacesOrganizationPublicKeyDataSource
=== RUN   TestAccGithubCodespacesOrganizationPublicKeyDataSource/queries_an_organization_public_key_without_error
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
--- PASS: TestAccGithubCodespacesOrganizationPublicKeyDataSource (0.00s)
    --- SKIP: TestAccGithubCodespacesOrganizationPublicKeyDataSource/queries_an_organization_public_key_without_error (0.00s)
=== RUN   TestAccGithubCodespacesOrganizationSecretsDataSource
=== RUN   TestAccGithubCodespacesOrganizationSecretsDataSource/queries_organization_codespaces_secrets_from_a_repository
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
--- PASS: TestAccGithubCodespacesOrganizationSecretsDataSource (0.00s)
    --- SKIP: TestAccGithubCodespacesOrganizationSecretsDataSource/queries_organization_codespaces_secrets_from_a_repository (0.00s)
=== RUN   TestAccGithubCodespacesPublicKeyDataSource
=== RUN   TestAccGithubCodespacesPublicKeyDataSource/queries_a_repository_public_key_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubCodespacesPublicKeyDataSource (0.00s)
    --- SKIP: TestAccGithubCodespacesPublicKeyDataSource/queries_a_repository_public_key_without_error (0.00s)
=== RUN   TestAccGithubCodespacesSecretsDataSource
=== RUN   TestAccGithubCodespacesSecretsDataSource/queries_codespaces_secrets_from_a_repository
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubCodespacesSecretsDataSource (0.00s)
    --- SKIP: TestAccGithubCodespacesSecretsDataSource/queries_codespaces_secrets_from_a_repository (0.00s)
=== RUN   TestAccGithubCodespacesUserPublicKeyDataSource
=== RUN   TestAccGithubCodespacesUserPublicKeyDataSource/queries_an_user_public_key_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubCodespacesUserPublicKeyDataSource (0.00s)
    --- SKIP: TestAccGithubCodespacesUserPublicKeyDataSource/queries_an_user_public_key_without_error (0.00s)
=== RUN   TestAccGithubCodespacesUserSecretsDataSource
=== RUN   TestAccGithubCodespacesUserSecretsDataSource/queries_user_codespaces_secrets_from_a_repository
    acc_test.go:297: Skipping as not supported test mode
--- PASS: TestAccGithubCodespacesUserSecretsDataSource (0.00s)
    --- SKIP: TestAccGithubCodespacesUserSecretsDataSource/queries_user_codespaces_secrets_from_a_repository (0.00s)
=== RUN   TestAccGithubCollaboratorsDataSource
=== RUN   TestAccGithubCollaboratorsDataSource/gets_all_collaborators
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubCollaboratorsDataSource/gets_admin_collaborators
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubCollaboratorsDataSource (0.00s)
    --- SKIP: TestAccGithubCollaboratorsDataSource/gets_all_collaborators (0.00s)
    --- SKIP: TestAccGithubCollaboratorsDataSource/gets_admin_collaborators (0.00s)
=== RUN   TestAccGithubDependabotOrganizationPublicKeyDataSource
=== RUN   TestAccGithubDependabotOrganizationPublicKeyDataSource/queries_an_organization_public_key_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubDependabotOrganizationPublicKeyDataSource (0.00s)
    --- SKIP: TestAccGithubDependabotOrganizationPublicKeyDataSource/queries_an_organization_public_key_without_error (0.00s)
=== RUN   TestAccGithubDependabotOrganizationSecretsDataSource
=== RUN   TestAccGithubDependabotOrganizationSecretsDataSource/queries_organization_dependabot_secrets_from_a_repository
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubDependabotOrganizationSecretsDataSource (0.00s)
    --- SKIP: TestAccGithubDependabotOrganizationSecretsDataSource/queries_organization_dependabot_secrets_from_a_repository (0.00s)
=== RUN   TestAccGithubDependabotPublicKeyDataSource
=== RUN   TestAccGithubDependabotPublicKeyDataSource/queries_a_repository_public_key_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubDependabotPublicKeyDataSource (0.00s)
    --- SKIP: TestAccGithubDependabotPublicKeyDataSource/queries_a_repository_public_key_without_error (0.00s)
=== RUN   TestAccGithubDependabotSecretsDataSource
=== RUN   TestAccGithubDependabotSecretsDataSource/queries_dependabot_secrets_from_a_repository
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubDependabotSecretsDataSource (0.00s)
    --- SKIP: TestAccGithubDependabotSecretsDataSource/queries_dependabot_secrets_from_a_repository (0.00s)
=== RUN   TestAccGithubEnterpriseDataSource
    acc_test.go:297: Skipping as not supported test mode
--- SKIP: TestAccGithubEnterpriseDataSource (0.00s)
=== RUN   TestAccGithubIpRangesDataSource
=== RUN   TestAccGithubIpRangesDataSource/reads_IP_ranges_without_error
--- PASS: TestAccGithubIpRangesDataSource (5.24s)
    --- PASS: TestAccGithubIpRangesDataSource/reads_IP_ranges_without_error (5.24s)
=== RUN   TestAccGithubIssueLabelsDataSource
=== RUN   TestAccGithubIssueLabelsDataSource/queries_the_labels_for_a_repository
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubIssueLabelsDataSource (0.00s)
    --- SKIP: TestAccGithubIssueLabelsDataSource/queries_the_labels_for_a_repository (0.00s)
=== RUN   TestAccGithubMembershipDataSource
    data_source_github_membership_test.go:13: No org user provided
--- SKIP: TestAccGithubMembershipDataSource (0.00s)
=== RUN   TestAccGithubOrganizationCustomRoleDataSource
=== RUN   TestAccGithubOrganizationCustomRoleDataSource/queries_a_custom_repo_role
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
--- PASS: TestAccGithubOrganizationCustomRoleDataSource (0.00s)
    --- SKIP: TestAccGithubOrganizationCustomRoleDataSource/queries_a_custom_repo_role (0.00s)
=== RUN   TestAccGithubOrganizationExternalIdentities
=== RUN   TestAccGithubOrganizationExternalIdentities/queries_without_error
    acc_test.go:297: Skipping as not supported test mode
--- PASS: TestAccGithubOrganizationExternalIdentities (0.00s)
    --- SKIP: TestAccGithubOrganizationExternalIdentities/queries_without_error (0.00s)
=== RUN   TestAccGithubOrganizationIpAllowListDataSource
=== RUN   TestAccGithubOrganizationIpAllowListDataSource/queries_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubOrganizationIpAllowListDataSource (0.00s)
    --- SKIP: TestAccGithubOrganizationIpAllowListDataSource/queries_without_error (0.00s)
=== RUN   TestAccGithubOrganizationRepositoryRoleDataSource
=== RUN   TestAccGithubOrganizationRepositoryRoleDataSource/queries_an_organization_repository_role
    acc_test.go:297: Skipping as not supported test mode
--- PASS: TestAccGithubOrganizationRepositoryRoleDataSource (0.00s)
    --- SKIP: TestAccGithubOrganizationRepositoryRoleDataSource/queries_an_organization_repository_role (0.00s)
=== RUN   TestAccDataSourceGithubOrganizationRepositoryRoles
=== RUN   TestAccDataSourceGithubOrganizationRepositoryRoles/get_empty_organization_roles_without_error
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
=== RUN   TestAccDataSourceGithubOrganizationRepositoryRoles/get_organization_roles_without_error
    acc_test.go:297: Skipping as not supported test mode
--- PASS: TestAccDataSourceGithubOrganizationRepositoryRoles (0.00s)
    --- SKIP: TestAccDataSourceGithubOrganizationRepositoryRoles/get_empty_organization_roles_without_error (0.00s)
    --- SKIP: TestAccDataSourceGithubOrganizationRepositoryRoles/get_organization_roles_without_error (0.00s)
=== RUN   TestAccDataSourceGithubOrganizationRoleTeams
=== RUN   TestAccDataSourceGithubOrganizationRoleTeams/get_the_organization_role_teams_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccDataSourceGithubOrganizationRoleTeams/get_indirect_organization_role_teams_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccDataSourceGithubOrganizationRoleTeams (0.00s)
    --- SKIP: TestAccDataSourceGithubOrganizationRoleTeams/get_the_organization_role_teams_without_error (0.00s)
    --- SKIP: TestAccDataSourceGithubOrganizationRoleTeams/get_indirect_organization_role_teams_without_error (0.00s)
=== RUN   TestAccDataSourceGithubOrganizationRole
=== RUN   TestAccDataSourceGithubOrganizationRole/get_the_organization_role_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccDataSourceGithubOrganizationRole (0.00s)
    --- SKIP: TestAccDataSourceGithubOrganizationRole/get_the_organization_role_without_error (0.00s)
=== RUN   TestAccDataSourceGithubOrganizationRoleUsers
=== RUN   TestAccDataSourceGithubOrganizationRoleUsers/get_the_organization_role_users_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccDataSourceGithubOrganizationRoleUsers/get_indirect_organization_role_users_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccDataSourceGithubOrganizationRoleUsers (0.00s)
    --- SKIP: TestAccDataSourceGithubOrganizationRoleUsers/get_the_organization_role_users_without_error (0.00s)
    --- SKIP: TestAccDataSourceGithubOrganizationRoleUsers/get_indirect_organization_role_users_without_error (0.00s)
=== RUN   TestAccDataSourceGithubOrganizationRoles
=== RUN   TestAccDataSourceGithubOrganizationRoles/get_the_organization_roles_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccDataSourceGithubOrganizationRoles (0.00s)
    --- SKIP: TestAccDataSourceGithubOrganizationRoles/get_the_organization_roles_without_error (0.00s)
=== RUN   TestAccDataSourceGithubOrganizationSecurityManagers
=== RUN   TestAccDataSourceGithubOrganizationSecurityManagers/get_the_organization_security_managers_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccDataSourceGithubOrganizationSecurityManagers (0.00s)
    --- SKIP: TestAccDataSourceGithubOrganizationSecurityManagers/get_the_organization_security_managers_without_error (0.00s)
=== RUN   TestAccGithubOrganizationTeamSyncGroupsDataSource_existing
    acc_test.go:297: Skipping as not supported test mode
--- SKIP: TestAccGithubOrganizationTeamSyncGroupsDataSource_existing (0.00s)
=== RUN   TestAccGithubOrganizationTeamsDataSource
=== RUN   TestAccGithubOrganizationTeamsDataSource/queries
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubOrganizationTeamsDataSource/queries_results_per_page
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubOrganizationTeamsDataSource (0.00s)
    --- SKIP: TestAccGithubOrganizationTeamsDataSource/queries (0.00s)
    --- SKIP: TestAccGithubOrganizationTeamsDataSource/queries_results_per_page (0.00s)
=== RUN   TestAccGithubOrganizationDataSource
=== RUN   TestAccGithubOrganizationDataSource/queries_for_an_organization_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubOrganizationDataSource/queries_for_an_organization_with_archived_repos
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubOrganizationDataSource/queries_for_an_organization_summary_only_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubOrganizationDataSource (0.00s)
    --- SKIP: TestAccGithubOrganizationDataSource/queries_for_an_organization_without_error (0.00s)
    --- SKIP: TestAccGithubOrganizationDataSource/queries_for_an_organization_with_archived_repos (0.00s)
    --- SKIP: TestAccGithubOrganizationDataSource/queries_for_an_organization_summary_only_without_error (0.00s)
=== RUN   TestAccGithubOrganizationWebhooksDataSource
=== RUN   TestAccGithubOrganizationWebhooksDataSource/manages_organization_webhooks
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubOrganizationWebhooksDataSource (0.00s)
    --- SKIP: TestAccGithubOrganizationWebhooksDataSource/manages_organization_webhooks (0.00s)
=== RUN   TestAccGithubRefDataSource
=== RUN   TestAccGithubRefDataSource/queries_an_existing_branch_ref_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRefDataSource (0.00s)
    --- SKIP: TestAccGithubRefDataSource/queries_an_existing_branch_ref_without_error (0.00s)
=== RUN   TestAccGithubReleaseDataSource
=== RUN   TestAccGithubReleaseDataSource/queries_latest_release
=== RUN   TestAccGithubReleaseDataSource/queries_release_by_id_or_tag
=== RUN   TestAccGithubReleaseDataSource/errors_when_querying_with_non-existent_id
=== RUN   TestAccGithubReleaseDataSource/errors_when_querying_with_non-existent_tag
=== RUN   TestAccGithubReleaseDataSource/errors_when_querying_with_non-existent_repository
--- PASS: TestAccGithubReleaseDataSource (12.48s)
    --- PASS: TestAccGithubReleaseDataSource/queries_latest_release (4.26s)
    --- PASS: TestAccGithubReleaseDataSource/queries_release_by_id_or_tag (6.58s)
    --- PASS: TestAccGithubReleaseDataSource/errors_when_querying_with_non-existent_id (0.46s)
    --- PASS: TestAccGithubReleaseDataSource/errors_when_querying_with_non-existent_tag (0.51s)
    --- PASS: TestAccGithubReleaseDataSource/errors_when_querying_with_non-existent_repository (0.67s)
=== RUN   TestAccGithubRepositoriesDataSource
=== RUN   TestAccGithubRepositoriesDataSource/queries_a_list_of_repositories_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoriesDataSource/queries_a_list_of_repositories_with_repo_ids_and_results_per_page_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoriesDataSource/returns_an_empty_list_given_an_invalid_query
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoriesDataSource (0.00s)
    --- SKIP: TestAccGithubRepositoriesDataSource/queries_a_list_of_repositories_without_error (0.00s)
    --- SKIP: TestAccGithubRepositoriesDataSource/queries_a_list_of_repositories_with_repo_ids_and_results_per_page_without_error (0.00s)
    --- SKIP: TestAccGithubRepositoriesDataSource/returns_an_empty_list_given_an_invalid_query (0.00s)
=== RUN   TestAccGithubRepositoryAutolinkReferencesDataSource
=== RUN   TestAccGithubRepositoryAutolinkReferencesDataSource/queries_autolink_references
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryAutolinkReferencesDataSource (0.00s)
    --- SKIP: TestAccGithubRepositoryAutolinkReferencesDataSource/queries_autolink_references (0.00s)
=== RUN   TestAccGithubRepositoryBranchesDataSource
=== RUN   TestAccGithubRepositoryBranchesDataSource/manages_branches_of_a_new_repository
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryBranchesDataSource/manages_branches_of_a_new_repository_with_filtering
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubRepositoryBranchesDataSource (0.00s)
    --- SKIP: TestAccGithubRepositoryBranchesDataSource/manages_branches_of_a_new_repository (0.00s)
    --- SKIP: TestAccGithubRepositoryBranchesDataSource/manages_branches_of_a_new_repository_with_filtering (0.00s)
=== RUN   TestAccGithubRepositoryCustomPropertiesDataSource
=== RUN   TestAccGithubRepositoryCustomPropertiesDataSource/creates_custom_property_of_type_single_select_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubRepositoryCustomPropertiesDataSource/creates_custom_property_of_type_multi_select_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubRepositoryCustomPropertiesDataSource/creates_custom_property_of_type_true_false_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubRepositoryCustomPropertiesDataSource/creates_custom_property_of_type_string_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubRepositoryCustomPropertiesDataSource (0.00s)
    --- SKIP: TestAccGithubRepositoryCustomPropertiesDataSource/creates_custom_property_of_type_single_select_without_error (0.00s)
    --- SKIP: TestAccGithubRepositoryCustomPropertiesDataSource/creates_custom_property_of_type_multi_select_without_error (0.00s)
    --- SKIP: TestAccGithubRepositoryCustomPropertiesDataSource/creates_custom_property_of_type_true_false_without_error (0.00s)
    --- SKIP: TestAccGithubRepositoryCustomPropertiesDataSource/creates_custom_property_of_type_string_without_error (0.00s)
=== RUN   TestAccGithubRepositoryDeployKeysDataSource
=== RUN   TestAccGithubRepositoryDeployKeysDataSource/manages_deploy_keys
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryDeployKeysDataSource (0.22s)
    --- SKIP: TestAccGithubRepositoryDeployKeysDataSource/manages_deploy_keys (0.22s)
=== RUN   TestAccGithubRepositoryDeploymentBranchPolicies
=== RUN   TestAccGithubRepositoryDeploymentBranchPolicies/queries_deployment_branch_policies
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryDeploymentBranchPolicies (0.00s)
    --- SKIP: TestAccGithubRepositoryDeploymentBranchPolicies/queries_deployment_branch_policies (0.00s)
=== RUN   TestAccGithubRepositoryEnvironmentDeploymentPolicies
=== RUN   TestAccGithubRepositoryEnvironmentDeploymentPolicies/queries_environment_deployment_policies
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryEnvironmentDeploymentPolicies (0.00s)
    --- SKIP: TestAccGithubRepositoryEnvironmentDeploymentPolicies/queries_environment_deployment_policies (0.00s)
=== RUN   TestAccGithubRepositoryEnvironmentsDataSource
=== RUN   TestAccGithubRepositoryEnvironmentsDataSource/queries_environments
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryEnvironmentsDataSource (0.00s)
    --- SKIP: TestAccGithubRepositoryEnvironmentsDataSource/queries_environments (0.00s)
=== RUN   TestAccGithubRepositoryFileDataSource
=== RUN   TestAccGithubRepositoryFileDataSource/reads_a_file_with_a_branch_name_provided_without_erroring
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryFileDataSource/reads_a_file_from_a_short_repo_name_without_erroring
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryFileDataSource/create_and_read_a_file_without_providing_a_branch_name
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryFileDataSource/reads_a_directory_without_erroring
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryFileDataSource (0.00s)
    --- SKIP: TestAccGithubRepositoryFileDataSource/reads_a_file_with_a_branch_name_provided_without_erroring (0.00s)
    --- SKIP: TestAccGithubRepositoryFileDataSource/reads_a_file_from_a_short_repo_name_without_erroring (0.00s)
    --- SKIP: TestAccGithubRepositoryFileDataSource/create_and_read_a_file_without_providing_a_branch_name (0.00s)
    --- SKIP: TestAccGithubRepositoryFileDataSource/reads_a_directory_without_erroring (0.00s)
=== RUN   TestAccGithubRepositoryMilestoneDataSource
=== RUN   TestAccGithubRepositoryMilestoneDataSource/queries_a_repository_milestone
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryMilestoneDataSource (0.00s)
    --- SKIP: TestAccGithubRepositoryMilestoneDataSource/queries_a_repository_milestone (0.00s)
=== RUN   TestAccGithubRepositoryPullRequestDataSource
=== RUN   TestAccGithubRepositoryPullRequestDataSource/manages_the_pull_request_lifecycle
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryPullRequestDataSource (0.00s)
    --- SKIP: TestAccGithubRepositoryPullRequestDataSource/manages_the_pull_request_lifecycle (0.00s)
=== RUN   TestAccGithubRepositoryPullRequestsDataSource
=== RUN   TestAccGithubRepositoryPullRequestsDataSource/manages_the_pull_request_lifecycle
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryPullRequestsDataSource (0.00s)
    --- SKIP: TestAccGithubRepositoryPullRequestsDataSource/manages_the_pull_request_lifecycle (0.00s)
=== RUN   TestAccGithubRepositoryTeamsDataSource
=== RUN   TestAccGithubRepositoryTeamsDataSource/queries_teams_of_an_existing_repository
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubRepositoryTeamsDataSource (0.00s)
    --- SKIP: TestAccGithubRepositoryTeamsDataSource/queries_teams_of_an_existing_repository (0.00s)
=== RUN   TestAccDataSourceGithubRepository
=== RUN   TestAccDataSourceGithubRepository/queries_a_public_repository_without_error
=== RUN   TestAccDataSourceGithubRepository/queries_repository_belonging_to_the_current_user_without_error
    data_source_github_repository_test.go:37: No test user repository provided
=== RUN   TestAccDataSourceGithubRepository/queries_an_org_repository_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccDataSourceGithubRepository/queries_a_repository_with_pages_configured
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccDataSourceGithubRepository/checks_defaults_on_a_new_repository
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccDataSourceGithubRepository/queries_a_public_repository_that_is_a_template
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccDataSourceGithubRepository/queries_an_org_repository_that_is_a_template
    data_source_github_repository_test.go:191: No org template repository provided
=== RUN   TestAccDataSourceGithubRepository/queries_a_repository_that_was_generated_from_a_template
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccDataSourceGithubRepository/queries_a_repository_that_has_no_primary_language
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccDataSourceGithubRepository/queries_a_repository_that_has_a_license
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccDataSourceGithubRepository (6.65s)
    --- PASS: TestAccDataSourceGithubRepository/queries_a_public_repository_without_error (6.65s)
    --- SKIP: TestAccDataSourceGithubRepository/queries_repository_belonging_to_the_current_user_without_error (0.00s)
    --- SKIP: TestAccDataSourceGithubRepository/queries_an_org_repository_without_error (0.00s)
    --- SKIP: TestAccDataSourceGithubRepository/queries_a_repository_with_pages_configured (0.00s)
    --- SKIP: TestAccDataSourceGithubRepository/checks_defaults_on_a_new_repository (0.00s)
    --- SKIP: TestAccDataSourceGithubRepository/queries_a_public_repository_that_is_a_template (0.00s)
    --- SKIP: TestAccDataSourceGithubRepository/queries_an_org_repository_that_is_a_template (0.00s)
    --- SKIP: TestAccDataSourceGithubRepository/queries_a_repository_that_was_generated_from_a_template (0.00s)
    --- SKIP: TestAccDataSourceGithubRepository/queries_a_repository_that_has_no_primary_language (0.00s)
    --- SKIP: TestAccDataSourceGithubRepository/queries_a_repository_that_has_a_license (0.00s)
=== RUN   TestAccGithubRepositoryWebhooksDataSource
=== RUN   TestAccGithubRepositoryWebhooksDataSource/manages_repository_webhooks
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryWebhooksDataSource (0.00s)
    --- SKIP: TestAccGithubRepositoryWebhooksDataSource/manages_repository_webhooks (0.00s)
=== RUN   TestAccGithubRestApiDataSource
=== RUN   TestAccGithubRestApiDataSource/queries_an_existing_branch_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRestApiDataSource/queries_a_collection_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRestApiDataSource/queries_an_invalid_branch_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRestApiDataSource (0.00s)
    --- SKIP: TestAccGithubRestApiDataSource/queries_an_existing_branch_without_error (0.00s)
    --- SKIP: TestAccGithubRestApiDataSource/queries_a_collection_without_error (0.00s)
    --- SKIP: TestAccGithubRestApiDataSource/queries_an_invalid_branch_without_error (0.00s)
=== RUN   TestAccGithubSshKeysDataSource
=== RUN   TestAccGithubSshKeysDataSource/reads_SSH_keys_without_error
--- PASS: TestAccGithubSshKeysDataSource (4.49s)
    --- PASS: TestAccGithubSshKeysDataSource/reads_SSH_keys_without_error (4.49s)
=== RUN   TestAccGithubTeamDataSource
=== RUN   TestAccGithubTeamDataSource/queries_an_existing_team_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubTeamDataSource/queries_an_existing_team_without_error_with_immediate_membership
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubTeamDataSource/errors_when_querying_a_non-existing_team
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubTeamDataSource/queries_an_existing_team_without_error_in_summary_only_mode
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubTeamDataSource/queries_an_existing_team_without_error_with_results_per_page_reduced
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubTeamDataSource/get_team_with_repositories_without_erroring
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubTeamDataSource/queries_an_existing_team_with_connected_repositories
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubTeamDataSource (0.00s)
    --- SKIP: TestAccGithubTeamDataSource/queries_an_existing_team_without_error (0.00s)
    --- SKIP: TestAccGithubTeamDataSource/queries_an_existing_team_without_error_with_immediate_membership (0.00s)
    --- SKIP: TestAccGithubTeamDataSource/errors_when_querying_a_non-existing_team (0.00s)
    --- SKIP: TestAccGithubTeamDataSource/queries_an_existing_team_without_error_in_summary_only_mode (0.00s)
    --- SKIP: TestAccGithubTeamDataSource/queries_an_existing_team_without_error_with_results_per_page_reduced (0.00s)
    --- SKIP: TestAccGithubTeamDataSource/get_team_with_repositories_without_erroring (0.00s)
    --- SKIP: TestAccGithubTeamDataSource/queries_an_existing_team_with_connected_repositories (0.00s)
=== RUN   TestAccGithubTreeDataSource
=== RUN   TestAccGithubTreeDataSource/get_tree
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubTreeDataSource (0.00s)
    --- SKIP: TestAccGithubTreeDataSource/get_tree (0.00s)
=== RUN   TestAccGithubUserExternalIdentity
=== RUN   TestAccGithubUserExternalIdentity/queries_without_error
    acc_test.go:297: Skipping as not supported test mode
--- PASS: TestAccGithubUserExternalIdentity (0.00s)
    --- SKIP: TestAccGithubUserExternalIdentity/queries_without_error (0.00s)
=== RUN   TestAccGithubUserDataSource
    data_source_github_user_test.go:13: No external user provided
--- SKIP: TestAccGithubUserDataSource (0.00s)
=== RUN   TestAccGithubUsersDataSource
    data_source_github_users_test.go:13: No external user provided
--- SKIP: TestAccGithubUsersDataSource (0.00s)
=== RUN   TestAccProviderConfigure
=== RUN   TestAccProviderConfigure/can_be_configured_to_run_anonymously
=== RUN   TestAccProviderConfigure/can_be_configured_with_app_auth_and_ignore_github_token
    provider_test.go:75: This test requires a valid app auth setup to run.
=== RUN   TestAccProviderConfigure/can_be_configured_to_run_insecurely
=== RUN   TestAccProviderConfigure/can_be_configured_with_an_individual_account
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccProviderConfigure/can_be_configured_with_an_organization_account
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccProviderConfigure/can_be_configured_with_an_organization_account_legacy
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccProviderConfigure/can_be_configured_with_a_GHES_deployment
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccProviderConfigure/can_be_configured_with_max_retries
=== RUN   TestAccProviderConfigure/can_be_configured_with_max_per_page
=== RUN   TestAccProviderConfigure/should_not_allow_both_token_and_app_auth_to_be_configured
    provider_test.go:260: This would be a semver breaking change, this will be reinstated for v7.
--- PASS: TestAccProviderConfigure (10.78s)
    --- PASS: TestAccProviderConfigure/can_be_configured_to_run_anonymously (1.98s)
    --- SKIP: TestAccProviderConfigure/can_be_configured_with_app_auth_and_ignore_github_token (0.00s)
    --- PASS: TestAccProviderConfigure/can_be_configured_to_run_insecurely (3.61s)
    --- SKIP: TestAccProviderConfigure/can_be_configured_with_an_individual_account (0.00s)
    --- SKIP: TestAccProviderConfigure/can_be_configured_with_an_organization_account (0.00s)
    --- SKIP: TestAccProviderConfigure/can_be_configured_with_an_organization_account_legacy (0.00s)
    --- SKIP: TestAccProviderConfigure/can_be_configured_with_a_GHES_deployment (0.00s)
    --- PASS: TestAccProviderConfigure/can_be_configured_with_max_retries (0.27s)
    --- PASS: TestAccProviderConfigure/can_be_configured_with_max_per_page (4.92s)
    --- SKIP: TestAccProviderConfigure/should_not_allow_both_token_and_app_auth_to_be_configured (0.00s)
=== RUN   TestAccGithubActionsEnvironmentSecret
=== RUN   TestAccGithubActionsEnvironmentSecret/creates_and_updates_secrets_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubActionsEnvironmentSecret/deletes_secrets_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubActionsEnvironmentSecret (0.00s)
    --- SKIP: TestAccGithubActionsEnvironmentSecret/creates_and_updates_secrets_without_error (0.00s)
    --- SKIP: TestAccGithubActionsEnvironmentSecret/deletes_secrets_without_error (0.00s)
=== RUN   TestAccGithubActionsEnvironmentSecretIgnoreChanges
=== RUN   TestAccGithubActionsEnvironmentSecretIgnoreChanges/creates_environment_secrets_using_lifecycle_ignore_changes
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubActionsEnvironmentSecretIgnoreChanges (0.00s)
    --- SKIP: TestAccGithubActionsEnvironmentSecretIgnoreChanges/creates_environment_secrets_using_lifecycle_ignore_changes (0.00s)
=== RUN   TestAccGithubActionsEnvironmentVariable
=== RUN   TestAccGithubActionsEnvironmentVariable/creates_and_updates_environment_variables_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubActionsEnvironmentVariable/deletes_environment_variables_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubActionsEnvironmentVariable/imports_environment_variables_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubActionsEnvironmentVariable (0.00s)
    --- SKIP: TestAccGithubActionsEnvironmentVariable/creates_and_updates_environment_variables_without_error (0.00s)
    --- SKIP: TestAccGithubActionsEnvironmentVariable/deletes_environment_variables_without_error (0.00s)
    --- SKIP: TestAccGithubActionsEnvironmentVariable/imports_environment_variables_without_error (0.00s)
=== RUN   TestAccGithubActionsEnvironmentVariable_alreadyExists
    acc_test.go:273: Skipping as test mode not authenticated
--- SKIP: TestAccGithubActionsEnvironmentVariable_alreadyExists (0.00s)
=== RUN   TestAccGithubActionsHostedRunner
=== RUN   TestAccGithubActionsHostedRunner/creates_hosted_runners_without_error
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
=== RUN   TestAccGithubActionsHostedRunner/creates_hosted_runner_with_optional_parameters
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
=== RUN   TestAccGithubActionsHostedRunner/updates_hosted_runner_configuration
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
=== RUN   TestAccGithubActionsHostedRunner/updates_size_field
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
=== RUN   TestAccGithubActionsHostedRunner/imports_hosted_runner
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
=== RUN   TestAccGithubActionsHostedRunner/deletes_hosted_runner
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
--- PASS: TestAccGithubActionsHostedRunner (0.00s)
    --- SKIP: TestAccGithubActionsHostedRunner/creates_hosted_runners_without_error (0.00s)
    --- SKIP: TestAccGithubActionsHostedRunner/creates_hosted_runner_with_optional_parameters (0.00s)
    --- SKIP: TestAccGithubActionsHostedRunner/updates_hosted_runner_configuration (0.00s)
    --- SKIP: TestAccGithubActionsHostedRunner/updates_size_field (0.00s)
    --- SKIP: TestAccGithubActionsHostedRunner/imports_hosted_runner (0.00s)
    --- SKIP: TestAccGithubActionsHostedRunner/deletes_hosted_runner (0.00s)
=== RUN   TestAccGithubActionsOrganizationOIDCSubjectClaimCustomizationTemplate
=== RUN   TestAccGithubActionsOrganizationOIDCSubjectClaimCustomizationTemplate/creates_organization_oidc_subject_claim_customization_template_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubActionsOrganizationOIDCSubjectClaimCustomizationTemplate/updates_organization_oidc_subject_claim_customization_template_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubActionsOrganizationOIDCSubjectClaimCustomizationTemplate/imports_organization_oidc_subject_claim_customization_template_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubActionsOrganizationOIDCSubjectClaimCustomizationTemplate (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationOIDCSubjectClaimCustomizationTemplate/creates_organization_oidc_subject_claim_customization_template_without_error (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationOIDCSubjectClaimCustomizationTemplate/updates_organization_oidc_subject_claim_customization_template_without_error (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationOIDCSubjectClaimCustomizationTemplate/imports_organization_oidc_subject_claim_customization_template_without_error (0.00s)
=== RUN   TestAccGithubActionsOrganizationPermissions
=== RUN   TestAccGithubActionsOrganizationPermissions/test_setting_of_basic_actions_organization_permissions
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubActionsOrganizationPermissions/imports_entire_set_of_github_action_organization_permissions_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubActionsOrganizationPermissions/test_setting_of_organization_allowed_actions
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubActionsOrganizationPermissions/test_not_setting_of_organization_allowed_actions_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubActionsOrganizationPermissions/test_setting_of_organization_enabled_repositories
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubActionsOrganizationPermissions (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationPermissions/test_setting_of_basic_actions_organization_permissions (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationPermissions/imports_entire_set_of_github_action_organization_permissions_without_error (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationPermissions/test_setting_of_organization_allowed_actions (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationPermissions/test_not_setting_of_organization_allowed_actions_without_error (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationPermissions/test_setting_of_organization_enabled_repositories (0.00s)
=== RUN   TestAccGithubActionsOrganizationSecretRepositories
=== RUN   TestAccGithubActionsOrganizationSecretRepositories/set_repository_allowlist_for_a_organization_secret
    resource_github_actions_organization_secret_repositories_test.go:18: 'GH_TEST_ORG_SECRET_NAME' environment variable is missing
--- PASS: TestAccGithubActionsOrganizationSecretRepositories (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationSecretRepositories/set_repository_allowlist_for_a_organization_secret (0.00s)
=== RUN   TestAccGithubActionsOrganizationSecretRepository
=== RUN   TestAccGithubActionsOrganizationSecretRepository/set_repository_allowlist_for_a_organization_secret
    resource_github_actions_organization_secret_repository_test.go:17: test organization secret name is not set
--- PASS: TestAccGithubActionsOrganizationSecretRepository (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationSecretRepository/set_repository_allowlist_for_a_organization_secret (0.00s)
=== RUN   TestAccGithubActionsOrganizationSecret
=== RUN   TestAccGithubActionsOrganizationSecret/creates_and_updates_secrets_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubActionsOrganizationSecret/deletes_secrets_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubActionsOrganizationSecret/imports_secrets_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubActionsOrganizationSecret (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationSecret/creates_and_updates_secrets_without_error (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationSecret/deletes_secrets_without_error (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationSecret/imports_secrets_without_error (0.00s)
=== RUN   TestAccGithubActionsOrganizationSecret_DestroyOnDrift
=== RUN   TestAccGithubActionsOrganizationSecret_DestroyOnDrift/destroyOnDrift_false
=== RUN   TestAccGithubActionsOrganizationSecret_DestroyOnDrift/destroyOnDrift_false/should_ignore_drift_when_ignore_changes_lifecycle_is_configured
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubActionsOrganizationSecret_DestroyOnDrift (0.00s)
    --- PASS: TestAccGithubActionsOrganizationSecret_DestroyOnDrift/destroyOnDrift_false (0.00s)
        --- SKIP: TestAccGithubActionsOrganizationSecret_DestroyOnDrift/destroyOnDrift_false/should_ignore_drift_when_ignore_changes_lifecycle_is_configured (0.00s)
=== RUN   TestAccGithubActionsOrganizationVariable
=== RUN   TestAccGithubActionsOrganizationVariable/creates_and_updates_a_private_organization_variable_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubActionsOrganizationVariable/creates_an_organization_variable_scoped_to_a_repo_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubActionsOrganizationVariable/deletes_organization_variables_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubActionsOrganizationVariable/imports_an_organization_variable_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubActionsOrganizationVariable (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationVariable/creates_and_updates_a_private_organization_variable_without_error (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationVariable/creates_an_organization_variable_scoped_to_a_repo_without_error (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationVariable/deletes_organization_variables_without_error (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationVariable/imports_an_organization_variable_without_error (0.00s)
=== RUN   TestAccGithubActionsOrganizationWorkflowPermissions
=== RUN   TestAccGithubActionsOrganizationWorkflowPermissions/creates_organization_workflow_permissions_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubActionsOrganizationWorkflowPermissions/updates_organization_workflow_permissions_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubActionsOrganizationWorkflowPermissions/imports_organization_workflow_permissions_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubActionsOrganizationWorkflowPermissions/deletes_organization_workflow_permissions_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubActionsOrganizationWorkflowPermissions/creates_with_minimal_config_using_defaults
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubActionsOrganizationWorkflowPermissions (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationWorkflowPermissions/creates_organization_workflow_permissions_without_error (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationWorkflowPermissions/updates_organization_workflow_permissions_without_error (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationWorkflowPermissions/imports_organization_workflow_permissions_without_error (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationWorkflowPermissions/deletes_organization_workflow_permissions_without_error (0.00s)
    --- SKIP: TestAccGithubActionsOrganizationWorkflowPermissions/creates_with_minimal_config_using_defaults (0.00s)
=== RUN   TestAccGithubActionsRepositoryAccessLevel
=== RUN   TestAccGithubActionsRepositoryAccessLevel/test_setting_of_user_action_access_level
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubActionsRepositoryAccessLevel/test_setting_of_organization_action_access_level
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubActionsRepositoryAccessLevel (0.00s)
    --- SKIP: TestAccGithubActionsRepositoryAccessLevel/test_setting_of_user_action_access_level (0.00s)
    --- SKIP: TestAccGithubActionsRepositoryAccessLevel/test_setting_of_organization_action_access_level (0.00s)
=== RUN   TestAccGithubActionsRepositoryOIDCSubjectClaimCustomizationTemplate
=== RUN   TestAccGithubActionsRepositoryOIDCSubjectClaimCustomizationTemplate/creates_repository_oidc_subject_claim_customization_template_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubActionsRepositoryOIDCSubjectClaimCustomizationTemplate/updates_repository_oidc_subject_claim_customization_template_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubActionsRepositoryOIDCSubjectClaimCustomizationTemplate/imports_repository_oidc_subject_claim_customization_template_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubActionsRepositoryOIDCSubjectClaimCustomizationTemplate (0.00s)
    --- SKIP: TestAccGithubActionsRepositoryOIDCSubjectClaimCustomizationTemplate/creates_repository_oidc_subject_claim_customization_template_without_error (0.00s)
    --- SKIP: TestAccGithubActionsRepositoryOIDCSubjectClaimCustomizationTemplate/updates_repository_oidc_subject_claim_customization_template_without_error (0.00s)
    --- SKIP: TestAccGithubActionsRepositoryOIDCSubjectClaimCustomizationTemplate/imports_repository_oidc_subject_claim_customization_template_without_error (0.00s)
=== RUN   TestAccGithubActionsRepositoryPermissions
=== RUN   TestAccGithubActionsRepositoryPermissions/test_setting_of_basic_actions_repository_permissions
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubActionsRepositoryPermissions/imports_entire_set_of_github_action_repository_permissions_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubActionsRepositoryPermissions/test_setting_of_repository_allowed_actions
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubActionsRepositoryPermissions/test_not_setting_of_repository_allowed_actions_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubActionsRepositoryPermissions/test_disabling_actions_on_a_repository
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubActionsRepositoryPermissions/test_load_with_disabled_actions
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubActionsRepositoryPermissions (0.00s)
    --- SKIP: TestAccGithubActionsRepositoryPermissions/test_setting_of_basic_actions_repository_permissions (0.00s)
    --- SKIP: TestAccGithubActionsRepositoryPermissions/imports_entire_set_of_github_action_repository_permissions_without_error (0.00s)
    --- SKIP: TestAccGithubActionsRepositoryPermissions/test_setting_of_repository_allowed_actions (0.00s)
    --- SKIP: TestAccGithubActionsRepositoryPermissions/test_not_setting_of_repository_allowed_actions_without_error (0.00s)
    --- SKIP: TestAccGithubActionsRepositoryPermissions/test_disabling_actions_on_a_repository (0.00s)
    --- SKIP: TestAccGithubActionsRepositoryPermissions/test_load_with_disabled_actions (0.00s)
=== RUN   TestAccGithubActionsRunnerGroup
=== RUN   TestAccGithubActionsRunnerGroup/creates_runner_groups_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubActionsRunnerGroup/manages_runner_visibility
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubActionsRunnerGroup/imports_an_all_runner_group_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubActionsRunnerGroup/imports_a_private_runner_group_without_error
    resource_github_actions_runner_group_test.go:191: This is not supported
=== RUN   TestAccGithubActionsRunnerGroup/imports_a_selected_runner_group_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubActionsRunnerGroup (0.00s)
    --- SKIP: TestAccGithubActionsRunnerGroup/creates_runner_groups_without_error (0.00s)
    --- SKIP: TestAccGithubActionsRunnerGroup/manages_runner_visibility (0.00s)
    --- SKIP: TestAccGithubActionsRunnerGroup/imports_an_all_runner_group_without_error (0.00s)
    --- SKIP: TestAccGithubActionsRunnerGroup/imports_a_private_runner_group_without_error (0.00s)
    --- SKIP: TestAccGithubActionsRunnerGroup/imports_a_selected_runner_group_without_error (0.00s)
=== RUN   TestAccGithubActionsSecret
=== RUN   TestAccGithubActionsSecret/reads_a_repository_public_key_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubActionsSecret/creates_and_updates_secrets_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubActionsSecret/creates_and_updates_repository_name_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubActionsSecret/deletes_secrets_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubActionsSecret/respects_destroy_on_drift_setting
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubActionsSecret (0.00s)
    --- SKIP: TestAccGithubActionsSecret/reads_a_repository_public_key_without_error (0.00s)
    --- SKIP: TestAccGithubActionsSecret/creates_and_updates_secrets_without_error (0.00s)
    --- SKIP: TestAccGithubActionsSecret/creates_and_updates_repository_name_without_error (0.00s)
    --- SKIP: TestAccGithubActionsSecret/deletes_secrets_without_error (0.00s)
    --- SKIP: TestAccGithubActionsSecret/respects_destroy_on_drift_setting (0.00s)
=== RUN   TestAccGithubActionsVariable
=== RUN   TestAccGithubActionsVariable/creates_and_updates_repository_variables_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubActionsVariable/deletes_repository_variables_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubActionsVariable/imports_repository_variables_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubActionsVariable (0.00s)
    --- SKIP: TestAccGithubActionsVariable/creates_and_updates_repository_variables_without_error (0.00s)
    --- SKIP: TestAccGithubActionsVariable/deletes_repository_variables_without_error (0.00s)
    --- SKIP: TestAccGithubActionsVariable/imports_repository_variables_without_error (0.00s)
=== RUN   TestAccGithubAppInstallationRepositories
    resource_github_app_installation_repositories_test.go:12: TODO: Broken test
--- SKIP: TestAccGithubAppInstallationRepositories (0.00s)
=== RUN   TestAccGithubAppInstallationRepository
    resource_github_app_installation_repository_test.go:12: TODO: Broken test
--- SKIP: TestAccGithubAppInstallationRepository (0.00s)
=== RUN   TestAccGithubBranchDefault
=== RUN   TestAccGithubBranchDefault/creates_and_manages_branch_defaults
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubBranchDefault/replaces_the_default_branch_of_a_repository
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubBranchDefault/creates_and_manages_branch_defaults_even_if_rename_is_set
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubBranchDefault/replaces_the_default_branch_of_a_repository_without_creating_a_branch_resource_prior_to
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubBranchDefault (0.00s)
    --- SKIP: TestAccGithubBranchDefault/creates_and_manages_branch_defaults (0.00s)
    --- SKIP: TestAccGithubBranchDefault/replaces_the_default_branch_of_a_repository (0.00s)
    --- SKIP: TestAccGithubBranchDefault/creates_and_manages_branch_defaults_even_if_rename_is_set (0.00s)
    --- SKIP: TestAccGithubBranchDefault/replaces_the_default_branch_of_a_repository_without_creating_a_branch_resource_prior_to (0.00s)
=== RUN   TestAccGithubBranchProtectionV4
=== RUN   TestAccGithubBranchProtectionV4/configures_default_settings_when_empty
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubBranchProtectionV4/configures_default_settings_when_conversation_resolution_is_true
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubBranchProtectionV4/configures_required_status_checks
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubBranchProtectionV4/configures_required_pull_request_reviews
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubBranchProtectionV4/configures_branch_push_restrictions
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubBranchProtectionV4/configures_branch_push_restrictions_with_node_id
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubBranchProtectionV4/configures_branch_push_restrictions_with_username
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubBranchProtectionV4/configures_branch_push_restrictions_with_blocksCreations_false
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubBranchProtectionV4/configures_force_pushes_and_deletions
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubBranchProtectionV4/configures_non-empty_list_of_force_push_bypassers
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubBranchProtectionV4/configures_allow_force_push_with_a_team_as_bypasser
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubBranchProtectionV4/configures_empty_list_of_force_push_bypassers
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubBranchProtectionV4/configures_non-empty_list_of_pull_request_bypassers
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubBranchProtectionV4/configures_empty_list_of_pull_request_bypassers
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubBranchProtectionV4 (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV4/configures_default_settings_when_empty (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV4/configures_default_settings_when_conversation_resolution_is_true (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV4/configures_required_status_checks (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV4/configures_required_pull_request_reviews (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV4/configures_branch_push_restrictions (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV4/configures_branch_push_restrictions_with_node_id (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV4/configures_branch_push_restrictions_with_username (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV4/configures_branch_push_restrictions_with_blocksCreations_false (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV4/configures_force_pushes_and_deletions (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV4/configures_non-empty_list_of_force_push_bypassers (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV4/configures_allow_force_push_with_a_team_as_bypasser (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV4/configures_empty_list_of_force_push_bypassers (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV4/configures_non-empty_list_of_pull_request_bypassers (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV4/configures_empty_list_of_pull_request_bypassers (0.00s)
=== RUN   TestAccGithubBranchProtectionV4StateUpgradeV1
--- PASS: TestAccGithubBranchProtectionV4StateUpgradeV1 (0.00s)
=== RUN   TestAccGithubBranchProtectionV3_required_pull_request_reviews
=== RUN   TestAccGithubBranchProtectionV3_required_pull_request_reviews/configures_required_pull_request_reviews
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubBranchProtectionV3_required_pull_request_reviews (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV3_required_pull_request_reviews/configures_required_pull_request_reviews (0.00s)
=== RUN   TestAccGithubBranchProtectionV3RequiredPullRequestReviewsBypassAllowances
=== RUN   TestAccGithubBranchProtectionV3RequiredPullRequestReviewsBypassAllowances/configures_required_pull_request_reviews_with_bypass_allowances
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubBranchProtectionV3RequiredPullRequestReviewsBypassAllowances (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV3RequiredPullRequestReviewsBypassAllowances/configures_required_pull_request_reviews_with_bypass_allowances (0.00s)
=== RUN   TestAccGithubBranchProtectionV3_branch_push_restrictions
=== RUN   TestAccGithubBranchProtectionV3_branch_push_restrictions/configures_branch_push_restrictions
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubBranchProtectionV3_branch_push_restrictions (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV3_branch_push_restrictions/configures_branch_push_restrictions (0.00s)
=== RUN   TestAccGithubBranchProtectionV3_computed_status_checks_no_churn
=== RUN   TestAccGithubBranchProtectionV3_computed_status_checks_no_churn/handles_computed_status_checks_without_churn
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubBranchProtectionV3_computed_status_checks_no_churn (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV3_computed_status_checks_no_churn/handles_computed_status_checks_without_churn (0.00s)
=== RUN   TestAccGithubBranchProtectionV3_computed_status_contexts_no_churn
=== RUN   TestAccGithubBranchProtectionV3_computed_status_contexts_no_churn/handles_computed_status_contexts_without_churn
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubBranchProtectionV3_computed_status_contexts_no_churn (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV3_computed_status_contexts_no_churn/handles_computed_status_contexts_without_churn (0.00s)
=== RUN   TestAccGithubBranchProtectionV3
=== RUN   TestAccGithubBranchProtectionV3/configures_default_settings_when_empty
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubBranchProtectionV3/configures_conversation_resolution
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubBranchProtectionV3/configures_required_status_checks
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubBranchProtectionV3/configures_required_status_checks_context
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubBranchProtectionV3/configures_required_pull_request_reviews
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubBranchProtectionV3/configures_required_pull_request_reviews_with_bypass_allowances
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubBranchProtectionV3/configures_branch_push_restrictions
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubBranchProtectionV3 (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV3/configures_default_settings_when_empty (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV3/configures_conversation_resolution (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV3/configures_required_status_checks (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV3/configures_required_status_checks_context (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV3/configures_required_pull_request_reviews (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV3/configures_required_pull_request_reviews_with_bypass_allowances (0.00s)
    --- SKIP: TestAccGithubBranchProtectionV3/configures_branch_push_restrictions (0.00s)
=== RUN   TestAccGithubBranch
=== RUN   TestAccGithubBranch/creates_a_branch_directly
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubBranch/creates_a_branch_named_main_directly_and_a_repository_with_a_gitignore_template
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubBranch/creates_a_branch_from_a_source_branch
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubBranch/renames_a_branch_without_replacement
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubBranch (0.00s)
    --- SKIP: TestAccGithubBranch/creates_a_branch_directly (0.00s)
    --- SKIP: TestAccGithubBranch/creates_a_branch_named_main_directly_and_a_repository_with_a_gitignore_template (0.00s)
    --- SKIP: TestAccGithubBranch/creates_a_branch_from_a_source_branch (0.00s)
    --- SKIP: TestAccGithubBranch/renames_a_branch_without_replacement (0.00s)
=== RUN   TestAccGithubCodespacesOrganizationSecretRepositories
=== RUN   TestAccGithubCodespacesOrganizationSecretRepositories/set_repository_allowlist_for_an_organization_secret
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
--- PASS: TestAccGithubCodespacesOrganizationSecretRepositories (0.00s)
    --- SKIP: TestAccGithubCodespacesOrganizationSecretRepositories/set_repository_allowlist_for_an_organization_secret (0.00s)
=== RUN   TestAccGithubCodespacesOrganizationSecret
=== RUN   TestAccGithubCodespacesOrganizationSecret/creates_and_updates_secrets_without_error
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
=== RUN   TestAccGithubCodespacesOrganizationSecret/deletes_secrets_without_error
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
=== RUN   TestAccGithubCodespacesOrganizationSecret/imports_secrets_without_error
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
--- PASS: TestAccGithubCodespacesOrganizationSecret (0.00s)
    --- SKIP: TestAccGithubCodespacesOrganizationSecret/creates_and_updates_secrets_without_error (0.00s)
    --- SKIP: TestAccGithubCodespacesOrganizationSecret/deletes_secrets_without_error (0.00s)
    --- SKIP: TestAccGithubCodespacesOrganizationSecret/imports_secrets_without_error (0.00s)
=== RUN   TestAccGithubCodespacesSecret
=== RUN   TestAccGithubCodespacesSecret/reads_a_repository_public_key_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubCodespacesSecret/creates_and_updates_secrets_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubCodespacesSecret/creates_and_updates_repository_name_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubCodespacesSecret/deletes_secrets_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubCodespacesSecret (0.00s)
    --- SKIP: TestAccGithubCodespacesSecret/reads_a_repository_public_key_without_error (0.00s)
    --- SKIP: TestAccGithubCodespacesSecret/creates_and_updates_secrets_without_error (0.00s)
    --- SKIP: TestAccGithubCodespacesSecret/creates_and_updates_repository_name_without_error (0.00s)
    --- SKIP: TestAccGithubCodespacesSecret/deletes_secrets_without_error (0.00s)
=== RUN   TestAccGithubCodespacesUserSecret
=== RUN   TestAccGithubCodespacesUserSecret/creates_and_updates_secrets_without_error
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubCodespacesUserSecret/deletes_secrets_without_error
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubCodespacesUserSecret/imports_secrets_without_error
    acc_test.go:297: Skipping as not supported test mode
--- PASS: TestAccGithubCodespacesUserSecret (0.00s)
    --- SKIP: TestAccGithubCodespacesUserSecret/creates_and_updates_secrets_without_error (0.00s)
    --- SKIP: TestAccGithubCodespacesUserSecret/deletes_secrets_without_error (0.00s)
    --- SKIP: TestAccGithubCodespacesUserSecret/imports_secrets_without_error (0.00s)
=== RUN   TestAccGithubDependabotOrganizationSecretRepositories
=== RUN   TestAccGithubDependabotOrganizationSecretRepositories/set_repository_allowlist_for_an_organization_secret
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
--- PASS: TestAccGithubDependabotOrganizationSecretRepositories (0.00s)
    --- SKIP: TestAccGithubDependabotOrganizationSecretRepositories/set_repository_allowlist_for_an_organization_secret (0.00s)
=== RUN   TestAccGithubDependabotOrganizationSecret
=== RUN   TestAccGithubDependabotOrganizationSecret/creates_and_updates_secrets_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubDependabotOrganizationSecret/deletes_secrets_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubDependabotOrganizationSecret/imports_secrets_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubDependabotOrganizationSecret (0.00s)
    --- SKIP: TestAccGithubDependabotOrganizationSecret/creates_and_updates_secrets_without_error (0.00s)
    --- SKIP: TestAccGithubDependabotOrganizationSecret/deletes_secrets_without_error (0.00s)
    --- SKIP: TestAccGithubDependabotOrganizationSecret/imports_secrets_without_error (0.00s)
=== RUN   TestAccGithubDependabotSecret
=== RUN   TestAccGithubDependabotSecret/reads_a_repository_public_key_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubDependabotSecret/creates_and_updates_secrets_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubDependabotSecret/creates_and_updates_repository_name_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubDependabotSecret/deletes_secrets_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubDependabotSecret (0.00s)
    --- SKIP: TestAccGithubDependabotSecret/reads_a_repository_public_key_without_error (0.00s)
    --- SKIP: TestAccGithubDependabotSecret/creates_and_updates_secrets_without_error (0.00s)
    --- SKIP: TestAccGithubDependabotSecret/creates_and_updates_repository_name_without_error (0.00s)
    --- SKIP: TestAccGithubDependabotSecret/deletes_secrets_without_error (0.00s)
=== RUN   TestAccGithubEMUGroupMapping
    resource_github_emu_group_mapping_test.go:17: Skipping EMU group mapping tests because testEnterpriseEMUGroupId is not set
--- SKIP: TestAccGithubEMUGroupMapping (0.00s)
=== RUN   TestAccGithubActionsEnterprisePermissions
=== RUN   TestAccGithubActionsEnterprisePermissions/test_setting_of_basic_actions_enterprise_permissions
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubActionsEnterprisePermissions/imports_entire_set_of_github_action_enterprise_permissions_without_error
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubActionsEnterprisePermissions/test_setting_of_enterprise_allowed_actions
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubActionsEnterprisePermissions/test_setting_of_enterprise_enabled_organizations
    acc_test.go:297: Skipping as not supported test mode
--- PASS: TestAccGithubActionsEnterprisePermissions (0.00s)
    --- SKIP: TestAccGithubActionsEnterprisePermissions/test_setting_of_basic_actions_enterprise_permissions (0.00s)
    --- SKIP: TestAccGithubActionsEnterprisePermissions/imports_entire_set_of_github_action_enterprise_permissions_without_error (0.00s)
    --- SKIP: TestAccGithubActionsEnterprisePermissions/test_setting_of_enterprise_allowed_actions (0.00s)
    --- SKIP: TestAccGithubActionsEnterprisePermissions/test_setting_of_enterprise_enabled_organizations (0.00s)
=== RUN   TestAccGithubActionsEnterpriseRunnerGroup
=== RUN   TestAccGithubActionsEnterpriseRunnerGroup/creates_enterprise_runner_groups_without_error
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubActionsEnterpriseRunnerGroup/manages_runner_group_visibility_to_selected_orgs
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubActionsEnterpriseRunnerGroup/imports_an_all_runner_group_without_error
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubActionsEnterpriseRunnerGroup/imports_a_runner_group_with_selected_orgs_without_error
    acc_test.go:297: Skipping as not supported test mode
--- PASS: TestAccGithubActionsEnterpriseRunnerGroup (0.00s)
    --- SKIP: TestAccGithubActionsEnterpriseRunnerGroup/creates_enterprise_runner_groups_without_error (0.00s)
    --- SKIP: TestAccGithubActionsEnterpriseRunnerGroup/manages_runner_group_visibility_to_selected_orgs (0.00s)
    --- SKIP: TestAccGithubActionsEnterpriseRunnerGroup/imports_an_all_runner_group_without_error (0.00s)
    --- SKIP: TestAccGithubActionsEnterpriseRunnerGroup/imports_a_runner_group_with_selected_orgs_without_error (0.00s)
=== RUN   TestAccGithubEnterpriseActionsWorkflowPermissions
=== RUN   TestAccGithubEnterpriseActionsWorkflowPermissions/creates_enterprise_workflow_permissions_without_error
    acc_test.go:291: Skipping as test mode is not enterprise
=== RUN   TestAccGithubEnterpriseActionsWorkflowPermissions/updates_enterprise_workflow_permissions_without_error
    acc_test.go:291: Skipping as test mode is not enterprise
=== RUN   TestAccGithubEnterpriseActionsWorkflowPermissions/imports_enterprise_workflow_permissions_without_error
    acc_test.go:291: Skipping as test mode is not enterprise
--- PASS: TestAccGithubEnterpriseActionsWorkflowPermissions (0.00s)
    --- SKIP: TestAccGithubEnterpriseActionsWorkflowPermissions/creates_enterprise_workflow_permissions_without_error (0.00s)
    --- SKIP: TestAccGithubEnterpriseActionsWorkflowPermissions/updates_enterprise_workflow_permissions_without_error (0.00s)
    --- SKIP: TestAccGithubEnterpriseActionsWorkflowPermissions/imports_enterprise_workflow_permissions_without_error (0.00s)
=== RUN   TestAccGithubEnterpriseOrganization
=== RUN   TestAccGithubEnterpriseOrganization/creates_and_updates_an_enterprise_organization_without_error
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubEnterpriseOrganization/deletes_an_enterprise_organization_without_error
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubEnterpriseOrganization/creates_and_updates_org_with_display_name
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubEnterpriseOrganization/creates_org_without_display_name,_set_and_update_display_name
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubEnterpriseOrganization/imports_enterprise_organization_without_error
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubEnterpriseOrganization/imports_enterprise_organization_invalid_enterprise_name
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubEnterpriseOrganization/imports_enterprise_organization_invalid_organization_name
    acc_test.go:297: Skipping as not supported test mode
--- PASS: TestAccGithubEnterpriseOrganization (0.00s)
    --- SKIP: TestAccGithubEnterpriseOrganization/creates_and_updates_an_enterprise_organization_without_error (0.00s)
    --- SKIP: TestAccGithubEnterpriseOrganization/deletes_an_enterprise_organization_without_error (0.00s)
    --- SKIP: TestAccGithubEnterpriseOrganization/creates_and_updates_org_with_display_name (0.00s)
    --- SKIP: TestAccGithubEnterpriseOrganization/creates_org_without_display_name,_set_and_update_display_name (0.00s)
    --- SKIP: TestAccGithubEnterpriseOrganization/imports_enterprise_organization_without_error (0.00s)
    --- SKIP: TestAccGithubEnterpriseOrganization/imports_enterprise_organization_invalid_enterprise_name (0.00s)
    --- SKIP: TestAccGithubEnterpriseOrganization/imports_enterprise_organization_invalid_organization_name (0.00s)
=== RUN   TestAccGithubEnterpriseSecurityAnalysisSettings
=== RUN   TestAccGithubEnterpriseSecurityAnalysisSettings/creates_enterprise_security_analysis_settings_without_error
    acc_test.go:291: Skipping as test mode is not enterprise
=== RUN   TestAccGithubEnterpriseSecurityAnalysisSettings/creates_enterprise_security_analysis_settings_with_custom_link
    acc_test.go:291: Skipping as test mode is not enterprise
=== RUN   TestAccGithubEnterpriseSecurityAnalysisSettings/updates_enterprise_security_analysis_settings_without_error
    acc_test.go:291: Skipping as test mode is not enterprise
=== RUN   TestAccGithubEnterpriseSecurityAnalysisSettings/creates_minimal_enterprise_security_analysis_settings
    acc_test.go:291: Skipping as test mode is not enterprise
=== RUN   TestAccGithubEnterpriseSecurityAnalysisSettings/imports_enterprise_security_analysis_settings_without_error
    acc_test.go:291: Skipping as test mode is not enterprise
=== RUN   TestAccGithubEnterpriseSecurityAnalysisSettings/handles_custom_link_removal
    acc_test.go:291: Skipping as test mode is not enterprise
--- PASS: TestAccGithubEnterpriseSecurityAnalysisSettings (0.00s)
    --- SKIP: TestAccGithubEnterpriseSecurityAnalysisSettings/creates_enterprise_security_analysis_settings_without_error (0.00s)
    --- SKIP: TestAccGithubEnterpriseSecurityAnalysisSettings/creates_enterprise_security_analysis_settings_with_custom_link (0.00s)
    --- SKIP: TestAccGithubEnterpriseSecurityAnalysisSettings/updates_enterprise_security_analysis_settings_without_error (0.00s)
    --- SKIP: TestAccGithubEnterpriseSecurityAnalysisSettings/creates_minimal_enterprise_security_analysis_settings (0.00s)
    --- SKIP: TestAccGithubEnterpriseSecurityAnalysisSettings/imports_enterprise_security_analysis_settings_without_error (0.00s)
    --- SKIP: TestAccGithubEnterpriseSecurityAnalysisSettings/handles_custom_link_removal (0.00s)
=== RUN   TestAccGithubRepositoryEtagPresent
    acc_test.go:273: Skipping as test mode not authenticated
--- SKIP: TestAccGithubRepositoryEtagPresent (0.00s)
=== RUN   TestAccGithubRepositoryEtagNoDiff
    acc_test.go:273: Skipping as test mode not authenticated
--- SKIP: TestAccGithubRepositoryEtagNoDiff (0.00s)
=== RUN   TestAccGithubIssueLabel
=== RUN   TestAccGithubIssueLabel/creates_and_updates_labels_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubIssueLabel/can_delete_labels_from_archived_repositories_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubIssueLabel (0.00s)
    --- SKIP: TestAccGithubIssueLabel/creates_and_updates_labels_without_error (0.00s)
    --- SKIP: TestAccGithubIssueLabel/can_delete_labels_from_archived_repositories_without_error (0.00s)
=== RUN   TestAccGithubIssueLabels
=== RUN   TestAccGithubIssueLabels/authoritatively_overtakes_existing_labels
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubIssueLabels (0.00s)
    --- SKIP: TestAccGithubIssueLabels/authoritatively_overtakes_existing_labels (0.00s)
=== RUN   TestAccGithubIssueLabelsArchived
=== RUN   TestAccGithubIssueLabelsArchived/can_delete_labels_from_archived_repositories_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubIssueLabelsArchived (0.00s)
    --- SKIP: TestAccGithubIssueLabelsArchived/can_delete_labels_from_archived_repositories_without_error (0.00s)
=== RUN   TestAccGithubIssue
=== RUN   TestAccGithubIssue/creates_an_issue_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubIssue/imports_a_issue_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubIssue (0.00s)
    --- SKIP: TestAccGithubIssue/creates_an_issue_without_error (0.00s)
    --- SKIP: TestAccGithubIssue/imports_a_issue_without_error (0.00s)
=== RUN   TestAccGithubMembership
    resource_github_membership_test.go:16: No external user provided
--- SKIP: TestAccGithubMembership (0.00s)
=== RUN   TestAccGithubOrganizationCustomPropertiesValidation
=== RUN   TestAccGithubOrganizationCustomPropertiesValidation/rejects_invalid_values_editable_by_value
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubOrganizationCustomPropertiesValidation (0.00s)
    --- SKIP: TestAccGithubOrganizationCustomPropertiesValidation/rejects_invalid_values_editable_by_value (0.00s)
=== RUN   TestAccGithubOrganizationCustomProperties
=== RUN   TestAccGithubOrganizationCustomProperties/creates_custom_property_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubOrganizationCustomProperties/create_custom_property_and_update_them
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubOrganizationCustomProperties/imports_organization_custom_property_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubOrganizationCustomProperties/creates_custom_property_with_values_editable_by_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubOrganizationCustomProperties/backward_compatibility_-_property_without_values_editable_by_defaults_correctly
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubOrganizationCustomProperties/update_values_editable_by_from_org_actors_to_org_and_repo_actors
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubOrganizationCustomProperties/imports_existing_property_with_values_editable_by_set_via_UI
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubOrganizationCustomProperties (0.00s)
    --- SKIP: TestAccGithubOrganizationCustomProperties/creates_custom_property_without_error (0.00s)
    --- SKIP: TestAccGithubOrganizationCustomProperties/create_custom_property_and_update_them (0.00s)
    --- SKIP: TestAccGithubOrganizationCustomProperties/imports_organization_custom_property_without_error (0.00s)
    --- SKIP: TestAccGithubOrganizationCustomProperties/creates_custom_property_with_values_editable_by_without_error (0.00s)
    --- SKIP: TestAccGithubOrganizationCustomProperties/backward_compatibility_-_property_without_values_editable_by_defaults_correctly (0.00s)
    --- SKIP: TestAccGithubOrganizationCustomProperties/update_values_editable_by_from_org_actors_to_org_and_repo_actors (0.00s)
    --- SKIP: TestAccGithubOrganizationCustomProperties/imports_existing_property_with_values_editable_by_set_via_UI (0.00s)
=== RUN   TestAccGithubOrganizationCustomRole
=== RUN   TestAccGithubOrganizationCustomRole/creates_custom_repo_role_without_error
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
=== RUN   TestAccGithubOrganizationCustomRole/updates_custom_repo_role_without_error
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
=== RUN   TestAccGithubOrganizationCustomRole/imports_custom_repo_role_without_error
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
--- PASS: TestAccGithubOrganizationCustomRole (0.00s)
    --- SKIP: TestAccGithubOrganizationCustomRole/creates_custom_repo_role_without_error (0.00s)
    --- SKIP: TestAccGithubOrganizationCustomRole/updates_custom_repo_role_without_error (0.00s)
    --- SKIP: TestAccGithubOrganizationCustomRole/imports_custom_repo_role_without_error (0.00s)
=== RUN   TestAccGithubOrganizationRepositoryRole
=== RUN   TestAccGithubOrganizationRepositoryRole/can_create_an_organization_repository_role_without_erroring
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubOrganizationRepositoryRole/can_create_an_minimal_organization_repository_role_without_erroring
    acc_test.go:297: Skipping as not supported test mode
--- PASS: TestAccGithubOrganizationRepositoryRole (0.00s)
    --- SKIP: TestAccGithubOrganizationRepositoryRole/can_create_an_organization_repository_role_without_erroring (0.00s)
    --- SKIP: TestAccGithubOrganizationRepositoryRole/can_create_an_minimal_organization_repository_role_without_erroring (0.00s)
=== RUN   TestAccGithubOrganizationRoleTeamAssignment
=== RUN   TestAccGithubOrganizationRoleTeamAssignment/creates_repo_assignment_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubOrganizationRoleTeamAssignment/create_and_re-creates_role_assignment_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubOrganizationRoleTeamAssignment (0.00s)
    --- SKIP: TestAccGithubOrganizationRoleTeamAssignment/creates_repo_assignment_without_error (0.00s)
    --- SKIP: TestAccGithubOrganizationRoleTeamAssignment/create_and_re-creates_role_assignment_without_error (0.00s)
=== RUN   TestAccGithubOrganizationRoleTeam
=== RUN   TestAccGithubOrganizationRoleTeam/adds_team_to_an_organization_org_role
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubOrganizationRoleTeam (0.00s)
    --- SKIP: TestAccGithubOrganizationRoleTeam/adds_team_to_an_organization_org_role (0.00s)
=== RUN   TestAccGithubOrganizationRole
=== RUN   TestAccGithubOrganizationRole/can_create_an_empty_organization_role
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubOrganizationRole/can_create_an_empty_organization_role_with_a_base_role
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubOrganizationRole/can_create_an_organization_role
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubOrganizationRole/can_create_an_organization_role_with_repo_permissions
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubOrganizationRole/can_create_an_organization_role_with_org_and_repo_permissions
    acc_test.go:297: Skipping as not supported test mode
--- PASS: TestAccGithubOrganizationRole (0.00s)
    --- SKIP: TestAccGithubOrganizationRole/can_create_an_empty_organization_role (0.00s)
    --- SKIP: TestAccGithubOrganizationRole/can_create_an_empty_organization_role_with_a_base_role (0.00s)
    --- SKIP: TestAccGithubOrganizationRole/can_create_an_organization_role (0.00s)
    --- SKIP: TestAccGithubOrganizationRole/can_create_an_organization_role_with_repo_permissions (0.00s)
    --- SKIP: TestAccGithubOrganizationRole/can_create_an_organization_role_with_org_and_repo_permissions (0.00s)
=== RUN   TestAccGithubOrganizationRoleUser
=== RUN   TestAccGithubOrganizationRoleUser/adds_user_to_an_organization_org_role
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubOrganizationRoleUser (0.00s)
    --- SKIP: TestAccGithubOrganizationRoleUser/adds_user_to_an_organization_org_role (0.00s)
=== RUN   TestAccGithubOrganizationRuleset
=== RUN   TestAccGithubOrganizationRuleset/create_branch_ruleset
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
=== RUN   TestAccGithubOrganizationRuleset/create_push_ruleset
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
=== RUN   TestAccGithubOrganizationRuleset/update_ruleset_name
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
=== RUN   TestAccGithubOrganizationRuleset/update_clear_bypass_actors
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
=== RUN   TestAccGithubOrganizationRuleset/update_bypass_mode
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
=== RUN   TestAccGithubOrganizationRuleset/import
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
--- PASS: TestAccGithubOrganizationRuleset (0.00s)
    --- SKIP: TestAccGithubOrganizationRuleset/create_branch_ruleset (0.00s)
    --- SKIP: TestAccGithubOrganizationRuleset/create_push_ruleset (0.00s)
    --- SKIP: TestAccGithubOrganizationRuleset/update_ruleset_name (0.00s)
    --- SKIP: TestAccGithubOrganizationRuleset/update_clear_bypass_actors (0.00s)
    --- SKIP: TestAccGithubOrganizationRuleset/update_bypass_mode (0.00s)
    --- SKIP: TestAccGithubOrganizationRuleset/import (0.00s)
=== RUN   TestAccGithubOrganizationSecurityManager
=== RUN   TestAccGithubOrganizationSecurityManager/adds_team_as_security_manager
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubOrganizationSecurityManager/handles_team_name_changes
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubOrganizationSecurityManager (0.00s)
    --- SKIP: TestAccGithubOrganizationSecurityManager/adds_team_as_security_manager (0.00s)
    --- SKIP: TestAccGithubOrganizationSecurityManager/handles_team_name_changes (0.00s)
=== RUN   TestAccGithubOrganizationSettings
    resource_github_organization_settings_test.go:11: TODO: Make this test cleanup correctly
--- SKIP: TestAccGithubOrganizationSettings (0.00s)
=== RUN   TestAccGithubOrganizationWebhook
=== RUN   TestAccGithubOrganizationWebhook/creates_and_updates_webhooks_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubOrganizationWebhook/imports_webhooks_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubOrganizationWebhook (0.00s)
    --- SKIP: TestAccGithubOrganizationWebhook/creates_and_updates_webhooks_without_error (0.00s)
    --- SKIP: TestAccGithubOrganizationWebhook/imports_webhooks_without_error (0.00s)
=== RUN   TestAccGithubProjectCard
    resource_github_project_card_test.go:14: Skipping test as the GitHub API no longer supports classic projects
--- SKIP: TestAccGithubProjectCard (0.00s)
=== RUN   TestAccGithubReleaseResource
=== RUN   TestAccGithubReleaseResource/create_a_release_with_defaults
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubReleaseResource/create_a_release_on_branch
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubReleaseResource (0.00s)
    --- SKIP: TestAccGithubReleaseResource/create_a_release_with_defaults (0.00s)
    --- SKIP: TestAccGithubReleaseResource/create_a_release_on_branch (0.00s)
=== RUN   TestAccGithubRepositoryAutolinkReference
=== RUN   TestAccGithubRepositoryAutolinkReference/creates_repository_autolink_reference_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryAutolinkReference/imports_repository_autolink_reference_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryAutolinkReference/imports_repository_autolink_reference_by_key_prefix_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryAutolinkReference/deletes_repository_autolink_reference_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryAutolinkReference (0.00s)
    --- SKIP: TestAccGithubRepositoryAutolinkReference/creates_repository_autolink_reference_without_error (0.00s)
    --- SKIP: TestAccGithubRepositoryAutolinkReference/imports_repository_autolink_reference_without_error (0.00s)
    --- SKIP: TestAccGithubRepositoryAutolinkReference/imports_repository_autolink_reference_by_key_prefix_without_error (0.00s)
    --- SKIP: TestAccGithubRepositoryAutolinkReference/deletes_repository_autolink_reference_without_error (0.00s)
=== RUN   TestAccGithubRepositoryCollaborator
    resource_github_repository_collaborator_test.go:14: No external user provided
--- SKIP: TestAccGithubRepositoryCollaborator (0.00s)
=== RUN   TestAccGithubRepositoryCollaboratorArchivedRepo
    resource_github_repository_collaborator_test.go:127: GH_TEST_COLLABORATOR not set, skipping archived repository collaborator test
--- SKIP: TestAccGithubRepositoryCollaboratorArchivedRepo (0.00s)
=== RUN   TestAccGithubRepositoryCollaborators
    resource_github_repository_collaborators_test.go:16: No external user provided
--- SKIP: TestAccGithubRepositoryCollaborators (0.00s)
=== RUN   TestAccGithubRepositoryCustomProperty
=== RUN   TestAccGithubRepositoryCustomProperty/creates_custom_property_of_type_single_select_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubRepositoryCustomProperty/creates_custom_property_of_type_multi_select_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubRepositoryCustomProperty/creates_custom_property_of_type_true-false_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubRepositoryCustomProperty/creates_custom_property_of_type_string_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubRepositoryCustomProperty (0.00s)
    --- SKIP: TestAccGithubRepositoryCustomProperty/creates_custom_property_of_type_single_select_without_error (0.00s)
    --- SKIP: TestAccGithubRepositoryCustomProperty/creates_custom_property_of_type_multi_select_without_error (0.00s)
    --- SKIP: TestAccGithubRepositoryCustomProperty/creates_custom_property_of_type_true-false_without_error (0.00s)
    --- SKIP: TestAccGithubRepositoryCustomProperty/creates_custom_property_of_type_string_without_error (0.00s)
=== RUN   TestAccGithubRepositoryDependabotSecurityUpdates
=== RUN   TestAccGithubRepositoryDependabotSecurityUpdates/enables_automated_security_fixes_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryDependabotSecurityUpdates/disables_automated_security_fixes_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryDependabotSecurityUpdates/imports_automated_security_fixes_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryDependabotSecurityUpdates (0.00s)
    --- SKIP: TestAccGithubRepositoryDependabotSecurityUpdates/enables_automated_security_fixes_without_error (0.00s)
    --- SKIP: TestAccGithubRepositoryDependabotSecurityUpdates/disables_automated_security_fixes_without_error (0.00s)
    --- SKIP: TestAccGithubRepositoryDependabotSecurityUpdates/imports_automated_security_fixes_without_error (0.00s)
=== RUN   TestAccGithubRepositoryDeployKey_basic
=== RUN   TestAccGithubRepositoryDeployKey_basic/creates_repository_deploy_key_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryDeployKey_basic (0.50s)
    --- SKIP: TestAccGithubRepositoryDeployKey_basic/creates_repository_deploy_key_without_error (0.50s)
=== RUN   TestAccGithubRepositoryDeployKeyArchivedRepo
=== RUN   TestAccGithubRepositoryDeployKeyArchivedRepo/can_delete_deploy_keys_from_archived_repositories_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryDeployKeyArchivedRepo (1.09s)
    --- SKIP: TestAccGithubRepositoryDeployKeyArchivedRepo/can_delete_deploy_keys_from_archived_repositories_without_error (1.09s)
=== RUN   TestAccGithubRepositoryDeploymentBranchPolicy
=== RUN   TestAccGithubRepositoryDeploymentBranchPolicy/creates_deployment_branch_policy
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryDeploymentBranchPolicy (0.00s)
    --- SKIP: TestAccGithubRepositoryDeploymentBranchPolicy/creates_deployment_branch_policy (0.00s)
=== RUN   TestAccGithubRepositoryEnvironmentDeploymentPolicy
=== RUN   TestAccGithubRepositoryEnvironmentDeploymentPolicy/creates_a_repository_environment_with_branch-based_deployment_policy
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryEnvironmentDeploymentPolicy/updates_the_pattern_for_a_branch-based_deployment_policy
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryEnvironmentDeploymentPolicy/creates_a_repository_environment_with_tag-based_deployment_policy
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryEnvironmentDeploymentPolicy/updates_the_pattern_for_a_tag-based_deployment_policy
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryEnvironmentDeploymentPolicy/recreates_deployment_policy_when_pattern_type_changes_from_branch_to_tag
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryEnvironmentDeploymentPolicy/recreates_deployment_policy_when_pattern_type_changes_from_tag_to_branch
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryEnvironmentDeploymentPolicy/import
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryEnvironmentDeploymentPolicy/errors_when_no_patterns_are_set
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryEnvironmentDeploymentPolicy/errors_when_both_patterns_are_set
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryEnvironmentDeploymentPolicy/errors_when_an_empty_branch_pattern_is_set
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryEnvironmentDeploymentPolicy/errors_when_an_empty_tag_pattern_is_set
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryEnvironmentDeploymentPolicy (0.00s)
    --- SKIP: TestAccGithubRepositoryEnvironmentDeploymentPolicy/creates_a_repository_environment_with_branch-based_deployment_policy (0.00s)
    --- SKIP: TestAccGithubRepositoryEnvironmentDeploymentPolicy/updates_the_pattern_for_a_branch-based_deployment_policy (0.00s)
    --- SKIP: TestAccGithubRepositoryEnvironmentDeploymentPolicy/creates_a_repository_environment_with_tag-based_deployment_policy (0.00s)
    --- SKIP: TestAccGithubRepositoryEnvironmentDeploymentPolicy/updates_the_pattern_for_a_tag-based_deployment_policy (0.00s)
    --- SKIP: TestAccGithubRepositoryEnvironmentDeploymentPolicy/recreates_deployment_policy_when_pattern_type_changes_from_branch_to_tag (0.00s)
    --- SKIP: TestAccGithubRepositoryEnvironmentDeploymentPolicy/recreates_deployment_policy_when_pattern_type_changes_from_tag_to_branch (0.00s)
    --- SKIP: TestAccGithubRepositoryEnvironmentDeploymentPolicy/import (0.00s)
    --- SKIP: TestAccGithubRepositoryEnvironmentDeploymentPolicy/errors_when_no_patterns_are_set (0.00s)
    --- SKIP: TestAccGithubRepositoryEnvironmentDeploymentPolicy/errors_when_both_patterns_are_set (0.00s)
    --- SKIP: TestAccGithubRepositoryEnvironmentDeploymentPolicy/errors_when_an_empty_branch_pattern_is_set (0.00s)
    --- SKIP: TestAccGithubRepositoryEnvironmentDeploymentPolicy/errors_when_an_empty_tag_pattern_is_set (0.00s)
=== RUN   TestAccGithubRepositoryEnvironment
=== RUN   TestAccGithubRepositoryEnvironment/creates_a_repository_environment
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryEnvironment/creates_a_repository_environment_with_id_separator
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryEnvironment/import
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryEnvironment (0.00s)
    --- SKIP: TestAccGithubRepositoryEnvironment/creates_a_repository_environment (0.00s)
    --- SKIP: TestAccGithubRepositoryEnvironment/creates_a_repository_environment_with_id_separator (0.00s)
    --- SKIP: TestAccGithubRepositoryEnvironment/import (0.00s)
=== RUN   TestAccGithubRepositoryFile
=== RUN   TestAccGithubRepositoryFile/creates_and_manages_files
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryFile/can_be_configured_to_overwrite_files_on_create
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryFile/creates_and_manages_files_on_default_branch_if_branch_is_omitted
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryFile/creates_and_manages_files_on_auto_created_branch_if_branch_does_not_exist
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryFile/can_delete_files_from_archived_repositories_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryFile (0.00s)
    --- SKIP: TestAccGithubRepositoryFile/creates_and_manages_files (0.00s)
    --- SKIP: TestAccGithubRepositoryFile/can_be_configured_to_overwrite_files_on_create (0.00s)
    --- SKIP: TestAccGithubRepositoryFile/creates_and_manages_files_on_default_branch_if_branch_is_omitted (0.00s)
    --- SKIP: TestAccGithubRepositoryFile/creates_and_manages_files_on_auto_created_branch_if_branch_does_not_exist (0.00s)
    --- SKIP: TestAccGithubRepositoryFile/can_delete_files_from_archived_repositories_without_error (0.00s)
=== RUN   TestAccGithubRepositoryMilestone
=== RUN   TestAccGithubRepositoryMilestone/creates_a_repository_milestone
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryMilestone (0.00s)
    --- SKIP: TestAccGithubRepositoryMilestone/creates_a_repository_milestone (0.00s)
=== RUN   TestAccGithubRepositoryProject
    resource_github_repository_project_test.go:13: Skipping test as the GitHub API no longer supports classic projects
--- SKIP: TestAccGithubRepositoryProject (0.00s)
=== RUN   TestAccGithubRepositoryPullRequest
=== RUN   TestAccGithubRepositoryPullRequest/manages_the_pull_request_lifecycle
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryPullRequest (0.00s)
    --- SKIP: TestAccGithubRepositoryPullRequest/manages_the_pull_request_lifecycle (0.00s)
=== RUN   TestAccGithubRepositoryRuleset
=== RUN   TestAccGithubRepositoryRuleset/create_branch_ruleset
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryRuleset/create_branch_ruleset_with_enterprise_features
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubRepositoryRuleset/creates_push_ruleset
    acc_test.go:285: Skipping as test mode doesn't have paid orgs
=== RUN   TestAccGithubRepositoryRuleset/update_ruleset_name
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryRuleset/update_clear_bypass_actors
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryRuleset/update_bypass_mode
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryRuleset/import
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryRuleset (0.00s)
    --- SKIP: TestAccGithubRepositoryRuleset/create_branch_ruleset (0.00s)
    --- SKIP: TestAccGithubRepositoryRuleset/create_branch_ruleset_with_enterprise_features (0.00s)
    --- SKIP: TestAccGithubRepositoryRuleset/creates_push_ruleset (0.00s)
    --- SKIP: TestAccGithubRepositoryRuleset/update_ruleset_name (0.00s)
    --- SKIP: TestAccGithubRepositoryRuleset/update_clear_bypass_actors (0.00s)
    --- SKIP: TestAccGithubRepositoryRuleset/update_bypass_mode (0.00s)
    --- SKIP: TestAccGithubRepositoryRuleset/import (0.00s)
=== RUN   TestAccGithubRepositoryRulesetArchived
=== RUN   TestAccGithubRepositoryRulesetArchived/skips_update_and_delete_on_archived_repository
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryRulesetArchived/prevents_creating_ruleset_on_archived_repository
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryRulesetArchived (0.00s)
    --- SKIP: TestAccGithubRepositoryRulesetArchived/skips_update_and_delete_on_archived_repository (0.00s)
    --- SKIP: TestAccGithubRepositoryRulesetArchived/prevents_creating_ruleset_on_archived_repository (0.00s)
=== RUN   TestAccGithubRepository
=== RUN   TestAccGithubRepository/creates_and_updates_repositories_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/updates_a_repositories_name_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/imports_repositories_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/archives_repositories_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/manages_the_project_feature_for_a_repository
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/manages_the_default_branch_feature_for_a_repository
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/allows_setting_default_branch_on_an_empty_repository
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/manages_the_license_and_gitignore_feature_for_a_repository
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/configures_topics_for_a_repository
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/creates_a_repository_using_a_public_template
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/creates_a_repository_using_an_org_template
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubRepository/archives_repositories_on_destroy
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/configures_vulnerability_alerts_for_a_public_repository
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/create_private_with_forking
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubRepository/create_private_with_forking_unset
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubRepository/configures_vulnerability_alerts_for_a_private_repository
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/create_and_modify_merge_commit_strategy_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/create_and_modify_squash_merge_commit_strategy_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/manages_the_legacy_pages_feature_for_a_repository
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/manages_the_pages_from_workflow_feature_for_a_repository
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/manages_the_security_feature_for_a_private_repository
    resource_github_repository_test.go:900: Advanced Security is not enabled for this account
=== RUN   TestAccGithubRepository/manages_the_security_feature_for_a_public_repository
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/creates_repos_with_private_visibility
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/creates_repos_with_internal_visibility
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubRepository/updates_repos_to_private_visibility
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/update_public_to_private_allow_forking
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/updates_repos_to_public_visibility
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository/updates_repos_to_internal_visibility
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubRepository/sets_private_visibility_for_repositories_created_by_a_template
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepository (0.00s)
    --- SKIP: TestAccGithubRepository/creates_and_updates_repositories_without_error (0.00s)
    --- SKIP: TestAccGithubRepository/updates_a_repositories_name_without_error (0.00s)
    --- SKIP: TestAccGithubRepository/imports_repositories_without_error (0.00s)
    --- SKIP: TestAccGithubRepository/archives_repositories_without_error (0.00s)
    --- SKIP: TestAccGithubRepository/manages_the_project_feature_for_a_repository (0.00s)
    --- SKIP: TestAccGithubRepository/manages_the_default_branch_feature_for_a_repository (0.00s)
    --- SKIP: TestAccGithubRepository/allows_setting_default_branch_on_an_empty_repository (0.00s)
    --- SKIP: TestAccGithubRepository/manages_the_license_and_gitignore_feature_for_a_repository (0.00s)
    --- SKIP: TestAccGithubRepository/configures_topics_for_a_repository (0.00s)
    --- SKIP: TestAccGithubRepository/creates_a_repository_using_a_public_template (0.00s)
    --- SKIP: TestAccGithubRepository/creates_a_repository_using_an_org_template (0.00s)
    --- SKIP: TestAccGithubRepository/archives_repositories_on_destroy (0.00s)
    --- SKIP: TestAccGithubRepository/configures_vulnerability_alerts_for_a_public_repository (0.00s)
    --- SKIP: TestAccGithubRepository/create_private_with_forking (0.00s)
    --- SKIP: TestAccGithubRepository/create_private_with_forking_unset (0.00s)
    --- SKIP: TestAccGithubRepository/configures_vulnerability_alerts_for_a_private_repository (0.00s)
    --- SKIP: TestAccGithubRepository/create_and_modify_merge_commit_strategy_without_error (0.00s)
    --- SKIP: TestAccGithubRepository/create_and_modify_squash_merge_commit_strategy_without_error (0.00s)
    --- SKIP: TestAccGithubRepository/manages_the_legacy_pages_feature_for_a_repository (0.00s)
    --- SKIP: TestAccGithubRepository/manages_the_pages_from_workflow_feature_for_a_repository (0.00s)
    --- SKIP: TestAccGithubRepository/manages_the_security_feature_for_a_private_repository (0.00s)
    --- SKIP: TestAccGithubRepository/manages_the_security_feature_for_a_public_repository (0.00s)
    --- SKIP: TestAccGithubRepository/creates_repos_with_private_visibility (0.00s)
    --- SKIP: TestAccGithubRepository/creates_repos_with_internal_visibility (0.00s)
    --- SKIP: TestAccGithubRepository/updates_repos_to_private_visibility (0.00s)
    --- SKIP: TestAccGithubRepository/update_public_to_private_allow_forking (0.00s)
    --- SKIP: TestAccGithubRepository/updates_repos_to_public_visibility (0.00s)
    --- SKIP: TestAccGithubRepository/updates_repos_to_internal_visibility (0.00s)
    --- SKIP: TestAccGithubRepository/sets_private_visibility_for_repositories_created_by_a_template (0.00s)
=== RUN   TestAccGithubRepository_fork
=== RUN   TestAccGithubRepository_fork/forks_a_repository_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepository_fork/can_update_forked_repository_properties
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepository_fork (0.00s)
    --- SKIP: TestAccGithubRepository_fork/forks_a_repository_without_error (0.00s)
    --- SKIP: TestAccGithubRepository_fork/can_update_forked_repository_properties (0.00s)
=== RUN   TestAccRepository_VulnerabilityAlerts
=== RUN   TestAccRepository_VulnerabilityAlerts/can_enable_vulnerability_alerts
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccRepository_VulnerabilityAlerts/sets_vulnerability_alerts_to_false_when_not_set_in_config
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccRepository_VulnerabilityAlerts/can_disable_vulnerability_alerts
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccRepository_VulnerabilityAlerts/can_modify_vulnerability_alerts
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccRepository_VulnerabilityAlerts (0.00s)
    --- SKIP: TestAccRepository_VulnerabilityAlerts/can_enable_vulnerability_alerts (0.00s)
    --- SKIP: TestAccRepository_VulnerabilityAlerts/sets_vulnerability_alerts_to_false_when_not_set_in_config (0.00s)
    --- SKIP: TestAccRepository_VulnerabilityAlerts/can_disable_vulnerability_alerts (0.00s)
    --- SKIP: TestAccRepository_VulnerabilityAlerts/can_modify_vulnerability_alerts (0.00s)
=== RUN   TestAccGithubRepositoryTopics
=== RUN   TestAccGithubRepositoryTopics/create_repository_topics_and_import_them
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryTopics/create_repository_topics_and_update_them
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryTopics (0.00s)
    --- SKIP: TestAccGithubRepositoryTopics/create_repository_topics_and_import_them (0.00s)
    --- SKIP: TestAccGithubRepositoryTopics/create_repository_topics_and_update_them (0.00s)
=== RUN   TestAccGithubRepositoryWebhook
=== RUN   TestAccGithubRepositoryWebhook/creates_repository_webhooks_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryWebhook/imports_repository_webhooks_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubRepositoryWebhook/updates_repository_webhooks_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubRepositoryWebhook (0.00s)
    --- SKIP: TestAccGithubRepositoryWebhook/creates_repository_webhooks_without_error (0.00s)
    --- SKIP: TestAccGithubRepositoryWebhook/imports_repository_webhooks_without_error (0.00s)
    --- SKIP: TestAccGithubRepositoryWebhook/updates_repository_webhooks_without_error (0.00s)
=== RUN   TestAccGithubTeamMembers
    resource_github_team_members_test.go:15: No test user provided
--- SKIP: TestAccGithubTeamMembers (0.00s)
=== RUN   TestAccGithubTeamMembership
    resource_github_team_membership_test.go:17: No test user provided
--- SKIP: TestAccGithubTeamMembership (0.00s)
=== RUN   TestAccGithubTeamRepository
=== RUN   TestAccGithubTeamRepository/manages_team_permissions_to_a_repository
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubTeamRepository/accepts_both_team_slug_and_team_ID_for_`team_id`
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubTeamRepository (0.00s)
    --- SKIP: TestAccGithubTeamRepository/manages_team_permissions_to_a_repository (0.00s)
    --- SKIP: TestAccGithubTeamRepository/accepts_both_team_slug_and_team_ID_for_`team_id` (0.00s)
=== RUN   TestAccGithubTeamRepositoryArchivedRepo
=== RUN   TestAccGithubTeamRepositoryArchivedRepo/can_delete_team_repository_access_from_archived_repositories_without_error
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubTeamRepositoryArchivedRepo (0.00s)
    --- SKIP: TestAccGithubTeamRepositoryArchivedRepo/can_delete_team_repository_access_from_archived_repositories_without_error (0.00s)
=== RUN   TestAccGithubTeamSettings
=== RUN   TestAccGithubTeamSettings/manages_team_settings_can_use_team_id_id_and_slug
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubTeamSettings/manages_team_code_review_settings
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubTeamSettings/cannot_manage_team_code_review_settings_if_disabled
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubTeamSettings (0.00s)
    --- SKIP: TestAccGithubTeamSettings/manages_team_settings_can_use_team_id_id_and_slug (0.00s)
    --- SKIP: TestAccGithubTeamSettings/manages_team_code_review_settings (0.00s)
    --- SKIP: TestAccGithubTeamSettings/cannot_manage_team_code_review_settings_if_disabled (0.00s)
=== RUN   TestAccGithubTeamSyncGroupMapping_basic
=== RUN   TestAccGithubTeamSyncGroupMapping_basic/creates_a_team_sync_group_mapping
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubTeamSyncGroupMapping_basic/creates_a_team_sync_group_mapping_and_then_deletes_it
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubTeamSyncGroupMapping_basic/creates_a_team_sync_group_mapping_and_then_updates_it
    acc_test.go:297: Skipping as not supported test mode
=== RUN   TestAccGithubTeamSyncGroupMapping_basic/creates_empty_team_sync_group_mapping
    acc_test.go:297: Skipping as not supported test mode
--- PASS: TestAccGithubTeamSyncGroupMapping_basic (0.00s)
    --- SKIP: TestAccGithubTeamSyncGroupMapping_basic/creates_a_team_sync_group_mapping (0.00s)
    --- SKIP: TestAccGithubTeamSyncGroupMapping_basic/creates_a_team_sync_group_mapping_and_then_deletes_it (0.00s)
    --- SKIP: TestAccGithubTeamSyncGroupMapping_basic/creates_a_team_sync_group_mapping_and_then_updates_it (0.00s)
    --- SKIP: TestAccGithubTeamSyncGroupMapping_basic/creates_empty_team_sync_group_mapping (0.00s)
=== RUN   TestAccGithubTeam
=== RUN   TestAccGithubTeam/creates_a_team_configured_with_defaults
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubTeam/creates_a_team_configured_with_alternatives
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubTeam/creates_a_hierarchy_of_teams
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubTeam/creates_a_team_and_removes_the_default_maintainer
    acc_test.go:279: Skipping as test mode doesn't have orgs
=== RUN   TestAccGithubTeam/updates_slug
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccGithubTeam (0.00s)
    --- SKIP: TestAccGithubTeam/creates_a_team_configured_with_defaults (0.00s)
    --- SKIP: TestAccGithubTeam/creates_a_team_configured_with_alternatives (0.00s)
    --- SKIP: TestAccGithubTeam/creates_a_hierarchy_of_teams (0.00s)
    --- SKIP: TestAccGithubTeam/creates_a_team_and_removes_the_default_maintainer (0.00s)
    --- SKIP: TestAccGithubTeam/updates_slug (0.00s)
=== RUN   TestAccGithubUserGpgKey
=== RUN   TestAccGithubUserGpgKey/creates_a_GPG_key_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubUserGpgKey (0.00s)
    --- SKIP: TestAccGithubUserGpgKey/creates_a_GPG_key_without_error (0.00s)
=== RUN   TestAccGithubUserInvitationAccepter
    resource_github_user_invitation_accepter_test.go:15: No external user provided
--- SKIP: TestAccGithubUserInvitationAccepter (0.00s)
=== RUN   TestAccGithubUserSshKey
=== RUN   TestAccGithubUserSshKey/creates_and_destroys_a_user_SSH_key_without_error
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubUserSshKey/imports_an_individual_account_SSH_key_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubUserSshKey (0.01s)
    --- SKIP: TestAccGithubUserSshKey/creates_and_destroys_a_user_SSH_key_without_error (0.00s)
    --- SKIP: TestAccGithubUserSshKey/imports_an_individual_account_SSH_key_without_error (0.01s)
=== RUN   TestAccGithubWorkflowRepositoryPermissions
=== RUN   TestAccGithubWorkflowRepositoryPermissions/test_setting_of_basic_workflow_repository_permissions
    acc_test.go:273: Skipping as test mode not authenticated
=== RUN   TestAccGithubWorkflowRepositoryPermissions/imports_entire_set_of_github_workflow_repository_permissions_without_error
    acc_test.go:273: Skipping as test mode not authenticated
--- PASS: TestAccGithubWorkflowRepositoryPermissions (0.00s)
    --- SKIP: TestAccGithubWorkflowRepositoryPermissions/test_setting_of_basic_workflow_repository_permissions (0.00s)
    --- SKIP: TestAccGithubWorkflowRepositoryPermissions/imports_entire_set_of_github_workflow_repository_permissions_without_error (0.00s)
=== RUN   TestAccOrganizationBlock_basic
=== RUN   TestAccOrganizationBlock_basic/creates_organization_block
    acc_test.go:279: Skipping as test mode doesn't have orgs
--- PASS: TestAccOrganizationBlock_basic (0.00s)
    --- SKIP: TestAccOrganizationBlock_basic/creates_organization_block (0.00s)
PASS
ok  	github.com/integrations/terraform-provider-github/v6/github	46.490s
```
</details>

- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

