### PR TITLE
fix: Revert provider input constraints

### DIFF
--- a/github/provider.go
+++ b/github/provider.go
@@ -18,11 +18,11 @@ func Provider() *schema.Provider {
 	p := &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"token": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				DefaultFunc:   schema.EnvDefaultFunc("GITHUB_TOKEN", nil),
-				Description:   descriptions["token"],
-				ConflictsWith: []string{"app_auth"},
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("GITHUB_TOKEN", nil),
+				Description: descriptions["token"],
+				// ConflictsWith: []string{"app_auth"}, // TODO: Enable as part of v7.
 			},
 			"owner": {
 				Type:        schema.TypeString,
@@ -94,11 +94,11 @@ func Provider() *schema.Provider {
 				Description: descriptions["parallel_requests"],
 			},
 			"app_auth": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				MaxItems:      1,
-				Description:   descriptions["app_auth"],
-				ConflictsWith: []string{"token"},
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: descriptions["app_auth"],
+				// ConflictsWith: []string{"token"}, // TODO: Enable as part of v7.
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -51,7 +51,7 @@ func TestProvider(t *testing.T) {
 }
 
 func TestAccProviderConfigure(t *testing.T) {
-	t.Run("can be configured to run anonymously", func(t *testing.T) {
+	t.Run("can_be_configured_to_run_anonymously", func(t *testing.T) {
 		config := `
 		provider "github" {
 		}
@@ -71,10 +71,36 @@ func TestAccProviderConfigure(t *testing.T) {
 		})
 	})
 
+	t.Run("can_be_configured_with_app_auth_and_ignore_github_token", func(t *testing.T) {
+		t.Skip("This test requires a valid app auth setup to run.")
+		config := fmt.Sprintf(`
+provider "github" {
+	owner = "%s"
+	app_auth {
+		id = "1234567890"
+		installation_id = "1234567890"
+		pem_file = "1234567890"
+	}
+}
+
+data "github_ip_ranges" "test" {}
+`, testAccConf.owner)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { t.Setenv("GITHUB_TOKEN", "1234567890") },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:             config,
+					ExpectNonEmptyPlan: false,
+				},
+			},
+		})
+	})
+
 	t.Run("can be configured to run insecurely", func(t *testing.T) {
 		config := `
 		provider "github" {
-			token = ""
 			insecure = true
 		}
 		data "github_ip_ranges" "test" {}
@@ -231,6 +257,7 @@ func TestAccProviderConfigure(t *testing.T) {
 		})
 	})
 	t.Run("should not allow both token and app_auth to be configured", func(t *testing.T) {
+		t.Skip("This would be a semver breaking change, this will be reinstated for v7.")
 		config := fmt.Sprintf(`
 			provider "github" {
 				owner = "%s"
@@ -251,31 +278,6 @@ func TestAccProviderConfigure(t *testing.T) {
 				{
 					Config:      config,
 					ExpectError: regexp.MustCompile(`"app_auth": conflicts with token`),
-				},
-			},
-		})
-	})
-	t.Run("should not allow app_auth and GITHUB_TOKEN to be configured", func(t *testing.T) {
-		config := fmt.Sprintf(`
-			provider "github" {
-				owner = "%s"
-				app_auth {
-					id = "1234567890"
-					installation_id = "1234567890"
-					pem_file = "1234567890"
-				}
-			}
-
-			data "github_ip_ranges" "test" {}
-			`, testAccConf.owner)
-
-		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { t.Setenv("GITHUB_TOKEN", "1234567890") },
-			ProviderFactories: providerFactories,
-			Steps: []resource.TestStep{
-				{
-					Config:      config,
-					ExpectError: regexp.MustCompile(`"token": conflicts with app_auth`),
 				},
 			},
 		})


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #3093
Resolves #3096

This fixes a regression caused by #3071.

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- The provider can't be configured with app auth if there is a `GITHUB_TOKEN` in the env

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- This behaviour has been reverted.

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
