### PR TITLE
chore(actions): Add release stack and extra validation test on Release (tag event)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,63 @@ permissions:
   contents: write
 
 jobs:
+  pre-release-tests:
+    name: Run tests before release
+    runs-on: ubuntu-latest
+    env:
+      test_stacks_directory: test_tf_stacks # root directory for test stacks
+      pre_release_tests: provider_only # directory name for pre-release tests
+    permissions:
+      contents: read
+      
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build provider
+        run: go build -o terraform-provider-github
+
+      - name: Setup dev overrides
+        run: |
+          ROOT_DIR=$(pwd)
+          cat > ~/.terraformrc << EOF
+          provider_installation {
+            dev_overrides {
+              "integrations/github" = "${ROOT_DIR}"
+            }
+            direct {}
+          }
+          EOF
+
+      - name: Verify dev overrides setup
+        run: cat ~/.terraformrc
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: 1.x
+
+      - name: Check Terraform version
+        run: terraform version
+
+      - name: Terraform init
+        continue-on-error: true # continue even if init fails
+        run: terraform -chdir=./${{ env.test_stacks_directory }}/${{ env.pre_release_tests }} init
+
+      - name: Terraform validate
+        run: terraform -chdir=./${{ env.test_stacks_directory }}/${{ env.pre_release_tests }} validate
+
+      - name: Clean up
+        run: rm -f ~/.terraformrc terraform-provider-github
+
   goreleaser:
+    needs: [ pre-release-tests ] # runs only if pre-release tests pass
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/test_tf_stacks/provider_only/provider.tf
+++ b/test_tf_stacks/provider_only/provider.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    github = {
+      source = "integrations/github"
+    }
+  }
+}
+
+provider "github" {
+  token = "fake_token_for_validation"
+}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2856

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* ❌ validation doesn't run on exactly release/tag commit at this moment

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* ✅ add extra job on "Release" workflow to run validation (own Terraform stack) before release happens
* ⚙️ add separate Terraform stack (for now only provider) which makes sense to run on "Release" 
* ✔️ result of the run of new version of workflow can be seen [there](https://github.com/vk-or/terraform-provider-github/actions/runs/19391362778/job/55485271596) 

### Pull request checklist
- [ ] Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

⚠️ PAY ATTENTION: If validation on release workflow fails it means "tag" most likely has to be deleted or moved to the fixed commit as provider is "broken" ! ⚠️ 