### PR TITLE
fix(environments): swallow 404 not found errors

### DIFF
--- a/github/resource_github_repository_environment.go
+++ b/github/resource_github_repository_environment.go
@@ -240,7 +240,7 @@ func resourceGithubRepositoryEnvironmentDelete(ctx context.Context, d *schema.Re
 
 	_, err = client.Repositories.DeleteEnvironment(ctx, owner, repoName, url.PathEscape(envName))
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.FromErr(deleteResourceOn404AndSwallow304OtherwiseReturnError(err, d, "environment (%s)", envName))
 	}
 
 	return nil


### PR DESCRIPTION
When an environment no longer exist, the deletion call should not throw back an error.

The resource is in the desired state, gone.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #3131
----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- Environments deleted externally would make the deletion fail

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Environments deleted externally will be deleted from the state

### Pull request checklist

- [ ] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
