### PR TITLE
fix: Correct forking and vulnerability alert logic

### DIFF
--- a/github/data_source_github_organization_role_users_test.go
+++ b/github/data_source_github_organization_role_users_test.go
@@ -10,6 +10,10 @@ import (
 
 func TestAccDataSourceGithubOrganizationRoleUsers(t *testing.T) {
 	t.Run("get the organization role users without error", func(t *testing.T) {
+		if testAccConf.testOrgUser == "" {
+			t.Skip("Skipping test because no organization user has been configured")
+		}
+
 		roleId := 8134
 		config := fmt.Sprintf(`
 			resource "github_organization_role_user" "test" {
@@ -44,6 +48,10 @@ func TestAccDataSourceGithubOrganizationRoleUsers(t *testing.T) {
 	})
 
 	t.Run("get indirect organization role users without error", func(t *testing.T) {
+		if testAccConf.testOrgUser == "" {
+			t.Skip("Skipping test because no organization user has been configured")
+		}
+
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		teamName := fmt.Sprintf("%steam-%s", testResourcePrefix, randomID)
 		roleId := 8134

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -23,12 +23,7 @@ func resourceGithubRepository() *schema.Resource {
 		UpdateContext: resourceGithubRepositoryUpdate,
 		DeleteContext: resourceGithubRepositoryDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-				if err := d.Set("auto_init", false); err != nil {
-					return nil, err
-				}
-				return []*schema.ResourceData{d}, nil
-			},
+			StateContext: resourceGithubRepositoryImport,
 		},
 
 		SchemaVersion: 1,
@@ -409,6 +404,7 @@ func resourceGithubRepository() *schema.Resource {
 			"ignore_vulnerability_alerts_during_read": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Default:     false,
 				Description: "Set to true to not call the vulnerability alerts endpoint so the resource can also be used without admin permissions during read.",
 			},
 			"full_name": {
@@ -634,7 +630,7 @@ func resourceGithubRepositoryObject(d *schema.ResourceData) *github.Repository {
 	}
 
 	// only configure allow forking if repository is not public
-	if allowForking, ok := d.GetOk("allow_forking"); ok && visibility != "public" {
+	if allowForking, ok := d.GetOkExists("allow_forking"); ok && visibility != "public" { //nolint:staticcheck,SA1019 // We sometimes need to use GetOkExists for booleans
 		if val, ok := allowForking.(bool); ok {
 			repository.AllowForking = github.Ptr(val)
 		}
@@ -771,11 +767,6 @@ func resourceGithubRepositoryCreate(ctx context.Context, d *schema.ResourceData,
 		if err != nil {
 			return diag.FromErr(err)
 		}
-	}
-
-	err := updateVulnerabilityAlerts(d, client, ctx, owner, repoName)
-	if err != nil {
-		return diag.FromErr(err)
 	}
 
 	return resourceGithubRepositoryUpdate(ctx, d, meta)
@@ -1013,10 +1004,12 @@ func resourceGithubRepositoryUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
-	if d.HasChange("vulnerability_alerts") {
-		err = updateVulnerabilityAlerts(d, client, ctx, owner, repoName)
-		if err != nil {
-			return diag.FromErr(err)
+	if v, ok := d.GetOkExists("vulnerability_alerts"); ok { //nolint:staticcheck,SA1019 // We sometimes need to use GetOkExists for booleans
+		if val, ok := v.(bool); ok {
+			err := updateVulnerabilityAlerts(ctx, client, owner, repoName, val)
+			if err != nil {
+				return diag.FromErr(err)
+			}
 		}
 	}
 
@@ -1063,6 +1056,16 @@ func resourceGithubRepositoryDelete(ctx context.Context, d *schema.ResourceData,
 	log.Printf("[DEBUG] Deleting repository: %s/%s", owner, repoName)
 	_, err := client.Repositories.Delete(ctx, owner, repoName)
 	return diag.FromErr(err)
+}
+
+func resourceGithubRepositoryImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+	if err := d.Set("auto_init", false); err != nil {
+		return nil, err
+	}
+	if err := d.Set("ignore_vulnerability_alerts_during_read", true); err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
 }
 
 func expandPages(input []any) *github.Pages {
@@ -1240,23 +1243,17 @@ func resourceGithubParseFullName(resourceDataLike interface {
 	return parts[0], parts[1], true
 }
 
-func updateVulnerabilityAlerts(d *schema.ResourceData, client *github.Client, ctx context.Context, owner, repoName string) error {
-	updateVulnerabilityAlertsSDK := client.Repositories.DisableVulnerabilityAlerts
-	vulnerabilityAlerts, ok := d.GetOk("vulnerability_alerts")
+func updateVulnerabilityAlerts(ctx context.Context, client *github.Client, owner, repoName string, state bool) error {
+	var err error
 
-	// Only if the vulnerability alerts are specifically set to true, enable them.
-	// Otherwise, disable them as GitHub defaults to enabled and we have not wanted to introduce a breaking change for this yet.
-	if ok && vulnerabilityAlerts.(bool) {
-		updateVulnerabilityAlertsSDK = client.Repositories.EnableVulnerabilityAlerts
+	if state {
+		_, err = client.Repositories.EnableVulnerabilityAlerts(ctx, owner, repoName)
+	} else {
+		_, err = client.Repositories.DisableVulnerabilityAlerts(ctx, owner, repoName)
 	}
-
-	resp, err := updateVulnerabilityAlertsSDK(ctx, owner, repoName)
 	if err != nil {
-		// Check if the error is because an Organization or Enterprise policy is preventing the change
-		// This is a temporary workaround while we extract Vulnerability Alerts into a separate resource.
-		if resp.StatusCode == http.StatusUnprocessableEntity && strings.Contains(err.Error(), "An enforced security configuration prevented modifying") && !ok {
-			return nil
-		}
+		return err
 	}
-	return err
+
+	return nil
 }

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -100,7 +100,7 @@ The following arguments are supported:
 
 * `allow_auto_merge` - (Optional) Set to `true` to allow auto-merging pull requests on the repository.
 
-* `allow_forking` - (Optional) Set to `true` to allow private forking on the repository; this is only relevant if the repository is owned by an organization and is private or internal.
+* `allow_forking` - (Optional) Configure private forking for organization owned private and internal repositories; set to `true` to enable, `false` to disable, and leave unset for the default behaviour. Configuring this requires that private forking is not being explicitly configured at the organization level.
 
 * `squash_merge_commit_title` - (Optional) Can be `PR_TITLE` or `COMMIT_OR_PR_TITLE` for a default squash merge commit title. Applicable only if `allow_squash_merge` is `true`.
 
@@ -140,9 +140,9 @@ initial repository creation and create the target branch inside of the repositor
 
 * `template` - (Optional) Use a template repository to create this resource. See [Template Repositories](#template-repositories) below for details.
 
-* `vulnerability_alerts` (Optional) - Set to `true` to enable security alerts for vulnerable dependencies. Enabling requires alerts to be enabled on the owner level. (Note for importing: GitHub enables the alerts on public repos but disables them on private repos by default.) See [GitHub Documentation](https://help.github.com/en/github/managing-security-vulnerabilities/about-security-alerts-for-vulnerable-dependencies) for details. Note that vulnerability alerts have not been successfully tested on any GitHub Enterprise instance and may be unavailable in those settings.
+* `vulnerability_alerts` - (Optional) Configure [Dependabot security alerts](https://help.github.com/en/github/managing-security-vulnerabilities/about-security-alerts-for-vulnerable-dependencies) for vulnerable dependencies; set to `true` to enable, set to `false` to disable, and leave unset for the default behavior. Configuring this requires that alerts are not being explicitly configured at the organization level.
 
-* `ignore_vulnerability_alerts_during_read` (Optional) - Set to `true` to not call the vulnerability alerts endpoint so the resource can also be used without admin permissions during read.
+* `ignore_vulnerability_alerts_during_read` (Optional) - Set to `true` to not call the vulnerability alerts endpoint so the resource can also be used without admin permissions during read, if this is set to `true` and `vulnerability_alerts` is unset then the computed value of `vulnerability_alerts` will be nil.
 
 * `allow_update_branch` (Optional) - Set to `true` to always suggest updating pull request branches.
 
@@ -245,6 +245,6 @@ The following additional attributes are exported:
 
 Repositories can be imported using the `name`, e.g.
 
-```text
-$ terraform import github_repository.terraform terraform
+```shell
+terraform import github_repository.terraform myrepo
 ```


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2988
Resolves #3111

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- Setting `allow_forking = false` on `github_repository` resulted in incorrect behaviour
- The `vulnerability_alerts` attribute of `github_repository` couldn't be left unset to support default behaviour
- Missing tests for `github_repository` allow forking and vulnerability alerts
- Tests from `github_organization_role_users` data source were broken

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Setting `allow_forking = false` on `github_repository` works as expected
- The `vulnerability_alerts` attribute of `github_repository` works correctly when unset
- Tests for `github_repository` allow forking and vulnerability alerts added
- Tests from `github_organization_role_users` data source fixed

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
