### PR TITLE
chore: Refactor base url logic

### DIFF
--- a/github/apps.go
+++ b/github/apps.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"path"
 	"time"
 
 	"github.com/go-jose/go-jose/v3"
@@ -16,7 +18,7 @@ import (
 
 // GenerateOAuthTokenFromApp generates a GitHub OAuth access token from a set of valid GitHub App credentials.
 // The returned token can be used to interact with both GitHub's REST and GraphQL APIs.
-func GenerateOAuthTokenFromApp(baseURL, appID, appInstallationID, pemData string) (string, error) {
+func GenerateOAuthTokenFromApp(baseURL *url.URL, appID, appInstallationID, pemData string) (string, error) {
 	appJWT, err := generateAppJWT(appID, time.Now(), []byte(pemData))
 	if err != nil {
 		return "", err
@@ -30,14 +32,15 @@ func GenerateOAuthTokenFromApp(baseURL, appID, appInstallationID, pemData string
 	return token, nil
 }
 
-func getInstallationAccessToken(baseURL, jwt, installationID string) (string, error) {
-	if baseURL != "https://api.github.com/" && !GHECDataResidencyMatch.MatchString(baseURL) {
-		baseURL += "api/v3/"
+func getInstallationAccessToken(baseURL *url.URL, jwt, installationID string) (string, error) {
+	hostname := baseURL.Hostname()
+	if hostname != DotComHost && !GHECDataResidencyHostMatch.MatchString(hostname) {
+		baseURL.Path = path.Join(baseURL.Path, "api/v3/")
 	}
 
-	url := fmt.Sprintf("%sapp/installations/%s/access_tokens", baseURL, installationID)
+	baseURL.Path = path.Join(baseURL.Path, "app/installations/", installationID, "access_tokens")
 
-	req, err := http.NewRequest(http.MethodPost, url, nil)
+	req, err := http.NewRequest(http.MethodPost, baseURL.String(), nil)
 	if err != nil {
 		return "", err
 	}

--- a/github/apps_test.go
+++ b/github/apps_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -157,7 +158,12 @@ func TestGetInstallationAccessToken(t *testing.T) {
 	})
 	defer ts.Close()
 
-	accessToken, err := getInstallationAccessToken(ts.URL+"/", fakeJWT, testGitHubAppInstallationID)
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("could not parse test server url")
+	}
+
+	accessToken, err := getInstallationAccessToken(u, fakeJWT, testGitHubAppInstallationID)
 	if err != nil {
 		t.Logf("Unexpected error: %s", err)
 		t.Fail()

--- a/github/config.go
+++ b/github/config.go
@@ -37,9 +37,12 @@ type Owner struct {
 	IsOrganization bool
 }
 
-// GHECDataResidencyMatch is a regex to match a GitHub Enterprise Cloud data residency URL:
-// https://[hostname].ghe.com instances expect paths that behave similar to GitHub.com, not GitHub Enterprise Server.
-var GHECDataResidencyMatch = regexp.MustCompile(`^https:\/\/[a-zA-Z0-9.\-]*\.ghe\.com$`)
+// DotComHost is the hostname for GitHub.com API.
+const DotComHost = "api.github.com"
+
+// GHECDataResidencyHostMatch is a regex to match a GitHub Enterprise Cloud data residency host:
+// https://[hostname].ghe.com/ instances expect paths that behave similar to GitHub.com, not GitHub Enterprise Server.
+var GHECDataResidencyHostMatch = regexp.MustCompile(`^[a-zA-Z0-9.\-]+\.ghe\.com\/?$`)
 
 func RateLimitedHTTPClient(client *http.Client, writeDelay, readDelay, retryDelay time.Duration, parallelRequests bool, retryableErrors map[int]bool, maxRetries int) *http.Client {
 	client.Transport = NewEtagTransport(client.Transport)
@@ -82,7 +85,8 @@ func (c *Config) NewGraphQLClient(client *http.Client) (*githubv4.Client, error)
 		return nil, err
 	}
 
-	if uv4.String() != "https://api.github.com/" && !GHECDataResidencyMatch.MatchString(uv4.String()) {
+	hostname := uv4.Hostname()
+	if hostname != DotComHost && !GHECDataResidencyHostMatch.MatchString(hostname) {
 		uv4.Path = path.Join(uv4.Path, "api/graphql/")
 	} else {
 		uv4.Path = path.Join(uv4.Path, "graphql")
@@ -97,8 +101,9 @@ func (c *Config) NewRESTClient(client *http.Client) (*github.Client, error) {
 		return nil, err
 	}
 
-	if uv3.String() != "https://api.github.com/" && !GHECDataResidencyMatch.MatchString(uv3.String()) {
-		uv3.Path = uv3.Path + "api/v3/"
+	hostname := uv3.Hostname()
+	if hostname != DotComHost && !GHECDataResidencyHostMatch.MatchString(hostname) {
+		uv3.Path = path.Join(uv3.Path, "api/v3/")
 	}
 
 	v3client, err := github.NewClient(client).WithEnterpriseURLs(uv3.String(), "")

--- a/github/config_test.go
+++ b/github/config_test.go
@@ -2,62 +2,62 @@ package github
 
 import (
 	"context"
+	"net/url"
 	"testing"
 
 	"github.com/shurcooL/githubv4"
 )
 
-func TestGHECDataResidencyMatch(t *testing.T) {
+func TestGHECDataResidencyHostMatch(t *testing.T) {
 	testCases := []struct {
 		url         string
 		matches     bool
 		description string
 	}{
 		{
-			url:         "https://customer.ghe.com",
+			url:         "https://customer.ghe.com/",
 			matches:     true,
 			description: "GHEC data residency URL with customer name",
 		},
 		{
-			url:         "https://customer-name.ghe.com",
+			url:         "https://customer-name.ghe.com/",
 			matches:     true,
 			description: "GHEC data residency URL with hyphenated name",
 		},
 		{
-			url:         "https://api.github.com",
-			matches:     false,
-			description: "GitHub.com API URL",
+			url:         "https://customer.ghe.com",
+			matches:     true,
+			description: "GHEC data residency URL without a trailing slash",
 		},
 		{
-			url:         "https://github.com",
+			url:         "https://ghe.com/",
+			matches:     false,
+			description: "GHEC domain without subdomain",
+		},
+		{
+			url:         "https://github.com/",
 			matches:     false,
 			description: "GitHub.com URL",
 		},
 		{
-			url:         "https://example.com",
+			url:         "https://api.github.com/",
+			matches:     false,
+			description: "GitHub.com API URL",
+		},
+		{
+			url:         "https://example.com/",
 			matches:     false,
 			description: "Generic URL",
-		},
-		{
-			url:         "http://customer.ghe.com",
-			matches:     false,
-			description: "Non-HTTPS GHEC URL",
-		},
-		{
-			url:         "https://customer.ghe.com/api/v3",
-			matches:     false,
-			description: "GHEC URL with path",
-		},
-		{
-			url:         "https://ghe.com",
-			matches:     false,
-			description: "GHEC domain without subdomain",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			matches := GHECDataResidencyMatch.MatchString(tc.url)
+			u, err := url.Parse(tc.url)
+			if err != nil {
+				t.Fatalf("failed to parse URL %q: %s", tc.url, err)
+			}
+			matches := GHECDataResidencyHostMatch.MatchString(u.Hostname())
 			if matches != tc.matches {
 				t.Errorf("URL %q: expected match=%v, got %v", tc.url, tc.matches, matches)
 			}

--- a/github/data_source_github_app_token.go
+++ b/github/data_source_github_app_token.go
@@ -41,7 +41,7 @@ func dataSourceGithubAppTokenRead(d *schema.ResourceData, meta any) error {
 	installationID := d.Get("installation_id").(string)
 	pemFile := d.Get("pem_file").(string)
 
-	baseURL := meta.(*Owner).v3client.BaseURL.String()
+	baseURL := meta.(*Owner).v3client.BaseURL
 
 	// The Go encoding/pem package only decodes PEM formatted blocks
 	// that contain new lines. Some platforms, like Terraform Cloud,

--- a/github/provider.go
+++ b/github/provider.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"regexp"
 	"strings"
 	"time"
 
@@ -367,6 +366,11 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 			owner = org
 		}
 
+		bu, err := validateBaseURL(baseURL)
+		if err != nil {
+			return nil, diag.FromErr(err)
+		}
+
 		if appAuth, ok := d.Get("app_auth").([]any); ok && len(appAuth) > 0 && appAuth[0] != nil {
 			appAuthAttr := appAuth[0].(map[string]any)
 
@@ -397,7 +401,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 				return nil, wrapErrors([]error{fmt.Errorf("app_auth.pem_file must be set and contain a non-empty value")})
 			}
 
-			appToken, err := GenerateOAuthTokenFromApp(baseURL, appID, appInstallationID, appPemFile)
+			appToken, err := GenerateOAuthTokenFromApp(bu, appID, appInstallationID, appPemFile)
 			if err != nil {
 				return nil, wrapErrors([]error{err})
 			}
@@ -405,17 +409,8 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 			token = appToken
 		}
 
-		isGithubDotCom, err := regexp.MatchString("^"+regexp.QuoteMeta("https://api.github.com"), baseURL)
-		if err != nil {
-			return nil, diag.FromErr(err)
-		}
-
 		if token == "" {
-			ghAuthToken, err := tokenFromGhCli(baseURL, isGithubDotCom)
-			if err != nil {
-				return nil, diag.FromErr(fmt.Errorf("gh auth token: %w", err))
-			}
-			token = ghAuthToken
+			token = tokenFromGHCLI(bu)
 		}
 
 		writeDelay := d.Get("write_delay_ms").(int)
@@ -488,41 +483,49 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 	}
 }
 
+// validateBaseURL checks that the provided base URL is valid and can be used.
+func validateBaseURL(b string) (*url.URL, error) {
+	u, err := url.Parse(b)
+	if err != nil {
+		return nil, err
+	}
+
+	if !u.IsAbs() {
+		return nil, fmt.Errorf("base_url must be absolute")
+	}
+
+	hostname := u.Hostname()
+	if hostname == DotComHost || GHECDataResidencyHostMatch.MatchString(hostname) {
+		if u.Scheme != "https" {
+			return nil, fmt.Errorf("base_url for github.com or ghe.com must use the https scheme")
+		}
+		if len(u.Path) > 1 {
+			return nil, fmt.Errorf("base_url for github.com or ghe.com must not contain a path, got %s", u.Path)
+		}
+	}
+
+	return u, err
+}
+
 // See https://github.com/integrations/terraform-provider-github/issues/1822
-func tokenFromGhCli(baseURL string, isGithubDotCom bool) (string, error) {
+func tokenFromGHCLI(u *url.URL) string {
 	ghCliPath := os.Getenv("GH_PATH")
 	if ghCliPath == "" {
 		ghCliPath = "gh"
 	}
-	hostname := ""
-	if isGithubDotCom {
-		hostname = "github.com"
-	} else {
-		parsedURL, err := url.Parse(baseURL)
-		if err != nil {
-			return "", fmt.Errorf("parse %s: %w", baseURL, err)
-		}
-		hostname = parsedURL.Host
+
+	host := u.Host
+	if u.Hostname() == DotComHost {
+		host = "github.com"
 	}
-	// GitHub CLI uses different base URLs in ~/.config/gh/hosts.yml, so when
-	// we're using the standard base path of this provider, it doesn't align
-	// with the way `gh` CLI stores the credentials. The following doesn't work:
-	//
-	// $ gh auth token --hostname api.github.com
-	// > no oauth token
-	//
-	// ... but the following does work correctly
-	//
-	// $ gh auth token --hostname github.com
-	// > gh..<valid token>
-	hostname = strings.TrimPrefix(hostname, "api.")
-	out, err := exec.Command(ghCliPath, "auth", "token", "--hostname", hostname).Output()
+
+	out, err := exec.Command(ghCliPath, "auth", "token", "--hostname", host).Output()
 	if err != nil {
 		// GH CLI is either not installed or there was no `gh auth login` command issued,
 		// which is fine. don't return the error to keep the flow going
-		return "", nil //nolint:nilerr
+		return ""
 	}
 
 	log.Printf("[INFO] Using the token from GitHub CLI")
-	return strings.TrimSpace(string(out)), nil
+	return strings.TrimSpace(string(out))
 }

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -202,3 +202,98 @@ func TestAccProviderConfigure(t *testing.T) {
 		})
 	})
 }
+
+func Test_validateBaseURL(t *testing.T) {
+	testCases := []struct {
+		name  string
+		url   string
+		valid bool
+	}{
+		{
+			name:  "dotcom",
+			url:   "https://api.github.com/",
+			valid: true,
+		},
+		{
+			name:  "dotcom_no_slash",
+			url:   "https://api.github.com",
+			valid: true,
+		},
+		{
+			name:  "dotcom_with_path",
+			url:   "http://api.github.com/test/",
+			valid: false,
+		},
+		{
+			name:  "dotcom_http",
+			url:   "http://api.github.com/",
+			valid: false,
+		},
+		{
+			name:  "dotcom_no_scheme",
+			url:   "api.github.com/",
+			valid: false,
+		},
+		{
+			name:  "ghec",
+			url:   "https://customer.ghe.com/",
+			valid: true,
+		},
+		{
+			name:  "ghec_no_slash",
+			url:   "https://customer.ghe.com",
+			valid: true,
+		},
+		{
+			name:  "ghec_with_path",
+			url:   "https://customer.ghe.com/test/",
+			valid: false,
+		},
+		{
+			name:  "ghec_http",
+			url:   "http://customer.ghe.com/",
+			valid: false,
+		},
+		{
+			name:  "ghec_no_scheme",
+			url:   "customer.ghe.com/",
+			valid: false,
+		},
+		{
+			name:  "ghes",
+			url:   "https://example.com/",
+			valid: true,
+		},
+		{
+			name:  "ghes_no_slash",
+			url:   "https://example.com",
+			valid: true,
+		},
+		{
+			name:  "ghes_with_path",
+			url:   "https://example.com/test/",
+			valid: true,
+		},
+		{
+			name:  "ghes_http",
+			url:   "http://example.com/",
+			valid: true,
+		},
+		{
+			name:  "ghes_no_scheme/",
+			url:   "example.com",
+			valid: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := validateBaseURL(tc.url)
+			if err != nil && tc.valid {
+				t.Errorf("URL %q: expected valid URL, got error: %s", tc.url, err)
+			} else if err == nil && !tc.valid {
+				t.Errorf("URL %q: expected invalid URL, got no error", tc.url)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2943
Closes #2944

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The base URL is often handled as a string with manual concatenations
* Base URL validation isn't well defined
* Base URL format is rigid and doesn't actually work for GHEC

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The base URL is handled as a strongly typed `url.URL`
* The base URL is validated with a single function
* GHEC should work correctly

### Pull request checklist
- [x] Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

