### PR TITLE
chore: Fix repo allow forking

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -634,9 +634,10 @@ func resourceGithubRepositoryObject(d *schema.ResourceData) *github.Repository {
 	}
 
 	// only configure allow forking if repository is not public
-	allowForking, ok := d.Get("allow_forking").(bool)
-	if ok && visibility != "public" {
-		repository.AllowForking = github.Ptr(allowForking)
+	if allowForking, ok := d.GetOk("allow_forking"); ok && visibility != "public" {
+		if val, ok := allowForking.(bool); ok {
+			repository.AllowForking = github.Ptr(val)
+		}
 	}
 
 	return repository

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -571,7 +571,7 @@ func TestAccGithubRepository(t *testing.T) {
 
 	t.Run("create_private_with_forking", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%svisibility-%s", testResourcePrefix, randomID)
+		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
 
 		config := fmt.Sprintf(`
 		resource "github_repository" "test" {
@@ -591,6 +591,33 @@ func TestAccGithubRepository(t *testing.T) {
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("github_repository.test", "visibility", "private"),
 						resource.TestCheckResourceAttr("github_repository.test", "allow_forking", "true"),
+					),
+				},
+			},
+		})
+	})
+
+	t.Run("create_private_with_forking_unset", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+
+		config := fmt.Sprintf(`
+resource "github_repository" "test" {
+	name       = "%s"
+	description = "A private repository with forking disabled"
+	visibility = "private"
+}
+`, repoName)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessHasOrgs(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("github_repository.test", "visibility", "private"),
+						resource.TestCheckResourceAttr("github_repository.test", "allow_forking", "false"),
 					),
 				},
 			},


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #3088

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- The `github_repository` resource incorrectly sends `AllowForking` even when not set.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The `github_repository` resource only sends `AllowForking` when not set.

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
