### PR TITLE
chore: PR for moving secrets

### DIFF
--- a/.github/workflows/hack-move-secrets.yaml
+++ b/.github/workflows/hack-move-secrets.yaml
@@ -1,0 +1,31 @@
+name: Hack - Move Secrets
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  hack:
+    name: Hack
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    environment:
+      name: hack
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Hack
+        env:
+          GITHUB_TOKEN: ${{ secrets.API_TOKEN }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+        run: |
+          set -eou pipefail
+
+          gh secret set --repo "${GITHUB_REPOSITORY}" --env release --app actions "GPG_PRIVATE_KEY" --body "${GPG_PRIVATE_KEY}"
+          gh secret set --repo "${GITHUB_REPOSITORY}" --env release --app actions "PASSPHRASE" --body "${PASSPHRASE}"


### PR DESCRIPTION
**DO NOT MERGE!**

@nickfloyd if you add a PAT token to the `API_TOKEN` secret in the `hack` environment you should be able to re-run the hack workflow to move the secret. This can all happen on this PR, no need to merge anything to `main`.