### PR TITLE
[BUG] Fixes boolean conversions in rulesets from causing Panics

### DIFF
--- a/github/respository_rules_utils.go
+++ b/github/respository_rules_utils.go
@@ -144,7 +144,10 @@ func expandConditions(input []any, org bool) *github.RulesetConditions {
 				}
 			}
 
-			protected := inputRepositoryName["protected"].(bool)
+			protected, ok := inputRepositoryName["protected"].(bool)
+			if !ok {
+				protected = false
+			}
 
 			rulesetConditions.RepositoryName = &github.RulesetRepositoryNamesConditionParameters{
 				Include:   include,
@@ -277,7 +280,10 @@ func expandRules(input []any, org bool) []*github.RepositoryRule {
 			patternParametersMap := v[0].(map[string]any)
 
 			name := patternParametersMap["name"].(string)
-			negate := patternParametersMap["negate"].(bool)
+			negate, ok := patternParametersMap["negate"].(bool)
+			if !ok {
+				negate = false
+			}
 
 			params := &github.RulePatternParameters{
 				Name:     &name,
@@ -355,10 +361,17 @@ func expandRules(input []any, org bool) []*github.RepositoryRule {
 			}
 		}
 
-		doNotEnforceOnCreate := requiredStatusMap["do_not_enforce_on_create"].(bool)
+		doNotEnforceOnCreate, ok := requiredStatusMap["do_not_enforce_on_create"].(bool)
+		if !ok {
+			doNotEnforceOnCreate = false
+		}
+		strictRequiredStatusChecksPolicy, ok := requiredStatusMap["strict_required_status_checks_policy"].(bool)
+		if !ok {
+			strictRequiredStatusChecksPolicy = false
+		}
 		params := &github.RequiredStatusChecksRuleParameters{
 			RequiredStatusChecks:             requiredStatusChecks,
-			StrictRequiredStatusChecksPolicy: requiredStatusMap["strict_required_status_checks_policy"].(bool),
+			StrictRequiredStatusChecksPolicy: strictRequiredStatusChecksPolicy,
 			DoNotEnforceOnCreate:             &doNotEnforceOnCreate,
 		}
 		rulesSlice = append(rulesSlice, github.NewRequiredStatusChecksRule(params))
@@ -389,8 +402,13 @@ func expandRules(input []any, org bool) []*github.RepositoryRule {
 			}
 		}
 
+		doNotEnforceOnCreate, ok := requiredWorkflowsMap["do_not_enforce_on_create"].(bool)
+		if !ok {
+			doNotEnforceOnCreate = false
+		}
+
 		params := &github.RequiredWorkflowsRuleParameters{
-			DoNotEnforceOnCreate: requiredWorkflowsMap["do_not_enforce_on_create"].(bool),
+			DoNotEnforceOnCreate: doNotEnforceOnCreate,
 			RequiredWorkflows:    requiredWorkflows,
 		}
 		rulesSlice = append(rulesSlice, github.NewRequiredWorkflowsRule(params))


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2708 #2872 https://github.com/integrations/terraform-provider-github/issues/2776

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Reading rulesets might cause a Panic if expected boolean values were nil

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Boolean conversions should default to `false` if conversion failed

### Pull request checklist
- [ ] ~Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))~
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)                                                            

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No
                                                                                                                                                  
----