### PR TITLE
[MAINT] Deprecate `has_downloads` field of `github_repository`

### DIFF
--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -61,8 +61,9 @@ func dataSourceGithubRepository() *schema.Resource {
 				Computed: true,
 			},
 			"has_downloads": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Type:       schema.TypeBool,
+				Computed:   true,
+				Deprecated: "This attribute is no longer in use, but it hasn't been removed yet. It will be removed in a future version. See https://github.com/orgs/community/discussions/102145#discussioncomment-8351756",
 			},
 			"has_wiki": {
 				Type:     schema.TypeBool,

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -211,6 +211,7 @@ func resourceGithubRepository() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Set to 'true' to enable the (deprecated) downloads features on the repository.",
+				Deprecated:  "This attribute is no longer in use, but it hasn't been removed yet. It will be removed in a future version. See https://github.com/orgs/community/discussions/102145#discussioncomment-8351756",
 			},
 			"has_wiki": {
 				Type:        schema.TypeBool,

--- a/website/docs/d/repository.html.markdown
+++ b/website/docs/d/repository.html.markdown
@@ -67,7 +67,7 @@ The following arguments are supported:
 
 * `merge_commit_message` - The default value for a merge commit message.
 
-* `has_downloads` - Whether the repository has Downloads feature enabled.
+* `has_downloads` - (**DEPRECATED**) Whether the repository has Downloads feature enabled. This attribute is no longer in use, but it hasn't been removed yet. It will be removed in a future version. See [this discussion](https://github.com/orgs/community/discussions/102145#discussioncomment-8351756).
 
 * `default_branch` - The name of the default branch of the repository.
 

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -114,7 +114,7 @@ The following arguments are supported:
 
 * `web_commit_signoff_required` - (Optional) Require contributors to sign off on web-based commits. See more [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository). Defaults to `false`.
 
-* `has_downloads` - (Optional) Set to `true` to enable the (deprecated) downloads features on the repository.
+* `has_downloads` - (**DEPRECATED**) (Optional) Set to `true` to enable the (deprecated) downloads features on the repository. This attribute is no longer in use, but it hasn't been removed yet. It will be removed in a future version. See [this discussion](https://github.com/orgs/community/discussions/102145#discussioncomment-8351756).
 
 * `auto_init` - (Optional) Set to `true` to produce an initial commit in the repository.
 


### PR DESCRIPTION
Supersedes #3022

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #966

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* `github_repository` has a field `has_downloads` which doesn't do anything but isn't marked deprecated

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The `has_downloads` field of `github_repository` is marked as deprecated

### Pull request checklist
- [ ] ~Schema migrations have been created if needed ([example](https://github.com/integrations/terraform-provider-github/pull/2820/files))~
- [ ] ~Tests for the changes have been added (for bug fixes / features)~
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----