### PR TITLE
feat: Add support for members_can_change_repo_visibility in github_organization_settings

### DIFF
--- a/github/data_source_github_organization.go
+++ b/github/data_source_github_organization.go
@@ -141,6 +141,10 @@ func dataSourceGithubOrganization() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"members_can_change_repo_visibility": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"summary_only": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -265,6 +269,7 @@ func dataSourceGithubOrganizationRead(ctx context.Context, d *schema.ResourceDat
 		_ = d.Set("dependency_graph_enabled_for_new_repositories", organization.GetDependencyGraphEnabledForNewRepos())
 		_ = d.Set("secret_scanning_enabled_for_new_repositories", organization.GetSecretScanningEnabledForNewRepos())
 		_ = d.Set("secret_scanning_push_protection_enabled_for_new_repositories", organization.GetSecretScanningPushProtectionEnabledForNewRepos())
+		_ = d.Set("members_can_change_repo_visibility", organization.GetMembersCanChangeRepoVisibility())
 	}
 
 	d.SetId(strconv.FormatInt(organization.GetID(), 10))

--- a/github/data_source_github_organization_test.go
+++ b/github/data_source_github_organization_test.go
@@ -41,6 +41,7 @@ func TestAccGithubOrganizationDataSource(t *testing.T) {
 			resource.TestCheckResourceAttrSet("data.github_organization.test", "dependency_graph_enabled_for_new_repositories"),
 			resource.TestCheckResourceAttrSet("data.github_organization.test", "secret_scanning_enabled_for_new_repositories"),
 			resource.TestCheckResourceAttrSet("data.github_organization.test", "secret_scanning_push_protection_enabled_for_new_repositories"),
+			resource.TestCheckResourceAttrSet("data.github_organization.test", "members_can_change_repo_visibility"),
 		)
 
 		resource.Test(t, resource.TestCase{

--- a/github/resource_github_organization_settings.go
+++ b/github/resource_github_organization_settings.go
@@ -81,6 +81,12 @@ func resourceGithubOrganizationSettings() *schema.Resource {
 				Default:     true,
 				Description: "Whether or not organization members can create new repositories.",
 			},
+			"members_can_change_repo_visibility": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether or not organization members can change the visibility of repositories.",
+			},
 			"members_can_create_internal_repositories": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -251,6 +257,9 @@ func buildOrganizationSettings(d *schema.ResourceData, isEnterprise bool) *githu
 	if shouldInclude("members_can_create_repositories") {
 		settings.MembersCanCreateRepos = new(d.Get("members_can_create_repositories").(bool))
 	}
+	if shouldInclude("members_can_change_repo_visibility") {
+		settings.MembersCanChangeRepoVisibility = github.Ptr(d.Get("members_can_change_repo_visibility").(bool))
+	}
 	if shouldInclude("members_can_create_private_repositories") {
 		settings.MembersCanCreatePrivateRepos = new(d.Get("members_can_create_private_repositories").(bool))
 	}
@@ -356,6 +365,9 @@ func resourceGithubOrganizationSettingsCreateOrUpdate(d *schema.ResourceData, me
 	}
 	if settings.MembersCanCreateRepos != nil {
 		log.Printf("[DEBUG]   MembersCanCreateRepos: %v", *settings.MembersCanCreateRepos)
+	}
+	if settings.MembersCanChangeRepoVisibility != nil {
+		log.Printf("[DEBUG]   MembersCanChangeRepoVisibility: %v", *settings.MembersCanChangeRepoVisibility)
 	}
 	if settings.MembersCanCreatePrivateRepos != nil {
 		log.Printf("[DEBUG]   MembersCanCreatePrivateRepos: %v", *settings.MembersCanCreatePrivateRepos)
@@ -466,6 +478,9 @@ func resourceGithubOrganizationSettingsRead(d *schema.ResourceData, meta any) er
 		return err
 	}
 	if err = d.Set("members_can_create_repositories", orgSettings.GetMembersCanCreateRepos()); err != nil {
+		return err
+	}
+	if err = d.Set("members_can_change_repo_visibility", orgSettings.GetMembersCanChangeRepoVisibility()); err != nil {
 		return err
 	}
 	if err = d.Set("members_can_create_internal_repositories", orgSettings.GetMembersCanCreateInternalRepos()); err != nil {

--- a/github/resource_github_organization_settings_test.go
+++ b/github/resource_github_organization_settings_test.go
@@ -25,6 +25,7 @@ func TestAccGithubOrganizationSettings(t *testing.T) {
 			has_repository_projects = true
 			default_repository_permission = "read"
 			members_can_create_repositories = true
+			members_can_change_repo_visibility = true
 			members_can_create_public_repositories = true
 			members_can_create_private_repositories = true
 			members_can_create_internal_repositories = false
@@ -42,10 +43,43 @@ func TestAccGithubOrganizationSettings(t *testing.T) {
 		  }`
 
 		check := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"billing_email", "test@example.com",
-			),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "billing_email", "test@example.com"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "company", "Test Company"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "blog", "https://example.com"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "email", "test@example.com"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "twitter_username", "Test"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "location", "Test Location"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "name", "Test Name"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "description", "Test Description"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "has_organization_projects", "true"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "has_repository_projects", "true"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "default_repository_permission", "read"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_create_repositories", "true"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_change_repo_visibility", "true"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_create_public_repositories", "true"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_create_private_repositories", "true"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_create_internal_repositories", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_create_pages", "true"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_create_public_pages", "true"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_create_private_pages", "true"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_fork_private_repositories", "true"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "web_commit_signoff_required", "true"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "advanced_security_enabled_for_new_repositories", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "dependabot_alerts_enabled_for_new_repositories", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "dependabot_security_updates_enabled_for_new_repositories", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "dependency_graph_enabled_for_new_repositories", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "secret_scanning_enabled_for_new_repositories", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "secret_scanning_push_protection_enabled_for_new_repositories", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "secret_scanning_validity_checks_enabled", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_delete_repositories", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_change_repo_visibility", "true"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_invite_outside_collaborators", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_delete_issues", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "display_commenter_full_name_setting_enabled", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "readers_can_create_discussions", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_create_teams", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_view_dependency_insights", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "default_repository_branch", "main"),
 		)
 
 		resource.Test(t, resource.TestCase{
@@ -84,14 +118,8 @@ func TestAccGithubOrganizationSettings(t *testing.T) {
 				}`, updatedBillingEmail, updatedCompany, updatedBlog),
 		}
 		checks := map[string]resource.TestCheckFunc{
-			"before": resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"billing_email", billingEmail,
-			),
-			"after": resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"billing_email", updatedBillingEmail,
-			),
+			"before": resource.TestCheckResourceAttr("github_organization_settings.test", "billing_email", billingEmail),
+			"after":  resource.TestCheckResourceAttr("github_organization_settings.test", "billing_email", updatedBillingEmail),
 		}
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessHasOrgs(t) },
@@ -150,6 +178,7 @@ func TestAccGithubOrganizationSettings(t *testing.T) {
 		resource "github_organization_settings" "test" {
 			billing_email = "test@example.com"
 			members_can_create_private_repositories = false
+			members_can_change_repo_visibility = false
 			members_can_create_internal_repositories = false
 			members_can_fork_private_repositories = false
 			web_commit_signoff_required = false
@@ -162,52 +191,19 @@ func TestAccGithubOrganizationSettings(t *testing.T) {
 		}`
 
 		check := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"billing_email", "test@example.com",
-			),
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"members_can_create_private_repositories", "false",
-			),
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"members_can_create_internal_repositories", "false",
-			),
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"members_can_fork_private_repositories", "false",
-			),
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"web_commit_signoff_required", "false",
-			),
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"advanced_security_enabled_for_new_repositories", "false",
-			),
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"dependabot_alerts_enabled_for_new_repositories", "false",
-			),
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"dependabot_security_updates_enabled_for_new_repositories", "false",
-			),
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"dependency_graph_enabled_for_new_repositories", "false",
-			),
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"secret_scanning_enabled_for_new_repositories", "false",
-			),
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"secret_scanning_push_protection_enabled_for_new_repositories", "false",
-			),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "billing_email", "test@example.com"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_create_private_repositories", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_change_repo_visibility", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_create_internal_repositories", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_fork_private_repositories", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "web_commit_signoff_required", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "advanced_security_enabled_for_new_repositories", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "dependabot_alerts_enabled_for_new_repositories", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "dependabot_security_updates_enabled_for_new_repositories", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "dependency_graph_enabled_for_new_repositories", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "secret_scanning_enabled_for_new_repositories", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "secret_scanning_push_protection_enabled_for_new_repositories", "false"),
 		)
-
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
@@ -225,6 +221,7 @@ func TestAccGithubOrganizationSettings(t *testing.T) {
 		resource "github_organization_settings" "test" {
 			billing_email = "test@example.com"
 			members_can_create_private_repositories = false
+			members_can_change_repo_visibility = true
 			members_can_create_internal_repositories = true
 			members_can_fork_private_repositories = false
 			web_commit_signoff_required = true
@@ -237,52 +234,19 @@ func TestAccGithubOrganizationSettings(t *testing.T) {
 		}`
 
 		check := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"billing_email", "test@example.com",
-			),
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"members_can_create_private_repositories", "false",
-			),
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"members_can_create_internal_repositories", "true",
-			),
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"members_can_fork_private_repositories", "false",
-			),
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"web_commit_signoff_required", "true",
-			),
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"advanced_security_enabled_for_new_repositories", "false",
-			),
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"dependabot_alerts_enabled_for_new_repositories", "true",
-			),
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"dependabot_security_updates_enabled_for_new_repositories", "false",
-			),
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"dependency_graph_enabled_for_new_repositories", "true",
-			),
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"secret_scanning_enabled_for_new_repositories", "false",
-			),
-			resource.TestCheckResourceAttr(
-				"github_organization_settings.test",
-				"secret_scanning_push_protection_enabled_for_new_repositories", "true",
-			),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "billing_email", "test@example.com"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_create_private_repositories", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_change_repo_visibility", "true"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_create_internal_repositories", "true"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_fork_private_repositories", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "web_commit_signoff_required", "true"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "advanced_security_enabled_for_new_repositories", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "dependabot_alerts_enabled_for_new_repositories", "true"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "dependabot_security_updates_enabled_for_new_repositories", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "dependency_graph_enabled_for_new_repositories", "true"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "secret_scanning_enabled_for_new_repositories", "false"),
+			resource.TestCheckResourceAttr("github_organization_settings.test", "secret_scanning_push_protection_enabled_for_new_repositories", "true"),
 		)
-
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
@@ -520,6 +484,7 @@ func TestAccGithubOrganizationSettings(t *testing.T) {
 				resource.TestCheckResourceAttr("github_organization_settings.test", "secret_scanning_enabled_for_new_repositories", "true"),
 				resource.TestCheckResourceAttr("github_organization_settings.test", "secret_scanning_push_protection_enabled_for_new_repositories", "true"),
 				resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_create_private_repositories", "true"),
+				resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_change_repo_visibility", "true"),
 				resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_create_internal_repositories", "true"),
 				resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_create_pages", "true"),
 				resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_create_public_pages", "true"),
@@ -551,6 +516,7 @@ func TestAccGithubOrganizationSettings(t *testing.T) {
 				secret_scanning_enabled_for_new_repositories = false
 				secret_scanning_push_protection_enabled_for_new_repositories = false
 				members_can_create_private_repositories = false
+				members_can_change_repo_visibility = false
 				members_can_create_internal_repositories = false
 				members_can_create_pages = false
 				members_can_create_public_pages = false
@@ -567,6 +533,7 @@ func TestAccGithubOrganizationSettings(t *testing.T) {
 				resource.TestCheckResourceAttr("github_organization_settings.test", "secret_scanning_enabled_for_new_repositories", "false"),
 				resource.TestCheckResourceAttr("github_organization_settings.test", "secret_scanning_push_protection_enabled_for_new_repositories", "false"),
 				resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_create_private_repositories", "false"),
+				resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_change_repo_visibility", "false"),
 				resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_create_internal_repositories", "false"),
 				resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_create_pages", "false"),
 				resource.TestCheckResourceAttr("github_organization_settings.test", "members_can_create_public_pages", "false"),

--- a/website/docs/d/organization.html.markdown
+++ b/website/docs/d/organization.html.markdown
@@ -43,6 +43,7 @@ data "github_organization" "example" {
  * `default_repository_permission` - Default permission level members have for organization repositories.
  * `members_allowed_repository_creation_type` - The type of repository allowed to be created by members of the organization. Can be one of `ALL`, `PUBLIC`, `PRIVATE`, `NONE`.
  * `members_can_create_repositories` - Whether non-admin organization members can create repositories.
+ * `members_can_change_repo_visibility` - Whether organization members can change the visibility of repositories.
  * `members_can_create_internal_repositories` - Whether organization members can create internal repositories.
  * `members_can_create_private_repositories` - Whether organization members can create private repositories.
  * `members_can_create_public_repositories` - Whether organization members can create public repositories.

--- a/website/docs/r/organization_settings.html.markdown
+++ b/website/docs/r/organization_settings.html.markdown
@@ -58,6 +58,7 @@ The following arguments are supported:
 * `has_repository_projects` - (Optional) Whether or not repository projects are enabled for the organization.
 * `default_repository_permission` - (Optional) The default permission for organization members to create new repositories. Can be one of `read`, `write`, `admin`, or `none`. Defaults to `read`.
 * `members_can_create_repositories` - (Optional) Whether or not organization members can create new repositories. Defaults to `true`.
+* `members_can_change_repo_visibility` - (Optional) Whether or not organization members can change the visibility of repositories. Defaults to `true`.
 * `members_can_create_public_repositories` - (Optional) Whether or not organization members can create new public repositories. Defaults to `true`.
 * `members_can_create_private_repositories` - (Optional) Whether or not organization members can create new private repositories. Defaults to `true`.
 * `members_can_create_internal_repositories` - (Optional) Whether or not organization members can create new internal repositories. For Enterprise Organizations only.


### PR DESCRIPTION
Also added support for the github_organization data source. 

This field is already a part of the `Organization` struct in the upstream `go-github` library, this is just surfacing it in the Terraform provider.

Resolves #3136

----

### Pull request checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

----
