### PR TITLE
[BUG] Revert anon auth complication

### DIFF
--- a/github/provider.go
+++ b/github/provider.go
@@ -18,11 +18,11 @@ func Provider() *schema.Provider {
 	p := &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"token": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				DefaultFunc:  schema.EnvDefaultFunc("GITHUB_TOKEN", nil),
-				Description:  descriptions["token"],
-				ExactlyOneOf: []string{"app_auth"},
+				Type:          schema.TypeString,
+				Optional:      true,
+				DefaultFunc:   schema.EnvDefaultFunc("GITHUB_TOKEN", nil),
+				Description:   descriptions["token"],
+				ConflictsWith: []string{"app_auth"},
 			},
 			"owner": {
 				Type:        schema.TypeString,
@@ -94,11 +94,11 @@ func Provider() *schema.Provider {
 				Description: descriptions["parallel_requests"],
 			},
 			"app_auth": {
-				Type:         schema.TypeList,
-				Optional:     true,
-				MaxItems:     1,
-				Description:  descriptions["app_auth"],
-				ExactlyOneOf: []string{"token"},
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				Description:   descriptions["app_auth"],
+				ConflictsWith: []string{"token"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {

--- a/github/provider.go
+++ b/github/provider.go
@@ -505,6 +505,7 @@ func tokenFromGHCLI(u *url.URL) string {
 
 	out, err := exec.Command(ghCliPath, "auth", "token", "--hostname", host).Output()
 	if err != nil {
+		log.Printf("[DEBUG] Error getting token from GitHub CLI: %s", err.Error())
 		// GH CLI is either not installed or there was no `gh auth login` command issued,
 		// which is fine. don't return the error to keep the flow going
 		return ""

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -192,7 +192,6 @@ func TestAccProviderConfigure(t *testing.T) {
 			`, testAccConf.owner, testMaxRetries)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnauthenticated(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -216,7 +215,6 @@ func TestAccProviderConfigure(t *testing.T) {
 			`, testAccConf.owner, testMaxPerPage)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnauthenticated(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -248,7 +246,6 @@ func TestAccProviderConfigure(t *testing.T) {
 			`, testAccConf.owner, testAccConf.token)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnauthenticated(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -273,7 +270,7 @@ func TestAccProviderConfigure(t *testing.T) {
 			`, testAccConf.owner)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnauthenticated(t); t.Setenv("GITHUB_TOKEN", "1234567890") },
+			PreCheck:          func() { t.Setenv("GITHUB_TOKEN", "1234567890") },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -248,7 +248,7 @@ func TestAccProviderConfigure(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config:      config,
-					ExpectError: regexp.MustCompile("only one of `app_auth,token` can be specified"),
+					ExpectError: regexp.MustCompile(`"app_auth": conflicts with token`),
 				},
 			},
 		})
@@ -273,7 +273,7 @@ func TestAccProviderConfigure(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config:      config,
-					ExpectError: regexp.MustCompile("only one of `app_auth,token` can be specified"),
+					ExpectError: regexp.MustCompile(`"token": conflicts with app_auth`),
 				},
 			},
 		})

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -161,10 +161,15 @@ func TestAccProviderConfigure(t *testing.T) {
 			provider "github" {
 				token = "%s"
 				base_url = "%s"
-			}`, testAccConf.token, testAccConf.owner)
+			}`, testAccConf.token, testAccConf.baseURL)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, individual) },
+			PreCheck: func() {
+				skipUnlessMode(t, enterprise)
+				if testAccConf.baseURL.Host != "api.github.com" {
+					t.Skip("Skipping as test mode is not GHES")
+				}
+			},
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -54,12 +54,12 @@ func TestAccProviderConfigure(t *testing.T) {
 	t.Run("can be configured to run anonymously", func(t *testing.T) {
 		config := `
 		provider "github" {
-			token = ""
 		}
 		data "github_ip_ranges" "test" {}
 		`
 
 		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { t.Setenv("GITHUB_TOKEN", ""); t.Setenv("GH_PATH", "none-existent-path") },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->


----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- Anonymous auth needed to have `token = ""` in provider config

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Anonymous auth works with empty provider block

### Pull request checklist

- [ ] ~Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))~
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
