### PR TITLE
breaking: remove deprecated `asserts_url` attribute

### DIFF
--- a/github/data_source_github_release.go
+++ b/github/data_source_github_release.go
@@ -82,11 +82,6 @@ func dataSourceGithubRelease() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"asserts_url": {
-				Type:       schema.TypeString,
-				Computed:   true,
-				Deprecated: "use assets_url instead",
-			},
 			"upload_url": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -228,10 +223,6 @@ func dataSourceGithubReleaseRead(d *schema.ResourceData, meta any) error {
 		return err
 	}
 	err = d.Set("assets_url", release.GetAssetsURL())
-	if err != nil {
-		return err
-	}
-	err = d.Set("asserts_url", release.GetAssetsURL()) // Deprecated, original version of assets_url
 	if err != nil {
 		return err
 	}

--- a/website/docs/d/release.html.markdown
+++ b/website/docs/d/release.html.markdown
@@ -69,7 +69,6 @@ data "github_release" "example" {
  * `url` - Base URL of the release
  * `html_url` - URL directing to detailed information on the release
  * `assets_url` - URL of any associated assets with the release
- * `asserts_url` - **Deprecated**: Use `assets_url` resource instead
  * `upload_url` - URL that can be used to upload Assets to the release
  * `zipball_url` - Download URL of a specific release in `zip` format
  * `tarball_url` - Download URL of a specific release in `tar.gz` format


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #488 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The `github_release` data source marked this field as deprecated, with 2 attributes referencing the same upstream value.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* This will remove the field and require all usage to move to referencing `assets_url` . 

### Pull request checklist
- [ ] Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [x] Yes
- [ ] No

----

