### PR TITLE
[MAINT] refactor `github_repository_file` to use Context-aware provider functions

### DIFF
--- a/github/resource_github_repository_file.go
+++ b/github/resource_github_repository_file.go
@@ -24,6 +24,8 @@ func resourceGithubRepositoryFile() *schema.Resource {
 			StateContext: resourceGithubRepositoryFileImporter,
 		},
 
+		Description: "This resource allows you to create and manage files within a GitHub repository.",
+
 		Schema: map[string]*schema.Schema{
 			"repository": {
 				Type:        schema.TypeString,

--- a/github/resource_github_repository_file.go
+++ b/github/resource_github_repository_file.go
@@ -119,7 +119,7 @@ func resourceGithubRepositoryFile() *schema.Resource {
 
 func resourceGithubRepositoryFileOptions(d *schema.ResourceData) (*github.RepositoryContentFileOptions, error) {
 	opts := &github.RepositoryContentFileOptions{
-		Content: []byte(*github.Ptr(d.Get("content").(string))),
+		Content: []byte(d.Get("content").(string)),
 	}
 
 	if branch, ok := d.GetOk("branch"); ok {
@@ -127,13 +127,11 @@ func resourceGithubRepositoryFileOptions(d *schema.ResourceData) (*github.Reposi
 	}
 
 	if commitMessage, hasCommitMessage := d.GetOk("commit_message"); hasCommitMessage {
-		opts.Message = new(string)
-		*opts.Message = commitMessage.(string)
+		opts.Message = github.Ptr(commitMessage.(string))
 	}
 
 	if SHA, hasSHA := d.GetOk("sha"); hasSHA {
-		opts.SHA = new(string)
-		*opts.SHA = SHA.(string)
+		opts.SHA = github.Ptr(SHA.(string))
 	}
 
 	commitAuthor, hasCommitAuthor := d.GetOk("commit_author")
@@ -148,10 +146,10 @@ func resourceGithubRepositoryFileOptions(d *schema.ResourceData) (*github.Reposi
 	}
 
 	if hasCommitAuthor && hasCommitEmail {
-		name := commitAuthor.(string)
-		mail := commitEmail.(string)
-		opts.Author = &github.CommitAuthor{Name: &name, Email: &mail}
-		opts.Committer = &github.CommitAuthor{Name: &name, Email: &mail}
+		name := github.Ptr(commitAuthor.(string))
+		mail := github.Ptr(commitEmail.(string))
+		opts.Author = &github.CommitAuthor{Name: name, Email: mail}
+		opts.Committer = &github.CommitAuthor{Name: name, Email: mail}
 	}
 
 	return opts, nil
@@ -202,8 +200,7 @@ func resourceGithubRepositoryFileCreate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if opts.Message == nil {
-		m := fmt.Sprintf("Add %s", file)
-		opts.Message = &m
+		opts.Message = github.Ptr(fmt.Sprintf("Add %s", file))
 	}
 
 	log.Printf("[DEBUG] Checking if overwriting a repository file: %s/%s/%s", owner, repo, file)
@@ -397,8 +394,7 @@ func resourceGithubRepositoryFileUpdate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if *opts.Message == fmt.Sprintf("Add %s", file) {
-		m := fmt.Sprintf("Update %s", file)
-		opts.Message = &m
+		opts.Message = github.Ptr(fmt.Sprintf("Update %s", file))
 	}
 
 	create, _, err := client.Repositories.CreateFile(ctx, owner, repo, file, opts)
@@ -428,8 +424,7 @@ func resourceGithubRepositoryFileDelete(ctx context.Context, d *schema.ResourceD
 	}
 
 	if *opts.Message == fmt.Sprintf("Add %s", file) {
-		m := fmt.Sprintf("Delete %s", file)
-		opts.Message = &m
+		opts.Message = github.Ptr(fmt.Sprintf("Delete %s", file))
 	}
 
 	if b, ok := d.GetOk("branch"); ok {
@@ -460,7 +455,7 @@ func resourceGithubRepositoryFileDelete(ctx context.Context, d *schema.ResourceD
 			}
 		}
 		branch = b.(string)
-		opts.Branch = &branch
+		opts.Branch = github.Ptr(branch)
 	}
 
 	_, _, err = client.Repositories.DeleteFile(ctx, owner, repo, file, opts)

--- a/github/resource_github_repository_file.go
+++ b/github/resource_github_repository_file.go
@@ -422,8 +422,6 @@ func resourceGithubRepositoryFileDelete(ctx context.Context, d *schema.ResourceD
 	repo := d.Get("repository").(string)
 	file := d.Get("file").(string)
 
-	var branch string
-
 	opts := resourceGithubRepositoryFileOptions(d)
 
 	if *opts.Message == fmt.Sprintf("Add %s", file) {
@@ -443,7 +441,7 @@ func resourceGithubRepositoryFileDelete(ctx context.Context, d *schema.ResourceD
 				return diag.FromErr(err)
 			}
 		}
-		branch = b.(string)
+		branch := b.(string)
 		opts.Branch = github.Ptr(branch)
 	}
 

--- a/github/resource_github_repository_file_test.go
+++ b/github/resource_github_repository_file_test.go
@@ -73,6 +73,71 @@ func TestAccGithubRepositoryFile(t *testing.T) {
 			},
 		})
 	})
+	t.Run("validates_commit_email_must_be_specified_if_commit_author_is_specified", func(t *testing.T) {
+		randomID := acctest.RandString(5)
+		repoName := fmt.Sprintf("%srepo-file-%s", testResourcePrefix, randomID)
+		config := fmt.Sprintf(`
+
+			resource "github_repository" "test" {
+				name                 = "%s"
+				auto_init            = true
+				vulnerability_alerts = true
+			}
+
+			resource "github_repository_file" "test" {
+				repository     = github_repository.test.name
+				branch         = "main"
+				file           = "test"
+				content        = "bar"
+				commit_message = "Managed by Terraform"
+				commit_author  = "Terraform User"
+			}
+		`, repoName)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:      config,
+					ExpectError: regexp.MustCompile("all of `commit_author,commit_email` must be specified"),
+				},
+			},
+		})
+	})
+
+	t.Run("validates_commit_author_must_be_specified_if_commit_email_is_specified", func(t *testing.T) {
+		randomID := acctest.RandString(5)
+		repoName := fmt.Sprintf("%srepo-file-%s", testResourcePrefix, randomID)
+		config := fmt.Sprintf(`
+
+			resource "github_repository" "test" {
+				name                 = "%s"
+				auto_init            = true
+				vulnerability_alerts = true
+			}
+
+			resource "github_repository_file" "test" {
+				repository     = github_repository.test.name
+				branch         = "main"
+				file           = "test"
+				content        = "bar"
+				commit_message = "Managed by Terraform"
+				commit_email   = "terraform@example.com"
+			}
+		`, repoName)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:      config,
+					ExpectError: regexp.MustCompile("all of `commit_author,commit_email` must be specified"),
+				},
+			},
+		})
+	})
 
 	t.Run("can be configured to overwrite files on create", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Implements #2996 #3070 for `github_repository_file`

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `github_repository_file` uses Context-aware provider functions
- Importer is extracted to it's own function
- Added top-level `Description` field
- Refactored to use `tflog` instead of `log`
- Extracted a `createBranch` function to reduce duplication
- Update validation logic to remove some conditional code

### Pull request checklist

- [ ] ~Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))~
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
