### PR TITLE
[MAINT] Improve provider tests

### DIFF
--- a/github/provider.go
+++ b/github/provider.go
@@ -18,10 +18,11 @@ func Provider() *schema.Provider {
 	p := &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"token": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("GITHUB_TOKEN", nil),
-				Description: descriptions["token"],
+				Type:          schema.TypeString,
+				Optional:      true,
+				DefaultFunc:   schema.EnvDefaultFunc("GITHUB_TOKEN", nil),
+				Description:   descriptions["token"],
+				ConflictsWith: []string{"app_auth"},
 			},
 			"owner": {
 				Type:        schema.TypeString,
@@ -93,10 +94,11 @@ func Provider() *schema.Provider {
 				Description: descriptions["parallel_requests"],
 			},
 			"app_auth": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				MaxItems:    1,
-				Description: descriptions["app_auth"],
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				Description:   descriptions["app_auth"],
+				ConflictsWith: []string{"token"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {

--- a/github/provider.go
+++ b/github/provider.go
@@ -18,11 +18,11 @@ func Provider() *schema.Provider {
 	p := &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"token": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				DefaultFunc:   schema.EnvDefaultFunc("GITHUB_TOKEN", nil),
-				Description:   descriptions["token"],
-				ConflictsWith: []string{"app_auth"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				DefaultFunc:  schema.EnvDefaultFunc("GITHUB_TOKEN", nil),
+				Description:  descriptions["token"],
+				ExactlyOneOf: []string{"app_auth"},
 			},
 			"owner": {
 				Type:        schema.TypeString,
@@ -94,11 +94,11 @@ func Provider() *schema.Provider {
 				Description: descriptions["parallel_requests"],
 			},
 			"app_auth": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				MaxItems:      1,
-				Description:   descriptions["app_auth"],
-				ConflictsWith: []string{"token"},
+				Type:         schema.TypeList,
+				Optional:     true,
+				MaxItems:     1,
+				Description:  descriptions["app_auth"],
+				ExactlyOneOf: []string{"token"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {

--- a/github/provider.go
+++ b/github/provider.go
@@ -416,6 +416,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 		}
 
 		if token == "" {
+			log.Printf("[INFO] No token found, using GitHub CLI to get token from hostname %s", baseURL.Host)
 			token = tokenFromGHCLI(baseURL)
 		}
 

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -241,4 +241,29 @@ func TestAccProviderConfigure(t *testing.T) {
 			},
 		})
 	})
+	t.Run("should not allow app_auth and GITHUB_TOKEN to be configured", func(t *testing.T) {
+		config := fmt.Sprintf(`
+			provider "github" {
+				owner = "%s"
+				app_auth {
+					id = "1234567890"
+					installation_id = "1234567890"
+					pem_file = "1234567890"
+				}
+			}
+
+			data "github_ip_ranges" "test" {}
+			`, testAccConf.owner)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t); t.Setenv("GITHUB_TOKEN", "1234567890") },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:      config,
+					ExpectError: regexp.MustCompile("\"app_auth\": conflicts with token"),
+				},
+			},
+		})
+	})
 }

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -54,7 +54,7 @@ func TestAccProviderConfigure(t *testing.T) {
 	t.Run("can be configured to run anonymously", func(t *testing.T) {
 		config := `
 		provider "github" {
-		  token = ""
+			token = ""
 		}
 		data "github_ip_ranges" "test" {}
 		`
@@ -78,7 +78,7 @@ func TestAccProviderConfigure(t *testing.T) {
 			insecure = true
 		}
 		data "github_ip_ranges" "test" {}
-    `
+		`
 
 		resource.Test(t, resource.TestCase{
 			ProviderFactories: providerFactories,
@@ -180,8 +180,8 @@ func TestAccProviderConfigure(t *testing.T) {
 				max_retries = %d
 			}
 
-      data "github_ip_ranges" "test" {}
-      `, testAccConf.owner, testMaxRetries)
+			data "github_ip_ranges" "test" {}
+			`, testAccConf.owner, testMaxRetries)
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnauthenticated(t) },

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -173,11 +173,15 @@ func TestAccProviderConfigure(t *testing.T) {
 	})
 
 	t.Run("can be configured with max retries", func(t *testing.T) {
+		testMaxRetries := -1
 		config := fmt.Sprintf(`
 			provider "github" {
 				owner = "%s"
-				max_retries = 3
-			}`, testAccConf.owner)
+				max_retries = %d
+			}
+
+      data "github_ip_ranges" "test" {}
+      `, testAccConf.owner, testMaxRetries)
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnauthenticated(t) },
@@ -186,6 +190,7 @@ func TestAccProviderConfigure(t *testing.T) {
 				{
 					Config:             config,
 					ExpectNonEmptyPlan: false,
+					ExpectError:        regexp.MustCompile("max_retries must be greater than or equal to 0"),
 				},
 			},
 		})

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -117,17 +117,20 @@ func TestAccProviderConfigure(t *testing.T) {
 		config := fmt.Sprintf(`
 			provider "github" {
 				token = "%s"
-				owner = "%s"
-			}`, testAccConf.token, testAccConf.owner)
+				owner = "%[2]s"
+			}
+
+			data "github_organization" "test" {
+				name = "%[2]s"
+			}
+			`, testAccConf.token, testAccConf.owner)
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
-					Config:             config,
-					PlanOnly:           true,
-					ExpectNonEmptyPlan: false,
+					Config: config,
 				},
 			},
 		})

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -131,25 +131,25 @@ func TestAccProviderConfigure(t *testing.T) {
 				},
 			},
 		})
+	})
 
-		t.Run("can be configured with an organization account legacy", func(t *testing.T) {
-			config := fmt.Sprintf(`
+	t.Run("can be configured with an organization account legacy", func(t *testing.T) {
+		config := fmt.Sprintf(`
 			provider "github" {
 				token = "%s"
 				organization = "%s"
 			}`, testAccConf.token, testAccConf.owner)
 
-			resource.Test(t, resource.TestCase{
-				PreCheck:          func() { skipUnlessHasOrgs(t) },
-				ProviderFactories: providerFactories,
-				Steps: []resource.TestStep{
-					{
-						Config:             config,
-						PlanOnly:           true,
-						ExpectNonEmptyPlan: false,
-					},
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessHasOrgs(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:             config,
+					PlanOnly:           true,
+					ExpectNonEmptyPlan: false,
 				},
-			})
+			},
 		})
 	})
 

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -245,7 +245,7 @@ func TestAccProviderConfigure(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config:      config,
-					ExpectError: regexp.MustCompile("\"app_auth\": conflicts with token"),
+					ExpectError: regexp.MustCompile("only one of `app_auth,token` can be specified"),
 				},
 			},
 		})
@@ -270,7 +270,7 @@ func TestAccProviderConfigure(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config:      config,
-					ExpectError: regexp.MustCompile("\"app_auth\": conflicts with token"),
+					ExpectError: regexp.MustCompile("only one of `app_auth,token` can be specified"),
 				},
 			},
 		})

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -192,11 +192,15 @@ func TestAccProviderConfigure(t *testing.T) {
 	})
 
 	t.Run("can be configured with max per page", func(t *testing.T) {
-		config := `
+		testMaxPerPage := 101
+		config := fmt.Sprintf(`
 			provider "github" {
 				owner = "%s"
-				max_per_page = 100
-			}`
+				max_per_page = %d
+			}
+
+			data "github_ip_ranges" "test" {}
+			`, testAccConf.owner, testMaxPerPage)
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnauthenticated(t) },
@@ -206,8 +210,8 @@ func TestAccProviderConfigure(t *testing.T) {
 					Config:             config,
 					ExpectNonEmptyPlan: false,
 					Check: func(_ *terraform.State) error {
-						if maxPerPage != 100 {
-							return fmt.Errorf("max_per_page should be set to 100, got %d", maxPerPage)
+						if maxPerPage != testMaxPerPage {
+							return fmt.Errorf("max_per_page should be set to %d, got %d", testMaxPerPage, maxPerPage)
 						}
 						return nil
 					},


### PR DESCRIPTION
Supersedes #3033

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* It was possible to inadvertently set `token` and `app_auth` at the same time
* Some provider test's weren't actually testing anything

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Ensures that `token` (or `GITHUB_TOKEN`) and `app_auth` can't be set at the same time
* Updated some provider tests to actually initialize the provider and verify changes

### Pull request checklist
- [ ] ~Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))~
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

