### PR TITLE
[MAINT]: Update GNUmakefile to enhance test command functionality

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -62,14 +62,6 @@ testacc:
 	printf "==> Running acceptance tests on branch: \033[1m%s\033[0m...\n" "🌿 $$branch 🌿"
 	TF_ACC=1 CGO_ENABLED=0 go test $(TEST) -v -run '^TestAcc' $(RUNARGS) $(TESTARGS) -timeout 120m -count=1
 
-test-compile:
-	@if [ "$(TEST)" = "./..." ]; then \
-		echo "ERROR: Set TEST to a specific package. For example,"; \
-		echo "  make test-compile TEST=./$(PKG_NAME)"; \
-		exit 1; \
-	fi
-	CGO_ENABLED=0 go test -c $(TEST) $(TESTARGS)
-
 sweep:
 	@echo "WARNING: This will destroy infrastructure. Use only in development accounts."
 	go test $(TEST) -v -sweep=$(SWEEP) $(SWEEPARGS)
@@ -92,4 +84,4 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build test testacc fmt lint lintcheck tools test-compile website website-lint website-test sweep
+.PHONY: build test testacc fmt lint lintcheck tools website website-lint website-test sweep


### PR DESCRIPTION
Supersedes #3020

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* No way to declare a granular test pattern for `make testacc`
* Coverage ran for all test commands

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Able to declare a granular test pattern for `make testacc T=TestAccFoo`
  * Inspired by: https://github.com/hashicorp/terraform-provider-aws/blob/main/GNUmakefile
* Coverage is only run if `COV=true` when calling a make command

### Pull request checklist
- [ ] ~Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))~
- [ ] ~Tests for the changes have been added (for bug fixes / features)~
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

