### PR TITLE
[MAINT] Add test for EMU Group Mapping state migration

### DIFF
--- a/github/resource_github_emu_group_mapping_migration_test.go
+++ b/github/resource_github_emu_group_mapping_migration_test.go
@@ -1,9 +1,13 @@
 package github
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-github/v89/github"
 )
 
 func Test_resourceGithubEMUGroupMappingStateUpgradeV1(t *testing.T) {
@@ -36,6 +40,98 @@ func Test_resourceGithubEMUGroupMappingStateUpgradeV1(t *testing.T) {
 
 			if diff := cmp.Diff(got, d.want); !d.shouldError && diff != "" {
 				t.Fatalf("got %+v, want %+v: %s", got, d.want, diff)
+			}
+		})
+	}
+}
+
+type v0StatusCode struct {
+	externalGroups int
+	team           int
+}
+type v0Body struct {
+	externalGroups *github.ExternalGroupList
+	team           *github.Team
+}
+
+func Test_resourceGithubEMUGroupMappingStateUpgradeV0(t *testing.T) {
+	t.Parallel()
+
+	const testOrgSlug = "test-org"
+	const testTeamSlug = "test-team"
+	const testTeamID = 432574718
+	const testGroupID = 1234567890
+
+	meta := &Owner{
+		name: testOrgSlug,
+	}
+
+	for _, tt := range []struct {
+		testName   string
+		rawState   map[string]any
+		want       map[string]any
+		wantErr    *string
+		statusCode v0StatusCode
+		body       v0Body
+	}{
+		{
+			testName: "migrates v0 to v1",
+			rawState: map[string]any{
+				"id":        fmt.Sprintf("teams/%s/%d/external-groups", testTeamSlug, testGroupID),
+				"team_slug": testTeamSlug,
+				"group_id":  testGroupID,
+			},
+			want: map[string]any{
+				"id":        fmt.Sprintf("%d:%s:%d", testTeamID, testTeamSlug, testGroupID),
+				"team_slug": testTeamSlug,
+				"team_id":   testTeamID,
+				"group_id":  testGroupID,
+			},
+			wantErr: nil,
+			statusCode: v0StatusCode{
+				externalGroups: 201,
+				team:           200,
+			},
+			body: v0Body{
+				externalGroups: &github.ExternalGroupList{
+					Groups: []*github.ExternalGroup{{
+						GroupID:   new(int64(testGroupID)),
+						GroupName: new(testOrgSlug),
+						UpdatedAt: new(github.Timestamp{Time: time.Now()}),
+					}},
+				},
+				team: &github.Team{
+					ID: new(int64(testTeamID)),
+				},
+			},
+		},
+	} {
+		t.Run(tt.testName, func(t *testing.T) {
+			mockResponses := []*mockResponse{
+				mustGetTestMockResponse(t, fmt.Sprintf("/orgs/%s/teams/%s/external-groups", testOrgSlug, testTeamSlug), tt.statusCode.externalGroups, tt.body.externalGroups),
+				mustGetTestMockResponse(t, fmt.Sprintf("/orgs/%s/teams/%s", testOrgSlug, testTeamSlug), tt.statusCode.team, tt.body.team),
+			}
+			ts := githubApiMock(mockResponses)
+			defer ts.Close()
+			meta.v3client = mustCreateTestGitHubClient(t, ts.URL)
+
+			got, err := resourceGithubEMUGroupMappingStateUpgradeV0(t.Context(), tt.rawState, meta)
+			if err != nil {
+				if tt.wantErr == nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				if !regexp.MustCompile(regexp.QuoteMeta(*tt.wantErr)).MatchString(err.Error()) {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				return
+			}
+
+			if tt.wantErr != nil {
+				t.Fatalf("expected error: %s", *tt.wantErr)
+			}
+
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Fatalf("got %+v, want %+v, diff %s", got, tt.want, diff)
 			}
 		})
 	}


### PR DESCRIPTION

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- EMU Group Mapping state migration v0 => v1 doesn't have a test

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- EMU Group Mapping state migration v0 => v1 doesn't has a test

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
