### PR TITLE
[BUG] `github_organization_role` Ensure `role_id` is set after Create

### DIFF
--- a/github/resource_github_organization_role.go
+++ b/github/resource_github_organization_role.go
@@ -84,6 +84,9 @@ func resourceGithubOrganizationRoleCreate(ctx context.Context, d *schema.Resourc
 	}
 
 	d.SetId(fmt.Sprint(role.GetID()))
+	if err = d.Set("role_id", role.GetID()); err != nil {
+		return diag.FromErr(err)
+	}
 	return nil
 }
 

--- a/github/resource_github_organization_role.go
+++ b/github/resource_github_organization_role.go
@@ -73,12 +73,18 @@ func resourceGithubOrganizationRoleCreate(ctx context.Context, d *schema.Resourc
 		permissionsStr[i] = v.(string)
 	}
 
-	role, _, err := client.Organizations.CreateCustomOrgRole(ctx, orgName, &github.CreateOrUpdateOrgRoleOptions{
+	createOrUpdateOrgRoleOptions := &github.CreateOrUpdateOrgRoleOptions{
 		Name:        github.String(d.Get("name").(string)),
 		Description: github.String(d.Get("description").(string)),
-		BaseRole:    github.String(d.Get("base_role").(string)),
 		Permissions: permissionsStr,
-	})
+	}
+
+	baseRole := d.Get("base_role").(string)
+	if baseRole != "none" {
+		createOrUpdateOrgRoleOptions.BaseRole = github.String(baseRole)
+	}
+
+	role, _, err := client.Organizations.CreateCustomOrgRole(ctx, orgName, createOrUpdateOrgRoleOptions)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating organization role (%s/%s): %w", orgName, d.Get("name").(string), err))
 	}
@@ -126,8 +132,14 @@ func resourceGithubOrganizationRoleRead(ctx context.Context, d *schema.ResourceD
 	if err = d.Set("description", role.Description); err != nil {
 		return diag.FromErr(err)
 	}
-	if err = d.Set("base_role", role.BaseRole); err != nil {
-		return diag.FromErr(err)
+	if role.BaseRole != nil {
+		if err = d.Set("base_role", role.BaseRole); err != nil {
+			return diag.FromErr(err)
+		}
+	} else {
+		if err = d.Set("base_role", "none"); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 	if err = d.Set("permissions", role.Permissions); err != nil {
 		return diag.FromErr(err)

--- a/github/resource_github_organization_role_test.go
+++ b/github/resource_github_organization_role_test.go
@@ -12,6 +12,7 @@ func TestAccGithubOrganizationRole(t *testing.T) {
 	t.Run("can create an empty organization role", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		name := fmt.Sprintf("tf-acc-org-role-%s", randomID)
+		baseRole := "none"
 		config := fmt.Sprintf(`
 			resource "github_organization_role" "test" {
 				name        = "%s"
@@ -25,12 +26,12 @@ func TestAccGithubOrganizationRole(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: config,
-					Check: resource.ComposeTestCheckFunc(
+					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttrSet("github_organization_role.test", "id"),
 						resource.TestCheckResourceAttrSet("github_organization_role.test", "role_id"),
 						resource.TestCheckResourceAttr("github_organization_role.test", "name", name),
-						resource.TestCheckResourceAttr("github_organization_role.test", "base_role", "none"),
-						resource.TestCheckResourceAttrSet("github_organization_role.test", "permissions.#"),
+						resource.TestCheckResourceAttr("github_organization_role.test", "base_role", baseRole),
+						resource.TestCheckNoResourceAttr("github_organization_role.test", "permissions"),
 						resource.TestCheckResourceAttr("github_organization_role.test", "permissions.#", "0"),
 					),
 				},
@@ -57,11 +58,11 @@ func TestAccGithubOrganizationRole(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: config,
-					Check: resource.ComposeTestCheckFunc(
+					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttrSet("github_organization_role.test", "id"),
 						resource.TestCheckResourceAttr("github_organization_role.test", "name", name),
 						resource.TestCheckResourceAttr("github_organization_role.test", "base_role", baseRole),
-						resource.TestCheckResourceAttrSet("github_organization_role.test", "permissions.#"),
+						resource.TestCheckNoResourceAttr("github_organization_role.test", "permissions"),
 						resource.TestCheckResourceAttr("github_organization_role.test", "permissions.#", "0"),
 					),
 				},
@@ -167,7 +168,7 @@ func TestAccGithubOrganizationRole(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: config,
-					Check: resource.ComposeTestCheckFunc(
+					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttrSet("github_organization_role.test", "id"),
 						resource.TestCheckResourceAttrSet("github_organization_role.test", "role_id"),
 						resource.TestCheckResourceAttr("github_organization_role.test", "name", name),
@@ -175,8 +176,8 @@ func TestAccGithubOrganizationRole(t *testing.T) {
 						resource.TestCheckResourceAttr("github_organization_role.test", "base_role", baseRole),
 						resource.TestCheckResourceAttrSet("github_organization_role.test", "permissions.#"),
 						resource.TestCheckResourceAttr("github_organization_role.test", "permissions.#", "2"),
-						resource.TestCheckResourceAttr("github_organization_role.test", "permissions.0", permission0),
-						resource.TestCheckResourceAttr("github_organization_role.test", "permissions.1", permission1),
+						resource.TestCheckTypeSetElemAttr("github_organization_role.test", "permissions.*", permission0),
+						resource.TestCheckTypeSetElemAttr("github_organization_role.test", "permissions.*", permission1),
 					),
 				},
 			},

--- a/github/resource_github_organization_role_test.go
+++ b/github/resource_github_organization_role_test.go
@@ -12,7 +12,6 @@ func TestAccGithubOrganizationRole(t *testing.T) {
 	t.Run("can create an empty organization role", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		name := fmt.Sprintf("tf-acc-org-role-%s", randomID)
-		baseRole := "none"
 		config := fmt.Sprintf(`
 			resource "github_organization_role" "test" {
 				name        = "%s"
@@ -30,7 +29,7 @@ func TestAccGithubOrganizationRole(t *testing.T) {
 						resource.TestCheckResourceAttrSet("github_organization_role.test", "id"),
 						resource.TestCheckResourceAttrSet("github_organization_role.test", "role_id"),
 						resource.TestCheckResourceAttr("github_organization_role.test", "name", name),
-						resource.TestCheckResourceAttr("github_organization_role.test", "base_role", baseRole),
+						resource.TestCheckResourceAttr("github_organization_role.test", "base_role", "none"),
 						resource.TestCheckNoResourceAttr("github_organization_role.test", "permissions"),
 						resource.TestCheckResourceAttr("github_organization_role.test", "permissions.#", "0"),
 					),


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #3009
Resolves #3004

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* `role_id` wouldn't not be set during `apply`, only on next `plan`, thus rendering the resource unusable for references

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* `role_id` is set in Create allowing it to be used in references

### Pull request checklist
- [ ] ~Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))~
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

