### PR TITLE
feat: allow forking added to the repository settings

### DIFF
--- a/github/resource_github_repository_allow_forking_test.go
+++ b/github/resource_github_repository_allow_forking_test.go
@@ -1,0 +1,103 @@
+package github
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccGithubRepositoryAllowForking(t *testing.T) {
+	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+	t.Run("manages allow_forking setting for a repository", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name          = "tf-acc-test-allow-forking-%[1]s"
+				description   = "Terraform acceptance test for allow_forking (Issue #353)"
+				visibility    = "private"
+				allow_forking = false
+				auto_init     = true
+			}
+		`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_repository.test", "allow_forking",
+				"false",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+
+	t.Run("reads allow_forking setting from API", func(t *testing.T) {
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name          = "tf-acc-test-fork-read-%[1]s"
+				description   = "Test allow_forking read from API"
+				visibility    = "private"
+				allow_forking = false
+				auto_init     = true
+			}
+		`, randomID)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_repository.test", "allow_forking",
+				"false",
+			),
+		)
+
+		testCase := func(t *testing.T, mode string) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:  func() { skipUnlessMode(t, mode) },
+				Providers: testAccProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		}
+
+		t.Run("with an anonymous account", func(t *testing.T) {
+			t.Skip("anonymous account not supported for this operation")
+		})
+
+		t.Run("with an individual account", func(t *testing.T) {
+			testCase(t, individual)
+		})
+
+		t.Run("with an organization account", func(t *testing.T) {
+			testCase(t, organization)
+		})
+	})
+}

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -36,6 +36,7 @@ func TestAccGithubRepositories(t *testing.T) {
 				allow_squash_merge          = false
 				allow_rebase_merge          = false
 				allow_auto_merge            = true
+				allow_forking               = true
 				merge_commit_title          = "MERGE_MESSAGE"
 				merge_commit_message        = "PR_TITLE"
 				auto_init                   = false
@@ -54,6 +55,10 @@ func TestAccGithubRepositories(t *testing.T) {
 			),
 			resource.TestCheckResourceAttr(
 				"github_repository.test", "allow_auto_merge",
+				"true",
+			),
+			resource.TestCheckResourceAttr(
+				"github_repository.test", "allow_forking",
 				"true",
 			),
 			resource.TestCheckResourceAttr(


### PR DESCRIPTION

Resolves #353 

----

### Before the change?


* Current behavior does not allow changing the repository setting to allow/disallow forking.

### After the change?


* Repositories can now (optionally) be set to allow forking. This only applies to private and internally owned repositories. This setting cannot be changed on publicly owned repositories as public repositories can always be forked.  

### Pull request checklist
- [x] Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?


Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
