### PR TITLE
Remove update method for GitHub Actions secret

### DIFF
--- a/github/resource_github_actions_secret.go
+++ b/github/resource_github_actions_secret.go
@@ -78,7 +78,7 @@ func resourceGithubActionsSecret() *schema.Resource {
 	}
 }
 
-func resourceGithubActionsSecretCreateOrUpdate(d *schema.ResourceData, meta any) error {
+func resourceGithubActionsSecretCreate(d *schema.ResourceData, meta any) error {
 	client := meta.(*Owner).v3client
 	owner := meta.(*Owner).name
 	ctx := context.Background()


### PR DESCRIPTION
I don't think and schema, test, or docs need to be updated. I also did not update the function code itself because it seems like the flow is the same for updates and creates so no reason to modify anything.

Fixes: 
Error: InternalValidate

  with provider["registry.opentofu.org/integrations/github"],
  on main.tofu line 12, in provider "github":
  12: provider "github" {

Internal validation of the provider failed! This is always a bug with the provider itself, and not a user issue. Please report this bug:

resource github_actions_secret: All fields are ForceNew or Computed w/out Optional, Update is superfluous
Error executing opentofu plan
[ERROR] Error during the execution: error running Plan: exit status 1

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

Resolves #2903 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* There was an update method got the `github_actions_secret` resource, but a change in 6.8.2 made updates superfluous causing a plan time provider error

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Since all attributes are now either `Computed` or `ForceNew` the update method is no longer needed. I removed update and renamed the "CreateOrUpdate" method to just be named "Create because it no longer updates"

### Pull request checklist
- [x] Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

