### PR TITLE
chore: update readme to reference min go version compatible with go.mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project is used to manipulate GitHub resources (repositories, teams, files,
 ## Requirements
 
 -	[Terraform](https://www.terraform.io/downloads.html) 0.10.x
--	[Go](https://golang.org/doc/install) 1.19.x (to build the provider plugin)
+-	[Go](https://golang.org/doc/install) 1.24.x (to build the provider plugin)
 
 ## Usage
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Relates #2864 

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

docs-only change: current requirements section references a min go version that is not compatible with version in `go.mod`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

README updated with golang version requirement reflecting the min version required by the module

### Pull request checklist
- [ ] Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

