### PR TITLE
fix(enterprise_organization): prevent taint when PAT not yet authorized

### DIFF
--- a/github/resource_github_enterprise_organization_test.go
+++ b/github/resource_github_enterprise_organization_test.go
@@ -2,12 +2,17 @@ package github
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"regexp"
 	"strings"
 	"testing"
 
+	"github.com/google/go-github/v67/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/shurcooL/githubv4"
 )
 
 func TestAccGithubEnterpriseOrganization(t *testing.T) {
@@ -567,5 +572,156 @@ func TestAccGithubEnterpriseOrganization(t *testing.T) {
 			}
 			testCase(t, enterprise)
 		})
+	})
+}
+
+// TestEnterpriseOrganizationReadGraphQLErrorHandling tests the Read function's
+// behavior when GraphQL returns "Could not resolve to a node" error.
+// This can happen when:
+// 1. The org was actually deleted
+// 2. The org exists but the PAT hasn't been authorized for it yet (EMU/SSO)
+func TestEnterpriseOrganizationReadGraphQLErrorHandling(t *testing.T) {
+	graphqlNotFoundResponse := `{
+		"data": { "node": null },
+		"errors": [{
+			"type": "NOT_FOUND",
+			"path": ["node"],
+			"message": "Could not resolve to a node with the global id of 'O_test123'"
+		}]
+	}`
+
+	t.Run("returns error and preserves state when REST returns 404 (could be deleted or unauthorized)", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/graphql", func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(graphqlNotFoundResponse))
+		})
+		mux.HandleFunc("/api/v3/orgs/test-org", func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"message": "Not Found"}`))
+		})
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		v3client, _ := github.NewClient(nil).WithEnterpriseURLs(server.URL+"/api/v3/", server.URL+"/")
+		meta := &Owner{
+			v4client: githubv4.NewClient(&http.Client{Transport: localRoundTripper{handler: mux}}),
+			v3client: v3client,
+		}
+
+		resourceData := schema.TestResourceDataRaw(t, resourceGithubEnterpriseOrganization().Schema, map[string]interface{}{
+			"name":          "test-org",
+			"enterprise_id": "E_test",
+			"billing_email": "test@example.com",
+			"admin_logins":  []interface{}{"admin"},
+		})
+		resourceData.SetId("O_test123")
+
+		err := resourceGithubEnterpriseOrganizationRead(resourceData, meta)
+
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "cannot read organization") {
+			t.Fatalf("expected 'cannot read organization' error, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "terraform state rm") {
+			t.Fatalf("expected guidance to use 'terraform state rm', got: %v", err)
+		}
+		if resourceData.Id() == "" {
+			t.Fatal("expected resource ID to NOT be cleared (to prevent accidental destruction)")
+		}
+	})
+
+	t.Run("returns error when org exists but GraphQL can't access it (REST 200)", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/graphql", func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(graphqlNotFoundResponse))
+		})
+		mux.HandleFunc("/api/v3/orgs/test-org", func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"login": "test-org", "id": 123}`))
+		})
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		v3client, _ := github.NewClient(nil).WithEnterpriseURLs(server.URL+"/api/v3/", server.URL+"/")
+		meta := &Owner{
+			v4client: githubv4.NewClient(&http.Client{Transport: localRoundTripper{handler: mux}}),
+			v3client: v3client,
+		}
+
+		resourceData := schema.TestResourceDataRaw(t, resourceGithubEnterpriseOrganization().Schema, map[string]interface{}{
+			"name":          "test-org",
+			"enterprise_id": "E_test",
+			"billing_email": "test@example.com",
+			"admin_logins":  []interface{}{"admin"},
+		})
+		resourceData.SetId("O_test123")
+
+		err := resourceGithubEnterpriseOrganizationRead(resourceData, meta)
+
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "exists but cannot be read via GraphQL") {
+			t.Fatalf("expected PAT authorization error message, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "authorize the PAT") {
+			t.Fatalf("expected guidance to authorize PAT, got: %v", err)
+		}
+		if resourceData.Id() == "" {
+			t.Fatal("expected resource ID to NOT be cleared")
+		}
+	})
+
+	t.Run("returns error and preserves state when REST fails with 403", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/graphql", func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(graphqlNotFoundResponse))
+		})
+		mux.HandleFunc("/api/v3/orgs/test-org", func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(`{"message": "Forbidden"}`))
+		})
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		v3client, _ := github.NewClient(nil).WithEnterpriseURLs(server.URL+"/api/v3/", server.URL+"/")
+		meta := &Owner{
+			v4client: githubv4.NewClient(&http.Client{Transport: localRoundTripper{handler: mux}}),
+			v3client: v3client,
+		}
+
+		resourceData := schema.TestResourceDataRaw(t, resourceGithubEnterpriseOrganization().Schema, map[string]interface{}{
+			"name":          "test-org",
+			"enterprise_id": "E_test",
+			"billing_email": "test@example.com",
+			"admin_logins":  []interface{}{"admin"},
+		})
+		resourceData.SetId("O_test123")
+
+		err := resourceGithubEnterpriseOrganizationRead(resourceData, meta)
+
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "cannot read organization") {
+			t.Fatalf("expected 'cannot read organization' error, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "GraphQL error") {
+			t.Fatalf("expected GraphQL error in message, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "REST error") {
+			t.Fatalf("expected REST error in message, got: %v", err)
+		}
+		if resourceData.Id() == "" {
+			t.Fatal("expected resource ID to NOT be cleared")
+		}
 	})
 }


### PR DESCRIPTION
  Resolves #1914

  ----

### Before the change?

When creating a `github_enterprise_organization` in an EMU environment, REST API calls fail with SAML enforcement errors until the PAT is authorized for the new org. This affects setting `description`/`display_name` during create (and any subsequent updates). The error caused Terraform to taint the resource, leading to destroy+recreate on the next apply.

### After the change?

SAML enforcement errors during create/update are now caught and handled gracefully:
- On create: clears `description`/`display_name` from state so it reflects reality
- On update: resets fields to previous values so state stays accurate
- Returns success instead of error to prevent tainting
- Logs a warning instructing the user to authorize the PAT and re-apply

Next plan will show drift and retry after PAT authorization.

### Pull request checklist
- [ ] Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No