### PR TITLE
Fix import command syntax for GitHub custom property documentation

### DIFF
--- a/website/docs/r/repository_custom_property.html.markdown
+++ b/website/docs/r/repository_custom_property.html.markdown
@@ -43,5 +43,5 @@ The following arguments are supported:
 GitHub Repository Custom Property can be imported using an ID made up of a comibnation of the names of the organization, repository, custom property separated by a `:` character, e.g.
 
 ```
-$ terraform import github_repository_custom_property.example <organization-name>:<repo-name>:<custom-property-name>
+$ terraform import github_repository_custom_property.example organization-name:repo-name:custom-property-name
 ```


### PR DESCRIPTION
----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The [import docs example](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_custom_property#import) is showing a broken syntax due to treating `<` as HTML tags (probably): `$ terraform import github_repository_custom_property.example ::`
<img width="612" height="256" alt="image" src="https://github.com/user-attachments/assets/5ce06df7-e6aa-40ce-9010-da2c32316d88" />
 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The import example should show up correctly: `$ terraform import github_repository_custom_property.example organization-name:repo-name:custom-property-name`

### Pull request checklist
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

