### PR TITLE
fix: Correct repo vulnerability alert logic

### DIFF
--- a/github/resource_github_organization_ruleset_test.go
+++ b/github/resource_github_organization_ruleset_test.go
@@ -22,7 +22,6 @@ resource "github_repository" "test" {
 	name = "%s"
 	visibility = "private"
 	auto_init = true
-	ignore_vulnerability_alerts_during_read = true
 }
 
 resource "github_repository_file" "workflow_file" {

--- a/github/resource_github_repository_environment_deployment_policy_test.go
+++ b/github/resource_github_repository_environment_deployment_policy_test.go
@@ -23,7 +23,6 @@ func TestAccGithubRepositoryEnvironmentDeploymentPolicy(t *testing.T) {
 
 			resource "github_repository" "test" {
 				name      = "%s"
-				ignore_vulnerability_alerts_during_read = true
 			}
 
 			resource "github_repository_environment" "test" {
@@ -90,7 +89,6 @@ func TestAccGithubRepositoryEnvironmentDeploymentPolicy(t *testing.T) {
 
 			resource "github_repository" "test" {
 				name      = "%s"
-				ignore_vulnerability_alerts_during_read = true
 			}
 
 			resource "github_repository_environment" "test" {
@@ -141,7 +139,6 @@ func TestAccGithubRepositoryEnvironmentDeploymentPolicy(t *testing.T) {
 
 			resource "github_repository" "test" {
 				name      = "%s"
-				ignore_vulnerability_alerts_during_read = true
 			}
 
 			resource "github_repository_environment" "test" {
@@ -203,7 +200,6 @@ func TestAccGithubRepositoryEnvironmentDeploymentPolicy(t *testing.T) {
 
 			resource "github_repository" "test" {
 				name      = "%s"
-				ignore_vulnerability_alerts_during_read = true
 			}
 
 			resource "github_repository_environment" "test" {
@@ -270,7 +266,6 @@ func TestAccGithubRepositoryEnvironmentDeploymentPolicy(t *testing.T) {
 
 			resource "github_repository" "test" {
 				name      = "%s"
-				ignore_vulnerability_alerts_during_read = true
 			}
 
 			resource "github_repository_environment" "test" {
@@ -321,7 +316,6 @@ func TestAccGithubRepositoryEnvironmentDeploymentPolicy(t *testing.T) {
 
 			resource "github_repository" "test" {
 				name      = "%s"
-				ignore_vulnerability_alerts_during_read = true
 			}
 
 			resource "github_repository_environment" "test" {
@@ -396,7 +390,6 @@ func TestAccGithubRepositoryEnvironmentDeploymentPolicy(t *testing.T) {
 
 			resource "github_repository" "test" {
 				name      = "%s"
-				ignore_vulnerability_alerts_during_read = true
 			}
 
 			resource "github_repository_environment" "test" {
@@ -447,7 +440,6 @@ func TestAccGithubRepositoryEnvironmentDeploymentPolicy(t *testing.T) {
 
 			resource "github_repository" "test" {
 				name      = "%s"
-				ignore_vulnerability_alerts_during_read = true
 			}
 
 			resource "github_repository_environment" "test" {
@@ -522,7 +514,6 @@ func TestAccGithubRepositoryEnvironmentDeploymentPolicy(t *testing.T) {
 
 			resource "github_repository" "test" {
 				name      = "%s"
-				ignore_vulnerability_alerts_during_read = true
 			}
 
 			resource "github_repository_environment" "test" {
@@ -573,7 +564,6 @@ func TestAccGithubRepositoryEnvironmentDeploymentPolicy(t *testing.T) {
 
 			resource "github_repository" "test" {
 				name      = "%s"
-				ignore_vulnerability_alerts_during_read = true
 			}
 
 			resource "github_repository_environment" "test" {
@@ -691,7 +681,6 @@ resource "github_repository_environment_deployment_policy" "test" {
 		config := fmt.Sprintf(`
 			resource "github_repository" "test" {
 				name      = "%s"
-				ignore_vulnerability_alerts_during_read = true
 			}
 
 			resource "github_repository_environment" "test" {
@@ -727,7 +716,6 @@ resource "github_repository_environment_deployment_policy" "test" {
 		config := fmt.Sprintf(`
 			resource "github_repository" "test" {
 				name      = "%s"
-				ignore_vulnerability_alerts_during_read = true
 			}
 
 			resource "github_repository_environment" "test" {
@@ -765,7 +753,6 @@ resource "github_repository_environment_deployment_policy" "test" {
 		config := fmt.Sprintf(`
 			resource "github_repository" "test" {
 				name      = "%s"
-				ignore_vulnerability_alerts_during_read = true
 			}
 
 			resource "github_repository_environment" "test" {
@@ -802,7 +789,6 @@ resource "github_repository_environment_deployment_policy" "test" {
 		config := fmt.Sprintf(`
 			resource "github_repository" "test" {
 				name      = "%s"
-				ignore_vulnerability_alerts_during_read = true
 			}
 
 			resource "github_repository_environment" "test" {

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -142,7 +142,7 @@ initial repository creation and create the target branch inside of the repositor
 
 * `vulnerability_alerts` - (Optional) Configure [Dependabot security alerts](https://help.github.com/en/github/managing-security-vulnerabilities/about-security-alerts-for-vulnerable-dependencies) for vulnerable dependencies; set to `true` to enable, set to `false` to disable, and leave unset for the default behavior. Configuring this requires that alerts are not being explicitly configured at the organization level.
 
-* `ignore_vulnerability_alerts_during_read` (Optional) - Set to `true` to not call the vulnerability alerts endpoint so the resource can also be used without admin permissions during read, if this is set to `true` and `vulnerability_alerts` is unset then the computed value of `vulnerability_alerts` will be nil.
+* `ignore_vulnerability_alerts_during_read` (**DEPRECATED**) (Optional) - This is ignored as the provider now handles lack of permissions automatically.
 
 * `allow_update_branch` (Optional) - Set to `true` to always suggest updating pull request branches.
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Corrects logic in #3127

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- Resource `github_repository` would call vulnerability alerts endpoint on every modification
- Resource `github_repository` used `ignore_vulnerability_alerts_during_read` to allow unprivileged users to skip calling the vulnerability alerts endpoint

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Resource `github_repository` only calls vulnerability alerts endpoint when required
- Resource `github_repository` only calls vulnerability alerts endpoint during read if the repo response show that the user has the correct permission

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
