### PR TITLE
fix: Correctly boxes max_file_size as an int and addresses the schema…

### DIFF
--- a/github/resource_github_organization_ruleset_test.go
+++ b/github/resource_github_organization_ruleset_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func TestGithubOrganizationRulesets(t *testing.T) {
@@ -574,9 +575,9 @@ func TestOrganizationPushRulesetSupport(t *testing.T) {
 				"restricted_file_paths": []any{"secrets/", "*.key", "private/"},
 			},
 		},
-		"max_file_size": []any{
-			map[string]any{
-				"max_file_size": float64(10485760), // 10MB
+		"max_file_size": []interface{}{
+			map[string]interface{}{
+				"max_file_size": 10485760, // 10MB
 			},
 		},
 		"max_file_path_length": []any{
@@ -586,7 +587,9 @@ func TestOrganizationPushRulesetSupport(t *testing.T) {
 		},
 		"file_extension_restriction": []any{
 			map[string]any{
-				"restricted_file_extensions": []any{".exe", ".bat", ".sh", ".ps1"},
+				"restricted_file_extensions": schema.NewSet(schema.HashString, []any{
+					".exe", ".bat", ".sh", ".ps1",
+				}),
 			},
 		},
 	}

--- a/github/respository_rules_utils.go
+++ b/github/respository_rules_utils.go
@@ -444,7 +444,7 @@ func expandRules(input []any, org bool) []*github.RepositoryRule {
 	// max_file_size rule
 	if v, ok := rulesMap["max_file_size"].([]any); ok && len(v) != 0 {
 		maxFileSizeMap := v[0].(map[string]any)
-		maxFileSize := int64(maxFileSizeMap["max_file_size"].(float64))
+		maxFileSize := int64(maxFileSizeMap["max_file_size"].(int))
 		params := &github.RuleMaxFileSizeParameters{
 			MaxFileSize: maxFileSize,
 		}
@@ -467,13 +467,19 @@ func expandRules(input []any, org bool) []*github.RepositoryRule {
 	if v, ok := rulesMap["file_extension_restriction"].([]any); ok && len(v) != 0 {
 		fileExtensionRestrictionMap := v[0].(map[string]any)
 		restrictedFileExtensions := make([]string, 0)
-		for _, extension := range fileExtensionRestrictionMap["restricted_file_extensions"].([]any) {
+
+		// Handle schema.TypeSet
+		extensionSet := fileExtensionRestrictionMap["restricted_file_extensions"].(*schema.Set)
+		for _, extension := range extensionSet.List() {
 			restrictedFileExtensions = append(restrictedFileExtensions, extension.(string))
 		}
-		params := &github.RuleFileExtensionRestrictionParameters{
-			RestrictedFileExtensions: restrictedFileExtensions,
+
+		if len(restrictedFileExtensions) > 0 {
+			params := &github.RuleFileExtensionRestrictionParameters{
+				RestrictedFileExtensions: restrictedFileExtensions,
+			}
+			rulesSlice = append(rulesSlice, github.NewFileExtensionRestrictionRule(params))
 		}
-		rulesSlice = append(rulesSlice, github.NewFileExtensionRestrictionRule(params))
 	}
 
 	return rulesSlice

--- a/github/respository_rules_utils_test.go
+++ b/github/respository_rules_utils_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v67/github"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func TestFlattenRulesHandlesUnknownTypes(t *testing.T) {
@@ -255,7 +256,7 @@ func TestMaxFilePathLengthWithOtherRules(t *testing.T) {
 		},
 		"max_file_size": []any{
 			map[string]any{
-				"max_file_size": float64(1048576), // 1MB
+				"max_file_size": 1048576, // 1MB
 			},
 		},
 	}
@@ -349,7 +350,7 @@ func TestCompletePushRulesetSupport(t *testing.T) {
 		},
 		"max_file_size": []any{
 			map[string]any{
-				"max_file_size": float64(5242880), // 5MB
+				"max_file_size": 5242880, // 5MB
 			},
 		},
 		"max_file_path_length": []any{
@@ -359,7 +360,9 @@ func TestCompletePushRulesetSupport(t *testing.T) {
 		},
 		"file_extension_restriction": []any{
 			map[string]any{
-				"restricted_file_extensions": []any{".exe", ".bat", ".sh"},
+				"restricted_file_extensions": schema.NewSet(schema.HashString, []any{
+					".exe", ".bat", ".sh",
+				}),
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2894

Patched into v6.8.0

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* `max_file_size` was declared as an int but being cast as a float
* `restricted_file_extensions` was panicing due to a Set type mismatch

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Both properties are now properly boxed and used by the provider

### Pull request checklist
- [ ] Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

