### PR TITLE
fix: Correctly boxes max_file_size as an int and addresses the schema…

### DIFF
--- a/github/resource_github_organization_ruleset_test.go
+++ b/github/resource_github_organization_ruleset_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func TestGithubOrganizationRulesets(t *testing.T) {
@@ -589,7 +590,7 @@ func TestOrganizationPushRulesetSupport(t *testing.T) {
 		},
 		"max_file_size": []interface{}{
 			map[string]interface{}{
-				"max_file_size": float64(10485760), // 10MB
+				"max_file_size": 10485760, // 10MB
 			},
 		},
 		"max_file_path_length": []interface{}{
@@ -599,7 +600,9 @@ func TestOrganizationPushRulesetSupport(t *testing.T) {
 		},
 		"file_extension_restriction": []interface{}{
 			map[string]interface{}{
-				"restricted_file_extensions": []interface{}{".exe", ".bat", ".sh", ".ps1"},
+				"restricted_file_extensions": schema.NewSet(schema.HashString, []interface{}{
+					".exe", ".bat", ".sh", ".ps1",
+				}),
 			},
 		},
 	}

--- a/github/respository_rules_utils_test.go
+++ b/github/respository_rules_utils_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v67/github"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func TestFlattenRulesHandlesUnknownTypes(t *testing.T) {
@@ -255,7 +256,7 @@ func TestMaxFilePathLengthWithOtherRules(t *testing.T) {
 		},
 		"max_file_size": []interface{}{
 			map[string]interface{}{
-				"max_file_size": float64(1048576), // 1MB
+				"max_file_size": 1048576, // 1MB
 			},
 		},
 	}
@@ -349,7 +350,7 @@ func TestCompletePushRulesetSupport(t *testing.T) {
 		},
 		"max_file_size": []interface{}{
 			map[string]interface{}{
-				"max_file_size": float64(5242880), // 5MB
+				"max_file_size": 5242880, // 5MB
 			},
 		},
 		"max_file_path_length": []interface{}{
@@ -359,7 +360,9 @@ func TestCompletePushRulesetSupport(t *testing.T) {
 		},
 		"file_extension_restriction": []interface{}{
 			map[string]interface{}{
-				"restricted_file_extensions": []interface{}{".exe", ".bat", ".sh"},
+				"restricted_file_extensions": schema.NewSet(schema.HashString, []interface{}{
+					".exe", ".bat", ".sh",
+				}),
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2894

To be patched into v6.8.0

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* `max_file_size` was declared as an int but being cast as a float
* `restricted_file_extensions` was panicing due to a Set type mismatch

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Both properties are now properly boxed and used by the provider

### Pull request checklist
- [ ] Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

