### PR TITLE
feat(repo-rulesets): add support for required reviewers in org and repo rs

### DIFF
--- a/github/resource_github_organization_ruleset.go
+++ b/github/resource_github_organization_ruleset.go
@@ -238,6 +238,7 @@ func resourceGithubOrganizationRuleset() *schema.Resource {
 										Default:     false,
 										Description: "All conversations on code must be resolved before a pull request can be merged. Defaults to `false`.",
 									},
+									"required_reviewers": requiredReviewersSchema(),
 								},
 							},
 						},

--- a/github/resource_github_repository_ruleset.go
+++ b/github/resource_github_repository_ruleset.go
@@ -229,6 +229,7 @@ func resourceGithubRepositoryRuleset() *schema.Resource {
 										Default:     false,
 										Description: "All conversations on code must be resolved before a pull request can be merged. Defaults to `false`.",
 									},
+									"required_reviewers": requiredReviewersSchema(),
 								},
 							},
 						},

--- a/website/docs/r/organization_ruleset.html.markdown
+++ b/website/docs/r/organization_ruleset.html.markdown
@@ -212,6 +212,18 @@ The `rules` block supports the following:
 - `required_approving_review_count` - (Optional) (Number) The number of approving reviews that are required before a pull request can be merged. Defaults to `0`.
 
 - `required_review_thread_resolution` - (Optional) (Boolean) All conversations on code must be resolved before a pull request can be merged. Defaults to `false`.
+- `required_reviewers` - (Optional) (Block List) Require specific reviewers to approve pull requests targeting matching branches. Note: This feature is in beta and subject to change. (see [below for nested schema](#rules.pull_request.required_reviewers))
+
+#### rules.pull_request.required_reviewers ####
+
+- `reviewer` - (Required) (Block List, Max: 1) The reviewer that must review matching files. (see [below for nested schema](#rules.pull_request.required_reviewers.reviewer))
+- `file_patterns` - (Required) (List of String) File patterns (fnmatch syntax) that this reviewer must approve.
+- `minimum_approvals` - (Required) (Number) Minimum number of approvals required from this reviewer. Set to 0 to make approval optional.
+
+#### rules.pull_request.required_reviewers.reviewer ####
+
+- `id` - (Required) (Number) The ID of the reviewer (team ID).
+- `type` - (Required) (String) The type of reviewer. Currently only `Team` is supported.
 
 #### rules.copilot_code_review ####
 

--- a/website/docs/r/repository_ruleset.html.markdown
+++ b/website/docs/r/repository_ruleset.html.markdown
@@ -213,6 +213,18 @@ The `rules` block supports the following:
 - `require_last_push_approval` - (Optional) (Boolean) Whether the most recent reviewable push must be approved by someone other than the person who pushed it. Defaults to `false`.
 - `required_approving_review_count` - (Optional) (Number) The number of approving reviews that are required before a pull request can be merged. Defaults to `0`.
 - `required_review_thread_resolution` - (Optional) (Boolean) All conversations on code must be resolved before a pull request can be merged. Defaults to `false`.
+- `required_reviewers` - (Optional) (Block List) Require specific reviewers to approve pull requests targeting matching branches. Note: This feature is in beta and subject to change. (see [below for nested schema](#rules.pull_request.required_reviewers))
+
+#### rules.pull_request.required_reviewers ####
+
+- `reviewer` - (Required) (Block List, Max: 1) The reviewer that must review matching files. (see [below for nested schema](#rules.pull_request.required_reviewers.reviewer))
+- `file_patterns` - (Required) (List of String) File patterns (fnmatch syntax) that this reviewer must approve.
+- `minimum_approvals` - (Required) (Number) Minimum number of approvals required from this reviewer. Set to 0 to make approval optional.
+
+#### rules.pull_request.required_reviewers.reviewer ####
+
+- `id` - (Required) (Number) The ID of the reviewer (team ID).
+- `type` - (Required) (String) The type of reviewer. Currently only `Team` is supported.
 
 #### rules.copilot_code_review ####
 


### PR DESCRIPTION
…on and repository rulesets

Resolves #3081 

----

### Before the change?
The pull_request rule in organization and repository rulesets did not support the required_reviewers field
Users could not configure specific teams to review changes to particular file patterns through Terraform
The "Required review by specific teams" feature (announced November 2025) was not available in the provider

- 

### After the change?

- Added required_reviewers block to the pull_request rule for both github_organization_ruleset and github_repository_ruleset resources
- Users can now specify teams that must approve changes to specific file patterns
- Supports configuring:

  1. reviewer block with id (team ID) and type (currently only "Team" supported)
  2. file_patterns - list of fnmatch patterns (e.g., ["*.go", "*.tf"])
  3. minimum_approvals - number of required approvals (0 = optional reviewer)

```
resource "github_repository_ruleset" "example" {
  name        = "example"
  repository  = github_repository.example.name
  target      = "branch"
  enforcement = "active"

  conditions {
    ref_name {
      include = ["~DEFAULT_BRANCH"]
      exclude = []
    }
  }

  rules {
    pull_request {
      required_approving_review_count = 1

      required_reviewers {
        reviewer {
          id   = github_team.security.id
          type = "Team"
        }
        file_patterns     = ["*.go", "security/**"]
        minimum_approvals = 2
      }
    }
  }
}
```

### Pull request checklist

- [ ] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

Additional Notes
This feature is currently in beta on GitHub's side and subject to change
Only Team reviewer type is supported (as per GitHub API)
Reference: GitHub Changelog - Required review by specific teams now available in rulesets
