### PR TITLE
fix: Prevent enterprise org taint on SAML enforcement error

### DIFF
--- a/github/resource_github_enterprise_organization.go
+++ b/github/resource_github_enterprise_organization.go
@@ -324,7 +324,7 @@ func updateDescription(ctx context.Context, data *schema.ResourceData, v3 *githu
 			ctx,
 			orgName,
 			&github.Organization{
-Description: github.Ptr(newDesc),
+				Description: github.Ptr(newDesc),
 			},
 		)
 		if err != nil {
@@ -349,7 +349,7 @@ func updateDisplayName(ctx context.Context, data *schema.ResourceData, v4 *githu
 			ctx,
 			orgName,
 			&github.Organization{
-Name: github.Ptr(newDisplayName),
+				Name: github.Ptr(newDisplayName),
 			},
 		)
 		if err != nil {

--- a/github/resource_github_enterprise_organization_test.go
+++ b/github/resource_github_enterprise_organization_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-github/v67/github"
+	"github.com/google/go-github/v81/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )


### PR DESCRIPTION
Resolves #1914

----

### Before the change?

When creating a `github_enterprise_organization` in an EMU environment, REST API calls fail with SAML enforcement errors until the PAT is authorized for the new org. This affects setting `description`/`display_name` during create (and any subsequent updates). The error caused Terraform to taint the resource, leading to destroy+recreate on the next apply.

### After the change?

SAML enforcement errors during create/update are now caught and handled gracefully:
- On create: clears `description`/`display_name` from state so it reflects reality
- On update: resets fields to previous values so state stays accurate
- Returns success instead of error to prevent tainting
- Logs a warning instructing the user to authorize the PAT and re-apply

Next plan will show drift and retry after PAT authorization.

### Pull request checklist
- [ ] Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No