### PR TITLE
[BUG] ensure failed membership invite can be deleted

### DIFF
--- a/github/resource_github_membership.go
+++ b/github/resource_github_membership.go
@@ -66,7 +66,7 @@ func resourceGithubMembershipCreateOrUpdate(ctx context.Context, d *schema.Resou
 		ctx = context.WithValue(ctx, ctxId, d.Id())
 	}
 
-	_, _, err = client.Organizations.EditOrgMembership(ctx,
+	_, resp, err := client.Organizations.EditOrgMembership(ctx,
 		username,
 		orgName,
 		&github.Membership{
@@ -79,7 +79,11 @@ func resourceGithubMembershipCreateOrUpdate(ctx context.Context, d *schema.Resou
 
 	d.SetId(buildTwoPartID(orgName, username))
 
-	return resourceGithubMembershipRead(ctx, d, meta)
+	if err = d.Set("etag", resp.Header.Get("ETag")); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
 }
 
 func resourceGithubMembershipRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/github/resource_github_membership.go
+++ b/github/resource_github_membership.go
@@ -174,6 +174,17 @@ func resourceGithubMembershipDelete(ctx context.Context, d *schema.ResourceData,
 	} else {
 		log.Printf("[INFO] Revoking '%s' membership for '%s'", orgName, username)
 		_, err = client.Organizations.RemoveOrgMembership(ctx, username, orgName)
+		if err != nil {
+			var ghErr *github.ErrorResponse
+			if errors.As(err, &ghErr) {
+				if ghErr.Response.StatusCode == http.StatusNotFound {
+					log.Printf("[INFO] Not removing '%s' membership for '%s' because they are not a member of the org anymore", orgName, username)
+					return nil
+				}
+			}
+
+			return diag.FromErr(err)
+		}
 	}
 
 	return diag.FromErr(err)

--- a/github/resource_github_membership.go
+++ b/github/resource_github_membership.go
@@ -7,15 +7,16 @@ import (
 	"net/http"
 
 	"github.com/google/go-github/v81/github"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceGithubMembership() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceGithubMembershipCreateOrUpdate,
-		Read:   resourceGithubMembershipRead,
-		Update: resourceGithubMembershipCreateOrUpdate,
-		Delete: resourceGithubMembershipDelete,
+		CreateContext: resourceGithubMembershipCreateOrUpdate,
+		ReadContext:   resourceGithubMembershipRead,
+		UpdateContext: resourceGithubMembershipCreateOrUpdate,
+		DeleteContext: resourceGithubMembershipDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -49,10 +50,10 @@ func resourceGithubMembership() *schema.Resource {
 	}
 }
 
-func resourceGithubMembershipCreateOrUpdate(d *schema.ResourceData, meta any) error {
+func resourceGithubMembershipCreateOrUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	err := checkOrganization(meta)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	client := meta.(*Owner).v3client
@@ -60,7 +61,6 @@ func resourceGithubMembershipCreateOrUpdate(d *schema.ResourceData, meta any) er
 	orgName := meta.(*Owner).name
 	username := d.Get("username").(string)
 	roleName := d.Get("role").(string)
-	ctx := context.Background()
 	if !d.IsNewResource() {
 		ctx = context.WithValue(ctx, ctxId, d.Id())
 	}
@@ -73,18 +73,18 @@ func resourceGithubMembershipCreateOrUpdate(d *schema.ResourceData, meta any) er
 		},
 	)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(buildTwoPartID(orgName, username))
 
-	return resourceGithubMembershipRead(d, meta)
+	return resourceGithubMembershipRead(ctx, d, meta)
 }
 
-func resourceGithubMembershipRead(d *schema.ResourceData, meta any) error {
+func resourceGithubMembershipRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	err := checkOrganization(meta)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	client := meta.(*Owner).v3client
@@ -92,9 +92,9 @@ func resourceGithubMembershipRead(d *schema.ResourceData, meta any) error {
 	orgName := meta.(*Owner).name
 	_, username, err := parseTwoPartID(d.Id(), "organization", "username")
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
-	ctx := context.WithValue(context.Background(), ctxId, d.Id())
+	ctx = context.WithValue(ctx, ctxId, d.Id())
 	if !d.IsNewResource() {
 		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
 	}
@@ -114,31 +114,31 @@ func resourceGithubMembershipRead(d *schema.ResourceData, meta any) error {
 				return nil
 			}
 		}
-		return err
+		return diag.FromErr(err)
 	}
 
 	if err = d.Set("etag", resp.Header.Get("ETag")); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	if err = d.Set("username", username); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	if err = d.Set("role", membership.GetRole()); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	return nil
 }
 
-func resourceGithubMembershipDelete(d *schema.ResourceData, meta any) error {
+func resourceGithubMembershipDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	err := checkOrganization(meta)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	client := meta.(*Owner).v3client
 	orgName := meta.(*Owner).name
-	ctx := context.WithValue(context.Background(), ctxId, d.Id())
+	ctx = context.WithValue(ctx, ctxId, d.Id())
 
 	username := d.Get("username").(string)
 	downgradeOnDestroy := d.Get("downgrade_on_destroy").(bool)
@@ -160,7 +160,7 @@ func resourceGithubMembershipDelete(d *schema.ResourceData, meta any) error {
 				}
 			}
 
-			return err
+			return diag.FromErr(err)
 		}
 
 		if *membership.Role == downgradeTo {
@@ -176,5 +176,5 @@ func resourceGithubMembershipDelete(d *schema.ResourceData, meta any) error {
 		_, err = client.Organizations.RemoveOrgMembership(ctx, username, orgName)
 	}
 
-	return err
+	return diag.FromErr(err)
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/go-github/v81 v81.0.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0
+	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/shurcooL/githubv4 v0.0.0-20221126192849-0b5c4c7994eb
 	github.com/stretchr/testify v1.11.1
@@ -39,7 +40,6 @@ require (
 	github.com/hashicorp/terraform-exec v0.23.1 // indirect
 	github.com/hashicorp/terraform-json v0.27.1 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.29.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.4.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect


### PR DESCRIPTION
Supersedes #3037
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2693

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Deleting `github_membership` when the invite had failed/expired would throw an error

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Deleting `github_membership` when the invite had failed/expired will ignore the 404 and complete
  * I wasn't able to write a test case which fails with the original behaviour :/

### Pull request checklist
- [ ] ~Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))~
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

