### PR TITLE
fix: Fix organization_custom_properties create

### DIFF
--- a/github/resource_github_organization_custom_properties.go
+++ b/github/resource_github_organization_custom_properties.go
@@ -85,16 +85,19 @@ func resourceGithubCustomPropertiesCreate(d *schema.ResourceData, meta any) erro
 	for _, v := range allowedValues {
 		allowedValuesString = append(allowedValuesString, v.(string))
 	}
-	valuesEditableBy := d.Get("values_editable_by").(string)
 
 	customProperty := &github.CustomProperty{
-		PropertyName:     &propertyName,
-		ValueType:        valueType,
-		Required:         &required,
-		DefaultValue:     &defaultValue,
-		Description:      &description,
-		AllowedValues:    allowedValuesString,
-		ValuesEditableBy: &valuesEditableBy,
+		PropertyName:  &propertyName,
+		ValueType:     valueType,
+		Required:      &required,
+		DefaultValue:  &defaultValue,
+		Description:   &description,
+		AllowedValues: allowedValuesString,
+	}
+
+	if val, ok := d.GetOk("values_editable_by"); ok {
+		str := val.(string)
+		customProperty.ValuesEditableBy = &str
 	}
 
 	customProperty, _, err := client.Organizations.CreateOrUpdateCustomProperty(ctx, ownerName, d.Get("property_name").(string), customProperty)


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2985

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* `github_organization_custom_properties` couldn't be created without explicitly setting `values_editable_by`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* `github_organization_custom_properties` can be created with any valid configuration

### Pull request checklist
- [x] Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

