### PR TITLE
[FEAT] Add missing IP ranges to DS `github_ip_ranges`

### DIFF
--- a/github/data_source_github_ip_ranges.go
+++ b/github/data_source_github_ip_ranges.go
@@ -1,16 +1,18 @@
 package github
 
 import (
+	"context"
 	"fmt"
 	"net"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataSourceGithubIpRanges() *schema.Resource {
 	return &schema.Resource{
 		Description: "Get the GitHub IP ranges used by various GitHub services.",
-		Read:        dataSourceGithubIpRangesRead,
+		ReadContext: dataSourceGithubIpRangesRead,
 		Schema: map[string]*schema.Schema{
 			"hooks": {
 				Type:     schema.TypeList,
@@ -193,67 +195,67 @@ func dataSourceGithubIpRanges() *schema.Resource {
 	}
 }
 
-func dataSourceGithubIpRangesRead(d *schema.ResourceData, meta any) error {
+func dataSourceGithubIpRangesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	owner := meta.(*Owner)
 
 	api, _, err := owner.v3client.Meta.Get(owner.StopContext)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	cidrHooksIpv4, cidrHooksIpv6, err := splitIpv4Ipv6Cidrs(&api.Hooks)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	cidrGitIpv4, cidrGitIpv6, err := splitIpv4Ipv6Cidrs(&api.Git)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	cidrPackagesIpv4, cidrPackagesIpv6, err := splitIpv4Ipv6Cidrs(&api.Packages)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	cidrPagesIpv4, cidrPagesIpv6, err := splitIpv4Ipv6Cidrs(&api.Pages)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	cidrImporterIpv4, cidrImporterIpv6, err := splitIpv4Ipv6Cidrs(&api.Importer)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	cidrActionsIpv4, cidrActionsIpv6, err := splitIpv4Ipv6Cidrs(&api.Actions)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	cidrActionsMacosIpv4, cidrActionsMacosIpv6, err := splitIpv4Ipv6Cidrs(&api.ActionsMacos)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	cidrGithubEnterpriseImporterIpv4, cidrGithubEnterpriseImporterIpv6, err := splitIpv4Ipv6Cidrs(&api.GithubEnterpriseImporter)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	cidrDependabotIpv4, cidrDependabotIpv6, err := splitIpv4Ipv6Cidrs(&api.Dependabot)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	cidrWebIpv4, cidrWebIpv6, err := splitIpv4Ipv6Cidrs(&api.Web)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	cidrApiIpv4, cidrApiIpv6, err := splitIpv4Ipv6Cidrs(&api.API)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if len(api.Hooks)+len(api.Git)+len(api.Pages)+len(api.Importer)+len(api.Actions)+len(api.Dependabot) > 0 {
@@ -261,123 +263,123 @@ func dataSourceGithubIpRangesRead(d *schema.ResourceData, meta any) error {
 	}
 	if len(api.Hooks) > 0 {
 		if err := d.Set("hooks", api.Hooks); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("hooks_ipv4", cidrHooksIpv4); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("hooks_ipv6", cidrHooksIpv6); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 	if len(api.Git) > 0 {
 		if err := d.Set("git", api.Git); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("git_ipv4", cidrGitIpv4); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("git_ipv6", cidrGitIpv6); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 	if len(api.Packages) > 0 {
 		if err := d.Set("packages", api.Packages); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("packages_ipv4", cidrPackagesIpv4); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("packages_ipv6", cidrPackagesIpv6); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 	if len(api.Pages) > 0 {
 		if err := d.Set("pages", api.Pages); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("pages_ipv4", cidrPagesIpv4); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("pages_ipv6", cidrPagesIpv6); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 	if len(api.Importer) > 0 {
 		if err := d.Set("importer", api.Importer); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("importer_ipv4", cidrImporterIpv4); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("importer_ipv6", cidrImporterIpv6); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 	if len(api.Actions) > 0 {
 		if err := d.Set("actions", api.Actions); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("actions_ipv4", cidrActionsIpv4); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("actions_ipv6", cidrActionsIpv6); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 	if len(api.ActionsMacos) > 0 {
 		if err := d.Set("actions_macos", api.ActionsMacos); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("actions_macos_ipv4", cidrActionsMacosIpv4); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("actions_macos_ipv6", cidrActionsMacosIpv6); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 	if len(api.GithubEnterpriseImporter) > 0 {
 		if err := d.Set("github_enterprise_importer", api.GithubEnterpriseImporter); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("github_enterprise_importer_ipv4", cidrGithubEnterpriseImporterIpv4); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("github_enterprise_importer_ipv6", cidrGithubEnterpriseImporterIpv6); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 	if len(api.Dependabot) > 0 {
 		if err := d.Set("dependabot", api.Dependabot); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("dependabot_ipv4", cidrDependabotIpv4); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("dependabot_ipv6", cidrDependabotIpv6); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 	if len(api.Web) > 0 {
 		if err := d.Set("web", api.Web); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("web_ipv4", cidrWebIpv4); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("web_ipv6", cidrWebIpv6); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 	if len(api.API) > 0 {
 		if err := d.Set("api", api.API); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("api_ipv4", cidrApiIpv4); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		if err := d.Set("api_ipv6", cidrApiIpv6); err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 

--- a/github/data_source_github_ip_ranges.go
+++ b/github/data_source_github_ip_ranges.go
@@ -260,147 +260,123 @@ func dataSourceGithubIpRangesRead(d *schema.ResourceData, meta any) error {
 		d.SetId("github-ip-ranges")
 	}
 	if len(api.Hooks) > 0 {
-		err = d.Set("hooks", api.Hooks)
-		if err != nil {
+		if err := d.Set("hooks", api.Hooks); err != nil {
 			return err
 		}
-		err = d.Set("hooks_ipv4", cidrHooksIpv4)
-		if err != nil {
+		if err := d.Set("hooks_ipv4", cidrHooksIpv4); err != nil {
 			return err
 		}
-		err = d.Set("hooks_ipv6", cidrHooksIpv6)
-		if err != nil {
+		if err := d.Set("hooks_ipv6", cidrHooksIpv6); err != nil {
 			return err
 		}
 	}
 	if len(api.Git) > 0 {
-		err = d.Set("git", api.Git)
-		if err != nil {
+		if err := d.Set("git", api.Git); err != nil {
 			return err
 		}
-		err = d.Set("git_ipv4", cidrGitIpv4)
-		if err != nil {
+		if err := d.Set("git_ipv4", cidrGitIpv4); err != nil {
 			return err
 		}
-		err = d.Set("git_ipv6", cidrGitIpv6)
-		if err != nil {
+		if err := d.Set("git_ipv6", cidrGitIpv6); err != nil {
 			return err
 		}
 	}
 	if len(api.Packages) > 0 {
-		_ = d.Set("packages", api.Packages)
-		_ = d.Set("packages_ipv4", cidrPackagesIpv4)
-		_ = d.Set("packages_ipv6", cidrPackagesIpv6)
+		if err := d.Set("packages", api.Packages); err != nil {
+			return err
+		}
+		if err := d.Set("packages_ipv4", cidrPackagesIpv4); err != nil {
+			return err
+		}
+		if err := d.Set("packages_ipv6", cidrPackagesIpv6); err != nil {
+			return err
+		}
 	}
 	if len(api.Pages) > 0 {
-		err = d.Set("pages", api.Pages)
-		if err != nil {
+		if err := d.Set("pages", api.Pages); err != nil {
 			return err
 		}
-		err = d.Set("pages_ipv4", cidrPagesIpv4)
-		if err != nil {
+		if err := d.Set("pages_ipv4", cidrPagesIpv4); err != nil {
 			return err
 		}
-		err = d.Set("pages_ipv6", cidrPagesIpv6)
-		if err != nil {
+		if err := d.Set("pages_ipv6", cidrPagesIpv6); err != nil {
 			return err
 		}
 	}
 	if len(api.Importer) > 0 {
-		err = d.Set("importer", api.Importer)
-		if err != nil {
+		if err := d.Set("importer", api.Importer); err != nil {
 			return err
 		}
-		err = d.Set("importer_ipv4", cidrImporterIpv4)
-		if err != nil {
+		if err := d.Set("importer_ipv4", cidrImporterIpv4); err != nil {
 			return err
 		}
-		err = d.Set("importer_ipv6", cidrImporterIpv6)
-		if err != nil {
+		if err := d.Set("importer_ipv6", cidrImporterIpv6); err != nil {
 			return err
 		}
 	}
 	if len(api.Actions) > 0 {
-		err = d.Set("actions", api.Actions)
-		if err != nil {
+		if err := d.Set("actions", api.Actions); err != nil {
 			return err
 		}
-		err = d.Set("actions_ipv4", cidrActionsIpv4)
-		if err != nil {
+		if err := d.Set("actions_ipv4", cidrActionsIpv4); err != nil {
 			return err
 		}
-		err = d.Set("actions_ipv6", cidrActionsIpv6)
-		if err != nil {
+		if err := d.Set("actions_ipv6", cidrActionsIpv6); err != nil {
 			return err
 		}
 	}
 	if len(api.ActionsMacos) > 0 {
-		err = d.Set("actions_macos", api.ActionsMacos)
-		if err != nil {
+		if err := d.Set("actions_macos", api.ActionsMacos); err != nil {
 			return err
 		}
-		err = d.Set("actions_macos_ipv4", cidrActionsMacosIpv4)
-		if err != nil {
+		if err := d.Set("actions_macos_ipv4", cidrActionsMacosIpv4); err != nil {
 			return err
 		}
-		err = d.Set("actions_macos_ipv6", cidrActionsMacosIpv6)
-		if err != nil {
+		if err := d.Set("actions_macos_ipv6", cidrActionsMacosIpv6); err != nil {
 			return err
 		}
 	}
 	if len(api.GithubEnterpriseImporter) > 0 {
-		err = d.Set("github_enterprise_importer", api.GithubEnterpriseImporter)
-		if err != nil {
+		if err := d.Set("github_enterprise_importer", api.GithubEnterpriseImporter); err != nil {
 			return err
 		}
-		err = d.Set("github_enterprise_importer_ipv4", cidrGithubEnterpriseImporterIpv4)
-		if err != nil {
+		if err := d.Set("github_enterprise_importer_ipv4", cidrGithubEnterpriseImporterIpv4); err != nil {
 			return err
 		}
-		err = d.Set("github_enterprise_importer_ipv6", cidrGithubEnterpriseImporterIpv6)
-		if err != nil {
+		if err := d.Set("github_enterprise_importer_ipv6", cidrGithubEnterpriseImporterIpv6); err != nil {
 			return err
 		}
 	}
 	if len(api.Dependabot) > 0 {
-		err = d.Set("dependabot", api.Dependabot)
-		if err != nil {
+		if err := d.Set("dependabot", api.Dependabot); err != nil {
 			return err
 		}
-		err = d.Set("dependabot_ipv4", cidrDependabotIpv4)
-		if err != nil {
+		if err := d.Set("dependabot_ipv4", cidrDependabotIpv4); err != nil {
 			return err
 		}
-		err = d.Set("dependabot_ipv6", cidrDependabotIpv6)
-		if err != nil {
+		if err := d.Set("dependabot_ipv6", cidrDependabotIpv6); err != nil {
 			return err
 		}
 	}
 	if len(api.Web) > 0 {
-		err = d.Set("web", api.Web)
-		if err != nil {
+		if err := d.Set("web", api.Web); err != nil {
 			return err
 		}
-		err = d.Set("web_ipv4", cidrWebIpv4)
-		if err != nil {
+		if err := d.Set("web_ipv4", cidrWebIpv4); err != nil {
 			return err
 		}
-		err = d.Set("web_ipv6", cidrWebIpv6)
-		if err != nil {
+		if err := d.Set("web_ipv6", cidrWebIpv6); err != nil {
 			return err
 		}
 	}
 	if len(api.API) > 0 {
-		err = d.Set("api", api.API)
-		if err != nil {
+		if err := d.Set("api", api.API); err != nil {
 			return err
 		}
-		err = d.Set("api_ipv4", cidrApiIpv4)
-		if err != nil {
+		if err := d.Set("api_ipv4", cidrApiIpv4); err != nil {
 			return err
 		}
-		err = d.Set("api_ipv6", cidrApiIpv6)
-		if err != nil {
+		if err := d.Set("api_ipv6", cidrApiIpv6); err != nil {
 			return err
 		}
 	}

--- a/github/data_source_github_ip_ranges.go
+++ b/github/data_source_github_ip_ranges.go
@@ -48,9 +48,22 @@ func dataSourceGithubIpRanges() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"actions": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "An array of IP addresses in CIDR format specifying the addresses that GitHub Actions will originate from.",
+			},
+			"actions_macos": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "An array of IP addresses in CIDR format specifying the addresses that GitHub Actions macOS runners will originate from.",
+			},
+			"github_enterprise_importer": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "An array of IP addresses in CIDR format specifying the addresses that GitHub Enterprise Importer will originate from.",
 			},
 			"dependabot": {
 				Deprecated: "This attribute is no longer returned form the API, Dependabot now uses the GitHub Actions IP addresses.",
@@ -94,9 +107,22 @@ func dataSourceGithubIpRanges() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"actions_ipv4": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "An array of IPv4 addresses in CIDR format specifying the addresses that GitHub Actions will originate from.",
+			},
+			"actions_macos_ipv4": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "An array of IPv4 addresses in CIDR format specifying the addresses that GitHub Actions macOS runners will originate from.",
+			},
+			"github_enterprise_importer_ipv4": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "An array of IPv4 addresses in CIDR format specifying the addresses that GitHub Enterprise Importer will originate from.",
 			},
 			"dependabot_ipv4": {
 				Deprecated: "This attribute is no longer returned form the API, Dependabot now uses the GitHub Actions IP addresses.",
@@ -140,9 +166,22 @@ func dataSourceGithubIpRanges() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"actions_ipv6": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "An array of IPv6 addresses in CIDR format specifying the addresses that GitHub Actions will originate from.",
+			},
+			"actions_macos_ipv6": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "An array of IPv6 addresses in CIDR format specifying the addresses that GitHub Actions macOS runners will originate from.",
+			},
+			"github_enterprise_importer_ipv6": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "An array of IPv6 addresses in CIDR format specifying the addresses that GitHub Enterprise Importer will originate from.",
 			},
 			"dependabot_ipv6": {
 				Deprecated: "This attribute is no longer returned form the API, Dependabot now uses the GitHub Actions IP addresses.",
@@ -188,6 +227,16 @@ func dataSourceGithubIpRangesRead(d *schema.ResourceData, meta any) error {
 	}
 
 	cidrActionsIpv4, cidrActionsIpv6, err := splitIpv4Ipv6Cidrs(&api.Actions)
+	if err != nil {
+		return err
+	}
+
+	cidrActionsMacosIpv4, cidrActionsMacosIpv6, err := splitIpv4Ipv6Cidrs(&api.ActionsMacos)
+	if err != nil {
+		return err
+	}
+
+	cidrGithubEnterpriseImporterIpv4, cidrGithubEnterpriseImporterIpv6, err := splitIpv4Ipv6Cidrs(&api.GithubEnterpriseImporter)
 	if err != nil {
 		return err
 	}
@@ -281,6 +330,34 @@ func dataSourceGithubIpRangesRead(d *schema.ResourceData, meta any) error {
 			return err
 		}
 		err = d.Set("actions_ipv6", cidrActionsIpv6)
+		if err != nil {
+			return err
+		}
+	}
+	if len(api.ActionsMacos) > 0 {
+		err = d.Set("actions_macos", api.ActionsMacos)
+		if err != nil {
+			return err
+		}
+		err = d.Set("actions_macos_ipv4", cidrActionsMacosIpv4)
+		if err != nil {
+			return err
+		}
+		err = d.Set("actions_macos_ipv6", cidrActionsMacosIpv6)
+		if err != nil {
+			return err
+		}
+	}
+	if len(api.GithubEnterpriseImporter) > 0 {
+		err = d.Set("github_enterprise_importer", api.GithubEnterpriseImporter)
+		if err != nil {
+			return err
+		}
+		err = d.Set("github_enterprise_importer_ipv4", cidrGithubEnterpriseImporterIpv4)
+		if err != nil {
+			return err
+		}
+		err = d.Set("github_enterprise_importer_ipv6", cidrGithubEnterpriseImporterIpv6)
 		if err != nil {
 			return err
 		}

--- a/github/data_source_github_ip_ranges_test.go
+++ b/github/data_source_github_ip_ranges_test.go
@@ -4,51 +4,55 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestAccGithubIpRangesDataSource(t *testing.T) {
 	t.Run("reads IP ranges without error", func(t *testing.T) {
 		config := `data "github_ip_ranges" "test" {}`
 
-		check := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "hooks.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "git.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "api.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "web.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "packages.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "pages.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "importer.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "actions.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "actions_macos.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "github_enterprise_importer.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "hooks_ipv4.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "git_ipv4.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "api_ipv4.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "web_ipv4.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "packages_ipv4.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "pages_ipv4.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "importer_ipv4.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "actions_ipv4.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "actions_macos_ipv4.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "github_enterprise_importer_ipv4.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "hooks_ipv6.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "git_ipv6.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "api_ipv6.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "web_ipv6.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "packages_ipv6.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "pages_ipv6.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "importer_ipv6.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "actions_ipv6.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "actions_macos_ipv6.#"),
-			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "github_enterprise_importer_ipv6.#"),
-		)
-
 		resource.Test(t, resource.TestCase{
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
 					Config: config,
-					Check:  check,
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("actions_ipv4"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("actions_ipv6"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("actions_macos_ipv4"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("actions_macos_ipv6"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("actions_macos"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("actions"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("api_ipv4"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("api_ipv6"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("api"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("dependabot_ipv4"), knownvalue.Null()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("dependabot_ipv6"), knownvalue.Null()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("dependabot"), knownvalue.Null()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("git_ipv4"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("git_ipv6"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("git"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("github_enterprise_importer_ipv4"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("github_enterprise_importer_ipv6"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("github_enterprise_importer"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("hooks_ipv4"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("hooks_ipv6"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("hooks"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("importer_ipv4"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("importer_ipv6"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("importer"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("packages_ipv4"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("packages_ipv6"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("packages"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("pages_ipv4"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("pages_ipv6"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("pages"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("web_ipv4"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("web_ipv6"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_ip_ranges.test", tfjsonpath.New("web"), knownvalue.NotNull()),
+					},
 				},
 			},
 		})

--- a/github/data_source_github_ip_ranges_test.go
+++ b/github/data_source_github_ip_ranges_test.go
@@ -19,6 +19,8 @@ func TestAccGithubIpRangesDataSource(t *testing.T) {
 			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "pages.#"),
 			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "importer.#"),
 			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "actions.#"),
+			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "actions_macos.#"),
+			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "github_enterprise_importer.#"),
 			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "hooks_ipv4.#"),
 			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "git_ipv4.#"),
 			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "api_ipv4.#"),
@@ -27,6 +29,8 @@ func TestAccGithubIpRangesDataSource(t *testing.T) {
 			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "pages_ipv4.#"),
 			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "importer_ipv4.#"),
 			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "actions_ipv4.#"),
+			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "actions_macos_ipv4.#"),
+			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "github_enterprise_importer_ipv4.#"),
 			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "hooks_ipv6.#"),
 			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "git_ipv6.#"),
 			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "api_ipv6.#"),
@@ -35,6 +39,8 @@ func TestAccGithubIpRangesDataSource(t *testing.T) {
 			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "pages_ipv6.#"),
 			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "importer_ipv6.#"),
 			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "actions_ipv6.#"),
+			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "actions_macos_ipv6.#"),
+			resource.TestCheckResourceAttrSet("data.github_ip_ranges.test", "github_enterprise_importer_ipv6.#"),
 		)
 
 		resource.Test(t, resource.TestCase{

--- a/website/docs/d/ip_ranges.html.markdown
+++ b/website/docs/d/ip_ranges.html.markdown
@@ -17,30 +17,36 @@ data "github_ip_ranges" "test" {}
 
 ## Attributes Reference
 
- * `actions` - An array of IP addresses in CIDR format specifying the addresses that incoming requests from GitHub actions will originate from.
- * `actions_ipv4` - A subset of the `actions` array that contains IP addresses in IPv4 CIDR format.
- * `actions_ipv6` - A subset of the `actions` array that contains IP addresses in IPv6 CIDR format.
- * `dependabot` - An array of IP addresses in CIDR format specifying the A records for dependabot.
- * `dependabot_ipv4` - A subset of the `dependabot` array that contains IP addresses in IPv4 CIDR format.
- * `dependabot_ipv6` - A subset of the `dependabot` array that contains IP addresses in IPv6 CIDR format.
- * `hooks` - An Array of IP addresses in CIDR format specifying the addresses that incoming service hooks will originate from.
- * `hooks_ipv4` - A subset of the `hooks` array that contains IP addresses in IPv4 CIDR format.
- * `hooks_ipv6` - A subset of the `hooks` array that contains IP addresses in IPv6 CIDR format.
- * `git` - An Array of IP addresses in CIDR format specifying the Git servers.
- * `git_ipv4` - A subset of the `git` array that contains IP addresses in IPv4 CIDR format.
- * `git_ipv6` - A subset of the `git` array that contains IP addresses in IPv6 CIDR format.
- * `web` - An Array of IP addresses in CIDR format for GitHub Web.
- * `web_ipv4` - A subset of the `web` array that contains IP addresses in IPv4 CIDR format.
- * `web_ipv6` - A subset of the `web` array that contains IP addresses in IPv6 CIDR format.
- * `api` - An Array of IP addresses in CIDR format for the GitHub API.
- * `api_ipv4` - A subset of the `api` array that contains IP addresses in IPv4 CIDR format.
- * `api_ipv6` - A subset of the `api` array that contains IP addresses in IPv6 CIDR format.
- * `packages` - An Array of IP addresses in CIDR format specifying the A records for GitHub Packages.
- * `packages_ipv4` - A subset of the `packages` array that contains IP addresses in IPv4 CIDR format.
- * `packages_ipv6` - A subset of the `packages` array that contains IP addresses in IPv6 CIDR format.
- * `pages` - An Array of IP addresses in CIDR format specifying the A records for GitHub Pages.
- * `pages_ipv4` - A subset of the `pages` array that contains IP addresses in IPv4 CIDR format.
- * `pages_ipv6` - A subset of the `pages` array that contains IP addresses in IPv6 CIDR format.
- * `importer` - An Array of IP addresses in CIDR format specifying the A records for GitHub Importer.
- * `importer_ipv4` - A subset of the `importer` array that contains IP addresses in IPv4 CIDR format.
- * `importer_ipv6` - A subset of the `importer` array that contains IP addresses in IPv6 CIDR format.
+- `actions` - An array of IP addresses in CIDR format specifying the addresses that incoming requests from GitHub Actions will originate from.
+- `actions_ipv4` - A subset of the `actions` array that contains IP addresses in IPv4 CIDR format.
+- `actions_ipv6` - A subset of the `actions` array that contains IP addresses in IPv6 CIDR format.
+- `actions_macos` - An array of IP addresses in CIDR format specifying the addresses that GitHub Actions macOS runners will originate from.
+- `actions_macos_ipv4` - A subset of the `actions_macos` array that contains IP addresses in IPv4 CIDR format.
+- `actions_macos_ipv6` - A subset of the `actions_macos` array that contains IP addresses in IPv6 CIDR format.
+- `dependabot` - **Deprecated.** Dependabot now uses GitHub Actions IP addresses. An array of IP addresses in CIDR format specifying the A records for Dependabot.
+- `dependabot_ipv4` - **Deprecated.** A subset of the `dependabot` array that contains IP addresses in IPv4 CIDR format.
+- `dependabot_ipv6` - **Deprecated.** A subset of the `dependabot` array that contains IP addresses in IPv6 CIDR format.
+- `github_enterprise_importer` - An array of IP addresses in CIDR format specifying the addresses that GitHub Enterprise Importer will originate from.
+- `github_enterprise_importer_ipv4` - A subset of the `github_enterprise_importer` array that contains IP addresses in IPv4 CIDR format.
+- `github_enterprise_importer_ipv6` - A subset of the `github_enterprise_importer` array that contains IP addresses in IPv6 CIDR format.
+- `hooks` - An Array of IP addresses in CIDR format specifying the addresses that incoming service hooks will originate from.
+- `hooks_ipv4` - A subset of the `hooks` array that contains IP addresses in IPv4 CIDR format.
+- `hooks_ipv6` - A subset of the `hooks` array that contains IP addresses in IPv6 CIDR format.
+- `git` - An Array of IP addresses in CIDR format specifying the Git servers.
+- `git_ipv4` - A subset of the `git` array that contains IP addresses in IPv4 CIDR format.
+- `git_ipv6` - A subset of the `git` array that contains IP addresses in IPv6 CIDR format.
+- `web` - An Array of IP addresses in CIDR format for GitHub Web.
+- `web_ipv4` - A subset of the `web` array that contains IP addresses in IPv4 CIDR format.
+- `web_ipv6` - A subset of the `web` array that contains IP addresses in IPv6 CIDR format.
+- `api` - An Array of IP addresses in CIDR format for the GitHub API.
+- `api_ipv4` - A subset of the `api` array that contains IP addresses in IPv4 CIDR format.
+- `api_ipv6` - A subset of the `api` array that contains IP addresses in IPv6 CIDR format.
+- `packages` - An Array of IP addresses in CIDR format specifying the A records for GitHub Packages.
+- `packages_ipv4` - A subset of the `packages` array that contains IP addresses in IPv4 CIDR format.
+- `packages_ipv6` - A subset of the `packages` array that contains IP addresses in IPv6 CIDR format.
+- `pages` - An Array of IP addresses in CIDR format specifying the A records for GitHub Pages.
+- `pages_ipv4` - A subset of the `pages` array that contains IP addresses in IPv4 CIDR format.
+- `pages_ipv6` - A subset of the `pages` array that contains IP addresses in IPv6 CIDR format.
+- `importer` - An Array of IP addresses in CIDR format specifying the A records for GitHub Importer.
+- `importer_ipv4` - A subset of the `importer` array that contains IP addresses in IPv4 CIDR format.
+- `importer_ipv6` - A subset of the `importer` array that contains IP addresses in IPv6 CIDR format.


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2607

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- DS `github_ip_ranges` was missing: `actions_macos` and `github_enterprise_importer` IP ranges

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- No more missing fields (according to SDK)

### Pull request checklist

- [ ] ~Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))~
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
