### PR TITLE
fix(parseID): separator in value

### DIFF
--- a/github/util.go
+++ b/github/util.go
@@ -60,8 +60,15 @@ func parseID(id string, count int) ([]string, error) {
 	}
 
 	parts := strings.Split(id, idSeparator)
-	if len(parts) != count {
+	if len(parts) < count {
 		return nil, fmt.Errorf("unexpected ID format (%q); expected %d parts separated by %q", id, count, idSeparator)
+	}
+
+	// If the number of part is greater than expected, we assume that the
+	// extra parts are due to the separator being part of a value. We join
+	// the extra parts back together for the last part.
+	if len(parts) > count {
+		parts = append(parts[:count-1], strings.Join(parts[count-1:], idSeparator))
 	}
 
 	return parts, nil

--- a/github/util_test.go
+++ b/github/util_test.go
@@ -172,8 +172,8 @@ func Test_parseID(t *testing.T) {
 			testName: "three_parts_expected_two",
 			id:       "part1:part2:part3",
 			count:    2,
-			expect:   nil,
-			hasError: true,
+			expect:   []string{"part1", "part2:part3"},
+			hasError: false,
 		},
 		{
 			testName: "empty_id",


### PR DESCRIPTION
parseID now ensures that there is at least count parts in the string ID. It then joins the extra together

Resolves https://github.com/integrations/terraform-provider-github/issues/3105
----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- parseID2 errors with ID: "part1:part2:part3"

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- parseID2 returns: "part1" and "part2:part3"

### Pull request checklist

- [ ] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

It actually fix a breaking change that some values have the separator.

----
