### PR TITLE
feat: Fixup repository environment logic

### DIFF
--- a/github/resource_github_repository_environment_deployment_policy.go
+++ b/github/resource_github_repository_environment_deployment_policy.go
@@ -3,33 +3,40 @@ package github
 import (
 	"context"
 	"errors"
-	"log"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
 
 	"github.com/google/go-github/v83/github"
-	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceGithubRepositoryEnvironmentDeploymentPolicy() *schema.Resource {
 	return &schema.Resource{
-		CustomizeDiff: resourceGithubRepositoryEnvironmentDeploymentPolicyDiff,
-		CreateContext: resourceGithubRepositoryEnvironmentDeploymentPolicyCreate,
-		ReadContext:   resourceGithubRepositoryEnvironmentDeploymentPolicyRead,
-		UpdateContext: resourceGithubRepositoryEnvironmentDeploymentPolicyUpdate,
-		DeleteContext: resourceGithubRepositoryEnvironmentDeploymentPolicyDelete,
-		Importer: &schema.ResourceImporter{
-			StateContext: resourceGithubRepositoryEnvironmentDeploymentPolicyImport,
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceGithubRepositoryEnvironmentDeploymentPolicyV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceGithubRepositoryEnvironmentDeploymentPolicyStateUpgradeV0,
+				Version: 0,
+			},
 		},
+
 		Schema: map[string]*schema.Schema{
 			"repository": {
 				Description: "The name of the GitHub repository.",
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
+			},
+			"repository_id": {
+				Description: "The ID of the GitHub repository.",
+				Type:        schema.TypeInt,
+				Computed:    true,
 			},
 			"environment": {
 				Description: "The name of the environment.",
@@ -38,47 +45,53 @@ func resourceGithubRepositoryEnvironmentDeploymentPolicy() *schema.Resource {
 				ForceNew:    true,
 			},
 			"branch_pattern": {
-				Description:  "The name pattern that branches must match in order to deploy to the environment.",
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     false,
-				ExactlyOneOf: []string{"branch_pattern", "tag_pattern"},
-				ValidateDiagFunc: func(i any, _ cty.Path) diag.Diagnostics {
-					str, ok := i.(string)
-					if ok && len(str) > 0 {
-						return nil
-					}
-					return diag.Errorf("`branch_pattern` must be a valid non-empty string")
-				},
+				Description:      "The name pattern that branches must match in order to deploy to the environment.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         false,
+				ExactlyOneOf:     []string{"branch_pattern", "tag_pattern"},
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
 			},
 			"tag_pattern": {
-				Description:  "The name pattern that tags must match in order to deploy to the environment.",
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     false,
-				ExactlyOneOf: []string{"branch_pattern", "tag_pattern"},
-				ValidateDiagFunc: func(i any, _ cty.Path) diag.Diagnostics {
-					str, ok := i.(string)
-					if ok && len(str) > 0 {
-						return nil
-					}
-					return diag.Errorf("`tag_pattern` must be a valid non-empty string")
-				},
+				Description:      "The name pattern that tags must match in order to deploy to the environment.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         false,
+				ExactlyOneOf:     []string{"branch_pattern", "tag_pattern"},
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
 			},
+			"policy_id": {
+				Description: "The ID of the deployment policy.",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
+		},
+
+		CustomizeDiff: customdiff.All(
+			diffRepository,
+			resourceGithubRepositoryEnvironmentDeploymentPolicyDiff,
+		),
+
+		CreateContext: resourceGithubRepositoryEnvironmentDeploymentPolicyCreate,
+		ReadContext:   resourceGithubRepositoryEnvironmentDeploymentPolicyRead,
+		UpdateContext: resourceGithubRepositoryEnvironmentDeploymentPolicyUpdate,
+		DeleteContext: resourceGithubRepositoryEnvironmentDeploymentPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceGithubRepositoryEnvironmentDeploymentPolicyImport,
 		},
 	}
 }
 
-func resourceGithubRepositoryEnvironmentDeploymentPolicyDiff(_ context.Context, diff *schema.ResourceDiff, v any) error {
-	if diff.Id() == "" {
+func resourceGithubRepositoryEnvironmentDeploymentPolicyDiff(_ context.Context, d *schema.ResourceDiff, _ any) error {
+	if d.Id() == "" {
 		return nil
 	}
 
-	if diff.HasChange("branch_pattern") && diff.HasChange("tag_pattern") {
-		if err := diff.ForceNew("branch_pattern"); err != nil {
+	if d.HasChange("branch_pattern") && d.HasChange("tag_pattern") {
+		if err := d.ForceNew("branch_pattern"); err != nil {
 			return err
 		}
-		if err := diff.ForceNew("tag_pattern"); err != nil {
+		if err := d.ForceNew("tag_pattern"); err != nil {
 			return err
 		}
 	}
@@ -86,59 +99,66 @@ func resourceGithubRepositoryEnvironmentDeploymentPolicyDiff(_ context.Context, 
 	return nil
 }
 
-func resourceGithubRepositoryEnvironmentDeploymentPolicyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*Owner).v3client
+func resourceGithubRepositoryEnvironmentDeploymentPolicyCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
 
-	owner := meta.(*Owner).name
 	repoName := d.Get("repository").(string)
 	envName := d.Get("environment").(string)
+	branchPattern := d.Get("branch_pattern").(string)
+	tagPattern := d.Get("tag_pattern").(string)
 
-	var createData github.DeploymentBranchPolicyRequest
-	if v, ok := d.GetOk("branch_pattern"); ok {
-		createData = github.DeploymentBranchPolicyRequest{
-			Name: github.Ptr(v.(string)),
-			Type: github.Ptr("branch"),
-		}
-	} else if v, ok := d.GetOk("tag_pattern"); ok {
-		createData = github.DeploymentBranchPolicyRequest{
-			Name: github.Ptr(v.(string)),
-			Type: github.Ptr("tag"),
-		}
-	} else {
-		return diag.Errorf("only one of 'branch_pattern' or 'tag_pattern' must be specified")
+	policyType := "branch"
+	pattern := branchPattern
+	if branchPattern == "" {
+		policyType = "tag"
+		pattern = tagPattern
 	}
 
-	resultKey, _, err := client.Repositories.CreateDeploymentBranchPolicy(ctx, owner, repoName, url.PathEscape(envName), &createData)
+	createData := github.DeploymentBranchPolicyRequest{
+		Name: github.Ptr(pattern),
+		Type: github.Ptr(policyType),
+	}
+
+	policy, _, err := client.Repositories.CreateDeploymentBranchPolicy(ctx, owner, repoName, url.PathEscape(envName), &createData)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	id, err := buildID(repoName, escapeIDPart(envName), strconv.FormatInt(resultKey.GetID(), 10))
+	id, err := buildID(repoName, escapeIDPart(envName), strconv.FormatInt(policy.GetID(), 10))
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	d.SetId(id)
 
+	repo, _, err := client.Repositories.Get(ctx, owner, repoName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("repository_id", int(repo.GetID())); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("policy_id", policy.GetID()); err != nil {
+		return diag.FromErr(err)
+	}
+
 	return nil
 }
 
-func resourceGithubRepositoryEnvironmentDeploymentPolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*Owner).v3client
-	owner := meta.(*Owner).name
+func resourceGithubRepositoryEnvironmentDeploymentPolicyRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	ctx = tflog.SetField(ctx, "id", d.Id())
 
-	repoName, envNamePart, branchPolicyIdString, err := parseID3(d.Id())
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	meta := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
 
-	envName := unescapeIDPart(envNamePart)
+	repoName := d.Get("repository").(string)
+	envName := d.Get("environment").(string)
+	policyID := d.Get("policy_id").(int)
 
-	branchPolicyId, err := strconv.ParseInt(branchPolicyIdString, 10, 64)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	branchPolicy, _, err := client.Repositories.GetDeploymentBranchPolicy(ctx, owner, repoName, url.PathEscape(envName), branchPolicyId)
+	policy, _, err := client.Repositories.GetDeploymentBranchPolicy(ctx, owner, repoName, url.PathEscape(envName), int64(policyID))
 	if err != nil {
 		var ghErr *github.ErrorResponse
 		if errors.As(err, &ghErr) {
@@ -146,8 +166,7 @@ func resourceGithubRepositoryEnvironmentDeploymentPolicyRead(ctx context.Context
 				return nil
 			}
 			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[INFO] Removing branch deployment policy for %s/%s/%s from state because it no longer exists in GitHub",
-					owner, repoName, envName)
+				tflog.Info(ctx, "Deployment branch policy not found, removing from state.", map[string]any{"repository": repoName, "environment": envName, "policy_id": policyID})
 				d.SetId("")
 				return nil
 			}
@@ -155,31 +174,28 @@ func resourceGithubRepositoryEnvironmentDeploymentPolicyRead(ctx context.Context
 		return diag.FromErr(err)
 	}
 
-	if branchPolicy.GetType() == "branch" {
-		_ = d.Set("branch_pattern", branchPolicy.GetName())
+	if policy.GetType() == "branch" {
+		if err := d.Set("branch_pattern", policy.GetName()); err != nil {
+			return diag.FromErr(err)
+		}
 	} else {
-		_ = d.Set("tag_pattern", branchPolicy.GetName())
+		if err := d.Set("tag_pattern", policy.GetName()); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 	return nil
 }
 
-func resourceGithubRepositoryEnvironmentDeploymentPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*Owner).v3client
+func resourceGithubRepositoryEnvironmentDeploymentPolicyUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
 
-	owner := meta.(*Owner).name
 	repoName := d.Get("repository").(string)
 	envName := d.Get("environment").(string)
 	branchPattern := d.Get("branch_pattern").(string)
 	tagPattern := d.Get("tag_pattern").(string)
-	_, _, branchPolicyIdString, err := parseID3(d.Id())
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	branchPolicyId, err := strconv.ParseInt(branchPolicyIdString, 10, 64)
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	policyID := d.Get("policy_id").(int)
 
 	pattern := branchPattern
 	if branchPattern == "" {
@@ -190,12 +206,12 @@ func resourceGithubRepositoryEnvironmentDeploymentPolicyUpdate(ctx context.Conte
 		Name: github.Ptr(pattern),
 	}
 
-	resultKey, _, err := client.Repositories.UpdateDeploymentBranchPolicy(ctx, owner, repoName, url.PathEscape(envName), branchPolicyId, &updateData)
+	_, _, err := client.Repositories.UpdateDeploymentBranchPolicy(ctx, owner, repoName, url.PathEscape(envName), int64(policyID), &updateData)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	id, err := buildID(repoName, escapeIDPart(envName), strconv.FormatInt(resultKey.GetID(), 10))
+	id, err := buildID(repoName, escapeIDPart(envName), strconv.Itoa(policyID))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -204,23 +220,16 @@ func resourceGithubRepositoryEnvironmentDeploymentPolicyUpdate(ctx context.Conte
 	return nil
 }
 
-func resourceGithubRepositoryEnvironmentDeploymentPolicyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*Owner).v3client
+func resourceGithubRepositoryEnvironmentDeploymentPolicyDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
 
-	owner := meta.(*Owner).name
-	repoName, envNamePart, branchPolicyIdString, err := parseID3(d.Id())
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	repoName := d.Get("repository").(string)
+	envName := d.Get("environment").(string)
+	policyID := d.Get("policy_id").(int)
 
-	envName := unescapeIDPart(envNamePart)
-
-	branchPolicyId, err := strconv.ParseInt(branchPolicyIdString, 10, 64)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	_, err = client.Repositories.DeleteDeploymentBranchPolicy(ctx, owner, repoName, url.PathEscape(envName), branchPolicyId)
+	_, err := client.Repositories.DeleteDeploymentBranchPolicy(ctx, owner, repoName, url.PathEscape(envName), int64(policyID))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -228,16 +237,36 @@ func resourceGithubRepositoryEnvironmentDeploymentPolicyDelete(ctx context.Conte
 	return nil
 }
 
-func resourceGithubRepositoryEnvironmentDeploymentPolicyImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	repoName, envNamePart, _, err := parseID3(d.Id())
+func resourceGithubRepositoryEnvironmentDeploymentPolicyImport(ctx context.Context, d *schema.ResourceData, m any) ([]*schema.ResourceData, error) {
+	meta := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
+
+	repoName, envNamePart, policyIDStr, err := parseID3(d.Id())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid id (%s), expected format <repository>:<environment>:<policy_id>", d.Id())
+	}
+
+	repo, _, err := client.Repositories.Get(ctx, owner, repoName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve repository %s: %w", repoName, err)
+	}
+
+	policyID, err := strconv.Atoi(policyIDStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid policy ID: %s", policyIDStr)
 	}
 
 	if err := d.Set("repository", repoName); err != nil {
 		return nil, err
 	}
+	if err := d.Set("repository_id", int(repo.GetID())); err != nil {
+		return nil, err
+	}
 	if err := d.Set("environment", unescapeIDPart(envNamePart)); err != nil {
+		return nil, err
+	}
+	if err := d.Set("policy_id", policyID); err != nil {
 		return nil, err
 	}
 

--- a/github/resource_github_repository_environment_deployment_policy_migration.go
+++ b/github/resource_github_repository_environment_deployment_policy_migration.go
@@ -1,0 +1,82 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceGithubRepositoryEnvironmentDeploymentPolicyV0() *schema.Resource {
+	return &schema.Resource{
+		SchemaVersion: 0,
+
+		Schema: map[string]*schema.Schema{
+			"repository": {
+				Description: "The name of the GitHub repository.",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"environment": {
+				Description: "The name of the environment.",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+			"branch_pattern": {
+				Description:      "The name pattern that branches must match in order to deploy to the environment.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         false,
+				ExactlyOneOf:     []string{"branch_pattern", "tag_pattern"},
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
+			},
+			"tag_pattern": {
+				Description:      "The name pattern that tags must match in order to deploy to the environment.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         false,
+				ExactlyOneOf:     []string{"branch_pattern", "tag_pattern"},
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
+			},
+		},
+	}
+}
+
+func resourceGithubRepositoryEnvironmentDeploymentPolicyStateUpgradeV0(ctx context.Context, rawState map[string]any, m any) (map[string]any, error) {
+	meta := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
+
+	tflog.Debug(ctx, "Starting state upgrade for GitHub Repository Environment Deployment Policy.", map[string]any{"raw_state": rawState})
+
+	_, _, policyIDStr, err := parseID3(rawState["id"].(string))
+	if err != nil {
+		return nil, err
+	}
+
+	repoName, ok := rawState["repository"].(string)
+	if !ok {
+		return nil, fmt.Errorf("repository not found or is not a string")
+	}
+
+	repo, _, err := client.Repositories.Get(ctx, owner, repoName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve repository %s: %w", repoName, err)
+	}
+
+	policyID, err := strconv.Atoi(policyIDStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid policy ID: %s", policyIDStr)
+	}
+
+	rawState["repository_id"] = int(repo.GetID())
+	rawState["policy_id"] = policyID
+
+	tflog.Debug(ctx, "Completed state upgrade for GitHub Repository Environment Deployment Policy.", map[string]any{"upgraded_state": rawState})
+
+	return rawState, nil
+}

--- a/github/resource_github_repository_environment_deployment_policy_migration_test.go
+++ b/github/resource_github_repository_environment_deployment_policy_migration_test.go
@@ -1,0 +1,76 @@
+package github
+
+// TODO: Enable this test once we have a pattern to create a mock client for the test.
+
+// import (
+// 	"testing"
+
+// 	"github.com/google/go-cmp/cmp"
+// )
+
+// func Test_resourceGithubRepositoryEnvironmentDeploymentPolicyStateUpgradeV0(t *testing.T) {
+// 	t.Parallel()
+
+// 	for _, d := range []struct {
+// 		testName    string
+// 		rawState    map[string]any
+// 		want        map[string]any
+// 		shouldError bool
+// 	}{
+// 		{
+// 			testName: "valid",
+// 			rawState: map[string]any{
+// 				"id":             "my-repo:my-environment:123456",
+// 				"repository":     "my-repo",
+// 				"environment":    "my-environment",
+// 				"branch_pattern": "main-*",
+// 			},
+// 			want: map[string]any{
+// 				"id":             "my-repo:my-environment:123456",
+// 				"repository":     "my-repo",
+// 				"repository_id":  123456,
+// 				"environment":    "my-environment",
+// 				"branch_pattern": "main-*",
+// 				"policy_id":      123456,
+// 			},
+// 			shouldError: false,
+// 		},
+// 		{
+// 			testName: "invalid_resource_id",
+// 			rawState: map[string]any{
+// 				"id":             "my-repo:my-environment",
+// 				"repository":     "my-repo",
+// 				"environment":    "my-environment",
+// 				"branch_pattern": "main-*",
+// 			},
+// 			want:        nil,
+// 			shouldError: true,
+// 		},
+// 		{
+// 			testName: "invalid_policy_id",
+// 			rawState: map[string]any{
+// 				"id":             "my-repo:my-environment:abcdef",
+// 				"repository":     "my-repo",
+// 				"environment":    "my-environment",
+// 				"branch_pattern": "main-*",
+// 			},
+// 			want:        nil,
+// 			shouldError: true,
+// 		},
+// 	} {
+// 		t.Run(d.testName, func(t *testing.T) {
+// 			t.Parallel()
+
+// 			got, err := resourceGithubRepositoryEnvironmentDeploymentPolicyStateUpgradeV0(t.Context(), d.rawState, nil)
+// 			if (err != nil) != d.shouldError {
+// 				t.Fatalf("unexpected error state: %v", err)
+// 			}
+
+// 			if !d.shouldError {
+// 				if diff := cmp.Diff(d.want, got); diff != "" {
+// 					t.Errorf("resourceGithubRepositoryEnvironmentDeploymentPolicyStateUpgradeV0() mismatch (-want +got):\n%s", diff)
+// 				}
+// 			}
+// 		})
+// 	}
+// }

--- a/github/resource_github_repository_environment_deployment_policy_test.go
+++ b/github/resource_github_repository_environment_deployment_policy_test.go
@@ -5,630 +5,20 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestAccGithubRepositoryEnvironmentDeploymentPolicy(t *testing.T) {
-	t.Run("creates a repository environment with branch-based deployment policy", func(t *testing.T) {
+	t.Run("create_branch_policy", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
-		envName := "environment / test"
-		config := fmt.Sprintf(`
 
-			data "github_user" "current" {
-				username = ""
-			}
-
-			resource "github_repository" "test" {
-				name      = "%s"
-			}
-
-			resource "github_repository_environment" "test" {
-				repository 	= github_repository.test.name
-				environment	= "%s"
-				wait_timer	= 10000
-				reviewers {
-					users = [data.github_user.current.id]
-				}
-				deployment_branch_policy {
-					protected_branches     = false
-					custom_branch_policies = true
-				}
-			}
-
-			resource "github_repository_environment_deployment_policy" "test" {
-				repository 	   = github_repository.test.name
-				environment	   = github_repository_environment.test.environment
-				branch_pattern = "releases/*"
-			}
-
-		`, repoName, envName)
-
-		check := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "repository",
-				repoName,
-			),
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "environment",
-				"environment / test",
-			),
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "branch_pattern",
-				"releases/*",
-			),
-			resource.TestCheckNoResourceAttr(
-				"github_repository_environment_deployment_policy.test", "tag_pattern",
-			),
-		)
-
-		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnauthenticated(t) },
-			ProviderFactories: providerFactories,
-			Steps: []resource.TestStep{
-				{
-					Config: config,
-					Check:  check,
-				},
-			},
-		})
-	})
-
-	t.Run("updates the pattern for a branch-based deployment policy", func(t *testing.T) {
-		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%srepo-env-deploy-%s", testResourcePrefix, randomID)
-		var deploymentPolicyId string
-
-		config1 := fmt.Sprintf(`
-
-			data "github_user" "current" {
-				username = ""
-			}
-
-			resource "github_repository" "test" {
-				name      = "%s"
-			}
-
-			resource "github_repository_environment" "test" {
-				repository 	= github_repository.test.name
-				environment	= "environment/test"
-				wait_timer	= 10000
-				reviewers {
-					users = [data.github_user.current.id]
-				}
-				deployment_branch_policy {
-					protected_branches     = false
-					custom_branch_policies = true
-				}
-			}
-
-			resource "github_repository_environment_deployment_policy" "test" {
-				repository 	= github_repository.test.name
-				environment	= github_repository_environment.test.environment
-				branch_pattern = "main"
-			}
-
-		`, repoName)
-
-		check1 := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "repository",
-				repoName,
-			),
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "environment",
-				"environment/test",
-			),
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "branch_pattern",
-				"main",
-			),
-			resource.TestCheckNoResourceAttr(
-				"github_repository_environment_deployment_policy.test", "tag_pattern",
-			),
-			testDeploymentPolicyId("github_repository_environment_deployment_policy.test", &deploymentPolicyId),
-		)
-
-		config2 := fmt.Sprintf(`
-
-			data "github_user" "current" {
-				username = ""
-			}
-
-			resource "github_repository" "test" {
-				name      = "%s"
-			}
-
-			resource "github_repository_environment" "test" {
-				repository 	= github_repository.test.name
-				environment	= "environment/test"
-				wait_timer	= 10000
-				reviewers {
-					users = [data.github_user.current.id]
-				}
-				deployment_branch_policy {
-					protected_branches     = false
-					custom_branch_policies = true
-				}
-			}
-
-			resource "github_repository_environment_deployment_policy" "test" {
-				repository 	= github_repository.test.name
-				environment	= github_repository_environment.test.environment
-				branch_pattern = "release/*"
-			}
-
-		`, repoName)
-
-		check2 := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr("github_repository_environment_deployment_policy.test", "repository", repoName),
-			resource.TestCheckResourceAttr("github_repository_environment_deployment_policy.test", "environment", "environment/test"),
-			resource.TestCheckResourceAttr("github_repository_environment_deployment_policy.test", "branch_pattern", "release/*"),
-			resource.TestCheckNoResourceAttr("github_repository_environment_deployment_policy.test", "tag_pattern"),
-			testSameDeploymentPolicyId(
-				"github_repository_environment_deployment_policy.test",
-				&deploymentPolicyId,
-			),
-		)
-
-		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnauthenticated(t) },
-			ProviderFactories: providerFactories,
-			Steps: []resource.TestStep{
-				{
-					Config: config1,
-					Check:  check1,
-				},
-				{
-					Config: config2,
-					Check:  check2,
-				},
-			},
-		})
-	})
-
-	t.Run("creates a repository environment with tag-based deployment policy", func(t *testing.T) {
-		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%srepo-env-deploy-%s", testResourcePrefix, randomID)
-		config := fmt.Sprintf(`
-
-			data "github_user" "current" {
-				username = ""
-			}
-
-			resource "github_repository" "test" {
-				name      = "%s"
-			}
-
-			resource "github_repository_environment" "test" {
-				repository 	= github_repository.test.name
-				environment	= "environment/test"
-				wait_timer	= 10000
-				reviewers {
-					users = [data.github_user.current.id]
-				}
-				deployment_branch_policy {
-					protected_branches     = false
-					custom_branch_policies = true
-				}
-			}
-
-			resource "github_repository_environment_deployment_policy" "test" {
-				repository 	= github_repository.test.name
-				environment	= github_repository_environment.test.environment
-				tag_pattern = "v*"
-			}
-
-		`, repoName)
-
-		check := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "repository",
-				repoName,
-			),
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "environment",
-				"environment/test",
-			),
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "tag_pattern",
-				"v*",
-			),
-			resource.TestCheckNoResourceAttr(
-				"github_repository_environment_deployment_policy.test", "branch_pattern",
-			),
-		)
-
-		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnauthenticated(t) },
-			ProviderFactories: providerFactories,
-			Steps: []resource.TestStep{
-				{
-					Config: config,
-					Check:  check,
-				},
-			},
-		})
-	})
-
-	t.Run("updates the pattern for a tag-based deployment policy", func(t *testing.T) {
-		var deploymentPolicyId string
-		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%srepo-env-deploy-%s", testResourcePrefix, randomID)
-
-		config1 := fmt.Sprintf(`
-
-			data "github_user" "current" {
-				username = ""
-			}
-
-			resource "github_repository" "test" {
-				name      = "%s"
-			}
-
-			resource "github_repository_environment" "test" {
-				repository 	= github_repository.test.name
-				environment	= "environment/test"
-				wait_timer	= 10000
-				reviewers {
-					users = [data.github_user.current.id]
-				}
-				deployment_branch_policy {
-					protected_branches     = false
-					custom_branch_policies = true
-				}
-			}
-
-			resource "github_repository_environment_deployment_policy" "test" {
-				repository 	= github_repository.test.name
-				environment	= github_repository_environment.test.environment
-				tag_pattern = "v*"
-			}
-
-		`, repoName)
-
-		check1 := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "repository",
-				repoName,
-			),
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "environment",
-				"environment/test",
-			),
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "tag_pattern",
-				"v*",
-			),
-			resource.TestCheckNoResourceAttr(
-				"github_repository_environment_deployment_policy.test", "branch_pattern",
-			),
-			testDeploymentPolicyId("github_repository_environment_deployment_policy.test", &deploymentPolicyId),
-		)
-
-		config2 := fmt.Sprintf(`
-
-			data "github_user" "current" {
-				username = ""
-			}
-
-			resource "github_repository" "test" {
-				name      = "%s"
-			}
-
-			resource "github_repository_environment" "test" {
-				repository 	= github_repository.test.name
-				environment	= "environment/test"
-				wait_timer	= 10000
-				reviewers {
-					users = [data.github_user.current.id]
-				}
-				deployment_branch_policy {
-					protected_branches     = false
-					custom_branch_policies = true
-				}
-			}
-
-			resource "github_repository_environment_deployment_policy" "test" {
-				repository 	= github_repository.test.name
-				environment	= github_repository_environment.test.environment
-				tag_pattern = "version*"
-			}
-
-		`, repoName)
-
-		check2 := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "repository",
-				repoName,
-			),
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "environment",
-				"environment/test",
-			),
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "tag_pattern",
-				"version*",
-			),
-			resource.TestCheckNoResourceAttr(
-				"github_repository_environment_deployment_policy.test", "branch_pattern",
-			),
-			testSameDeploymentPolicyId(
-				"github_repository_environment_deployment_policy.test",
-				&deploymentPolicyId,
-			),
-		)
-
-		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnauthenticated(t) },
-			ProviderFactories: providerFactories,
-			Steps: []resource.TestStep{
-				{
-					Config: config1,
-					Check:  check1,
-				},
-				{
-					Config: config2,
-					Check:  check2,
-				},
-			},
-		})
-	})
-
-	t.Run("recreates deployment policy when pattern type changes from branch to tag", func(t *testing.T) {
-		var deploymentPolicyId string
-		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%srepo-env-deploy-%s", testResourcePrefix, randomID)
-
-		config1 := fmt.Sprintf(`
-
-			data "github_user" "current" {
-				username = ""
-			}
-
-			resource "github_repository" "test" {
-				name      = "%s"
-			}
-
-			resource "github_repository_environment" "test" {
-				repository 	= github_repository.test.name
-				environment	= "environment/test"
-				wait_timer	= 10000
-				reviewers {
-					users = [data.github_user.current.id]
-				}
-				deployment_branch_policy {
-					protected_branches     = false
-					custom_branch_policies = true
-				}
-			}
-
-			resource "github_repository_environment_deployment_policy" "test" {
-				repository 	= github_repository.test.name
-				environment	= github_repository_environment.test.environment
-				branch_pattern = "release/*"
-			}
-
-		`, repoName)
-
-		check1 := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "repository",
-				repoName,
-			),
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "environment",
-				"environment/test",
-			),
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "branch_pattern",
-				"release/*",
-			),
-			resource.TestCheckNoResourceAttr(
-				"github_repository_environment_deployment_policy.test", "tag_pattern",
-			),
-			testDeploymentPolicyId("github_repository_environment_deployment_policy.test", &deploymentPolicyId),
-		)
-
-		config2 := fmt.Sprintf(`
-
-			data "github_user" "current" {
-				username = ""
-			}
-
-			resource "github_repository" "test" {
-				name      = "%s"
-			}
-
-			resource "github_repository_environment" "test" {
-				repository 	= github_repository.test.name
-				environment	= "environment/test"
-				wait_timer	= 10000
-				reviewers {
-					users = [data.github_user.current.id]
-				}
-				deployment_branch_policy {
-					protected_branches     = false
-					custom_branch_policies = true
-				}
-			}
-
-			resource "github_repository_environment_deployment_policy" "test" {
-				repository 	= github_repository.test.name
-				environment	= github_repository_environment.test.environment
-				tag_pattern = "v*"
-			}
-
-		`, repoName)
-
-		check2 := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "repository",
-				repoName,
-			),
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "environment",
-				"environment/test",
-			),
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "tag_pattern",
-				"v*",
-			),
-			resource.TestCheckNoResourceAttr(
-				"github_repository_environment_deployment_policy.test", "branch_pattern",
-			),
-			testNewDeploymentPolicyId(
-				"github_repository_environment_deployment_policy.test",
-				&deploymentPolicyId,
-			),
-		)
-
-		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnauthenticated(t) },
-			ProviderFactories: providerFactories,
-			Steps: []resource.TestStep{
-				{
-					Config: config1,
-					Check:  check1,
-				},
-				{
-					Config: config2,
-					Check:  check2,
-				},
-			},
-		})
-	})
-
-	t.Run("recreates deployment policy when pattern type changes from tag to branch", func(t *testing.T) {
-		var deploymentPolicyId string
-		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%srepo-env-deploy-%s", testResourcePrefix, randomID)
-
-		config1 := fmt.Sprintf(`
-
-			data "github_user" "current" {
-				username = ""
-			}
-
-			resource "github_repository" "test" {
-				name      = "%s"
-			}
-
-			resource "github_repository_environment" "test" {
-				repository 	= github_repository.test.name
-				environment	= "environment/test"
-				wait_timer	= 10000
-				reviewers {
-					users = [data.github_user.current.id]
-				}
-				deployment_branch_policy {
-					protected_branches     = false
-					custom_branch_policies = true
-				}
-			}
-
-			resource "github_repository_environment_deployment_policy" "test" {
-				repository 	= github_repository.test.name
-				environment	= github_repository_environment.test.environment
-				tag_pattern = "v*"
-			}
-
-		`, repoName)
-
-		check1 := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "repository",
-				repoName,
-			),
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "environment",
-				"environment/test",
-			),
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "tag_pattern",
-				"v*",
-			),
-			resource.TestCheckNoResourceAttr(
-				"github_repository_environment_deployment_policy.test", "branch_pattern",
-			),
-			testDeploymentPolicyId("github_repository_environment_deployment_policy.test", &deploymentPolicyId),
-		)
-
-		config2 := fmt.Sprintf(`
-
-			data "github_user" "current" {
-				username = ""
-			}
-
-			resource "github_repository" "test" {
-				name      = "%s"
-			}
-
-			resource "github_repository_environment" "test" {
-				repository 	= github_repository.test.name
-				environment	= "environment/test"
-				wait_timer	= 10000
-				reviewers {
-					users = [data.github_user.current.id]
-				}
-				deployment_branch_policy {
-					protected_branches     = false
-					custom_branch_policies = true
-				}
-			}
-
-			resource "github_repository_environment_deployment_policy" "test" {
-				repository 	= github_repository.test.name
-				environment	= github_repository_environment.test.environment
-				branch_pattern = "release/*"
-			}
-
-		`, repoName)
-
-		check2 := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "repository",
-				repoName,
-			),
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "environment",
-				"environment/test",
-			),
-			resource.TestCheckResourceAttr(
-				"github_repository_environment_deployment_policy.test", "branch_pattern",
-				"release/*",
-			),
-			resource.TestCheckNoResourceAttr(
-				"github_repository_environment_deployment_policy.test", "tag_pattern",
-			),
-			testNewDeploymentPolicyId(
-				"github_repository_environment_deployment_policy.test",
-				&deploymentPolicyId,
-			),
-		)
-
-		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnauthenticated(t) },
-			ProviderFactories: providerFactories,
-			Steps: []resource.TestStep{
-				{
-					Config: config1,
-					Check:  check1,
-				},
-				{
-					Config: config2,
-					Check:  check2,
-				},
-			},
-		})
-	})
-
-	t.Run("import", func(t *testing.T) {
-		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
-		envName := "environment / test"
 		config := fmt.Sprintf(`
 data "github_user" "current" {
 	username = ""
@@ -640,7 +30,367 @@ resource "github_repository" "test" {
 
 resource "github_repository_environment" "test" {
 	repository  = github_repository.test.name
-	environment = "%s"
+	environment = "test"
+	wait_timer = 10000
+	reviewers {
+		users = [data.github_user.current.id]
+	}
+	deployment_branch_policy {
+		protected_branches     = false
+		custom_branch_policies = true
+	}
+}
+
+resource "github_repository_environment_deployment_policy" "test" {
+	repository 	   = github_repository.test.name
+	environment	   = github_repository_environment.test.environment
+	branch_pattern = "releases/*"
+}
+`, repoName)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_environment_deployment_policy.test", tfjsonpath.New("repository_id"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("github_repository_environment_deployment_policy.test", tfjsonpath.New("policy_id"), knownvalue.NotNull()),
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("create_update_branch_policy", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+
+		config := `
+data "github_user" "current" {
+	username = ""
+}
+
+resource "github_repository" "test" {
+	name = "%s"
+}
+
+resource "github_repository_environment" "test" {
+	repository  = github_repository.test.name
+	environment = "test"
+	wait_timer  = 10000
+	reviewers {
+		users = [data.github_user.current.id]
+	}
+	deployment_branch_policy {
+		protected_branches     = false
+		custom_branch_policies = true
+	}
+}
+
+resource "github_repository_environment_deployment_policy" "test" {
+	repository     = github_repository.test.name
+	environment    = github_repository_environment.test.environment
+	branch_pattern = "%s"
+}
+`
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(config, repoName, "main"),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_environment_deployment_policy.test", tfjsonpath.New("repository_id"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("github_repository_environment_deployment_policy.test", tfjsonpath.New("policy_id"), knownvalue.NotNull()),
+					},
+				},
+				{
+					Config: fmt.Sprintf(config, repoName, "release/*"),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("github_repository_environment_deployment_policy.test", plancheck.ResourceActionUpdate),
+						},
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("create_tag_policy", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+
+		config := fmt.Sprintf(`
+data "github_user" "current" {
+	username = ""
+}
+
+resource "github_repository" "test" {
+	name = "%s"
+}
+
+resource "github_repository_environment" "test" {
+	repository  = github_repository.test.name
+	environment = "test"
+	wait_timer  = 10000
+	reviewers {
+		users = [data.github_user.current.id]
+	}
+	deployment_branch_policy {
+		protected_branches     = false
+		custom_branch_policies = true
+	}
+}
+
+resource "github_repository_environment_deployment_policy" "test" {
+	repository  = github_repository.test.name
+	environment = github_repository_environment.test.environment
+	tag_pattern = "v*"
+}
+`, repoName)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_environment_deployment_policy.test", tfjsonpath.New("repository_id"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("github_repository_environment_deployment_policy.test", tfjsonpath.New("policy_id"), knownvalue.NotNull()),
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("create_update_tag_policy", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+
+		config := `
+data "github_user" "current" {
+	username = ""
+}
+
+resource "github_repository" "test" {
+	name = "%s"
+}
+
+resource "github_repository_environment" "test" {
+	repository 	= github_repository.test.name
+	environment = "environment/test"
+	wait_timer  = 10000
+	reviewers {
+		users = [data.github_user.current.id]
+	}
+	deployment_branch_policy {
+		protected_branches     = false
+		custom_branch_policies = true
+	}
+}
+
+resource "github_repository_environment_deployment_policy" "test" {
+	repository  = github_repository.test.name
+	environment = github_repository_environment.test.environment
+	tag_pattern = "%s"
+}
+`
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(config, repoName, "v*"),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_environment_deployment_policy.test", tfjsonpath.New("repository_id"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("github_repository_environment_deployment_policy.test", tfjsonpath.New("policy_id"), knownvalue.NotNull()),
+					},
+				},
+				{
+					Config: fmt.Sprintf(config, repoName, "version*"),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("github_repository_environment_deployment_policy.test", plancheck.ResourceActionUpdate),
+						},
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("recreates_when_pattern_type_changes_from_branch_to_tag", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+
+		preConfig := fmt.Sprintf(`
+data "github_user" "current" {
+	username = ""
+}
+
+resource "github_repository" "test" {
+	name = "%s"
+}
+
+resource "github_repository_environment" "test" {
+	repository  = github_repository.test.name
+	environment = "test"
+	wait_timer  = 10000
+	reviewers {
+		users = [data.github_user.current.id]
+	}
+	deployment_branch_policy {
+		protected_branches     = false
+		custom_branch_policies = true
+	}
+}
+`, repoName)
+
+		config1 := fmt.Sprintf(`
+%s
+
+resource "github_repository_environment_deployment_policy" "test" {
+	repository     = github_repository.test.name
+	environment    = github_repository_environment.test.environment
+	branch_pattern = "release/*"
+}
+
+`, preConfig)
+
+		config2 := fmt.Sprintf(`
+%s
+
+resource "github_repository_environment_deployment_policy" "test" {
+	repository  = github_repository.test.name
+	environment = github_repository_environment.test.environment
+	tag_pattern = "v*"
+}
+`, preConfig)
+
+		comparePolicyIDChanages := statecheck.CompareValue(compare.ValuesDiffer())
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config1,
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_environment_deployment_policy.test", tfjsonpath.New("repository_id"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("github_repository_environment_deployment_policy.test", tfjsonpath.New("policy_id"), knownvalue.NotNull()),
+						comparePolicyIDChanages.AddStateValue("github_repository_environment_deployment_policy.test", tfjsonpath.New("policy_id")),
+					},
+				},
+				{
+					Config: config2,
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("github_repository_environment_deployment_policy.test", plancheck.ResourceActionReplace),
+						},
+					},
+					ConfigStateChecks: []statecheck.StateCheck{
+						comparePolicyIDChanages.AddStateValue("github_repository_environment_deployment_policy.test", tfjsonpath.New("policy_id")),
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("recreates_when_pattern_type_changes_from_tag_to_branch", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+
+		preConfig := fmt.Sprintf(`
+data "github_user" "current" {
+	username = ""
+}
+
+resource "github_repository" "test" {
+	name = "%s"
+}
+
+resource "github_repository_environment" "test" {
+	repository  = github_repository.test.name
+	environment = "test"
+	wait_timer  = 10000
+	reviewers {
+		users = [data.github_user.current.id]
+	}
+	deployment_branch_policy {
+		protected_branches     = false
+		custom_branch_policies = true
+	}
+}
+`, repoName)
+
+		config1 := fmt.Sprintf(`
+%s
+
+resource "github_repository_environment_deployment_policy" "test" {
+	repository  = github_repository.test.name
+	environment = github_repository_environment.test.environment
+	tag_pattern = "v*"
+}
+`, preConfig)
+
+		config2 := fmt.Sprintf(`
+%s
+
+resource "github_repository_environment_deployment_policy" "test" {
+	repository     = github_repository.test.name
+	environment    = github_repository_environment.test.environment
+	branch_pattern = "release/*"
+}
+
+`, preConfig)
+
+		comparePolicyIDChanages := statecheck.CompareValue(compare.ValuesDiffer())
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config1,
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_environment_deployment_policy.test", tfjsonpath.New("repository_id"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("github_repository_environment_deployment_policy.test", tfjsonpath.New("policy_id"), knownvalue.NotNull()),
+						comparePolicyIDChanages.AddStateValue("github_repository_environment_deployment_policy.test", tfjsonpath.New("policy_id")),
+					},
+				},
+				{
+					Config: config2,
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("github_repository_environment_deployment_policy.test", plancheck.ResourceActionReplace),
+						},
+					},
+					ConfigStateChecks: []statecheck.StateCheck{
+						comparePolicyIDChanages.AddStateValue("github_repository_environment_deployment_policy.test", tfjsonpath.New("policy_id")),
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("import", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+
+		config := fmt.Sprintf(`
+data "github_user" "current" {
+	username = ""
+}
+
+resource "github_repository" "test" {
+	name = "%s"
+}
+
+resource "github_repository_environment" "test" {
+	repository  = github_repository.test.name
+	environment = "test"
 	wait_timer  = 10000
 	reviewers {
 		users = [data.github_user.current.id]
@@ -656,7 +406,7 @@ resource "github_repository_environment_deployment_policy" "test" {
 	environment    = github_repository_environment.test.environment
 	branch_pattern = "main"
 }
-`, repoName, envName)
+`, repoName)
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnauthenticated(t) },
@@ -664,7 +414,10 @@ resource "github_repository_environment_deployment_policy" "test" {
 			Steps: []resource.TestStep{
 				{
 					Config: config,
-					Check:  resource.TestCheckResourceAttr("github_repository_environment_deployment_policy.test", "environment", envName),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_environment_deployment_policy.test", tfjsonpath.New("repository_id"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("github_repository_environment_deployment_policy.test", tfjsonpath.New("policy_id"), knownvalue.NotNull()),
+					},
 				},
 				{
 					ResourceName:      "github_repository_environment_deployment_policy.test",
@@ -677,26 +430,27 @@ resource "github_repository_environment_deployment_policy" "test" {
 
 	t.Run("errors when no patterns are set", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%srepo-env-deploy-%s", testResourcePrefix, randomID)
+		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+
 		config := fmt.Sprintf(`
-			resource "github_repository" "test" {
-				name      = "%s"
-			}
+resource "github_repository" "test" {
+	name = "%s"
+}
 
-			resource "github_repository_environment" "test" {
-				repository 	= github_repository.test.name
-				environment	= "environment/test"
-				deployment_branch_policy {
-					protected_branches     = false
-					custom_branch_policies = true
-				}
-			}
+resource "github_repository_environment" "test" {
+	repository  = github_repository.test.name
+	environment = "environment/test"
+	deployment_branch_policy {
+		protected_branches     = false
+		custom_branch_policies = true
+	}
+}
 
-			resource "github_repository_environment_deployment_policy" "test" {
-				repository 	= github_repository.test.name
-				environment	= github_repository_environment.test.environment
-			}
-		`, repoName)
+resource "github_repository_environment_deployment_policy" "test" {
+	repository  = github_repository.test.name
+	environment = github_repository_environment.test.environment
+}
+`, repoName)
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnauthenticated(t) },
@@ -712,28 +466,29 @@ resource "github_repository_environment_deployment_policy" "test" {
 
 	t.Run("errors when both patterns are set", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%srepo-env-deploy-%s", testResourcePrefix, randomID)
+		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+
 		config := fmt.Sprintf(`
-			resource "github_repository" "test" {
-				name      = "%s"
-			}
+resource "github_repository" "test" {
+	name = "%s"
+}
 
-			resource "github_repository_environment" "test" {
-				repository 	= github_repository.test.name
-				environment	= "environment/test"
-				deployment_branch_policy {
-					protected_branches     = false
-					custom_branch_policies = true
-				}
-			}
+resource "github_repository_environment" "test" {
+	repository  = github_repository.test.name
+	environment = "environment/test"
+	deployment_branch_policy {
+		protected_branches     = false
+		custom_branch_policies = true
+	}
+}
 
-			resource "github_repository_environment_deployment_policy" "test" {
-				repository     = github_repository.test.name
-				environment    = github_repository_environment.test.environment
-				branch_pattern = "main"
-				tag_pattern    = "v*"
-			}
-		`, repoName)
+resource "github_repository_environment_deployment_policy" "test" {
+	repository     = github_repository.test.name
+	environment    = github_repository_environment.test.environment
+	branch_pattern = "main"
+	tag_pattern    = "v*"
+}
+`, repoName)
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnauthenticated(t) },
@@ -749,27 +504,28 @@ resource "github_repository_environment_deployment_policy" "test" {
 
 	t.Run("errors when an empty branch pattern is set", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%srepo-env-deploy-%s", testResourcePrefix, randomID)
+		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+
 		config := fmt.Sprintf(`
-			resource "github_repository" "test" {
-				name      = "%s"
-			}
+resource "github_repository" "test" {
+	name = "%s"
+}
 
-			resource "github_repository_environment" "test" {
-				repository 	= github_repository.test.name
-				environment	= "environment/test"
-				deployment_branch_policy {
-					protected_branches     = false
-					custom_branch_policies = true
-				}
-			}
+resource "github_repository_environment" "test" {
+	repository 	= github_repository.test.name
+	environment	= "environment/test"
+	deployment_branch_policy {
+		protected_branches     = false
+		custom_branch_policies = true
+	}
+}
 
-			resource "github_repository_environment_deployment_policy" "test" {
-				repository     = github_repository.test.name
-				environment    = github_repository_environment.test.environment
-				branch_pattern = ""
-			}
-		`, repoName)
+resource "github_repository_environment_deployment_policy" "test" {
+	repository     = github_repository.test.name
+	environment    = github_repository_environment.test.environment
+	branch_pattern = ""
+}
+`, repoName)
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnauthenticated(t) },
@@ -777,7 +533,7 @@ resource "github_repository_environment_deployment_policy" "test" {
 			Steps: []resource.TestStep{
 				{
 					Config:      config,
-					ExpectError: regexp.MustCompile("`branch_pattern` must be a valid non-empty string"),
+					ExpectError: regexp.MustCompile(`expected "branch_pattern" to not be an empty string`),
 				},
 			},
 		})
@@ -785,27 +541,28 @@ resource "github_repository_environment_deployment_policy" "test" {
 
 	t.Run("errors when an empty tag pattern is set", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%srepo-env-deploy-%s", testResourcePrefix, randomID)
+		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+
 		config := fmt.Sprintf(`
-			resource "github_repository" "test" {
-				name      = "%s"
-			}
+resource "github_repository" "test" {
+	name = "%s"
+}
 
-			resource "github_repository_environment" "test" {
-				repository 	= github_repository.test.name
-				environment	= "environment/test"
-				deployment_branch_policy {
-					protected_branches     = false
-					custom_branch_policies = true
-				}
-			}
+resource "github_repository_environment" "test" {
+	repository  = github_repository.test.name
+	environment = "environment/test"
+	deployment_branch_policy {
+		protected_branches     = false
+		custom_branch_policies = true
+	}
+}
 
-			resource "github_repository_environment_deployment_policy" "test" {
-				repository     = github_repository.test.name
-				environment    = github_repository_environment.test.environment
-				tag_pattern = ""
-			}
-		`, repoName)
+resource "github_repository_environment_deployment_policy" "test" {
+	repository     = github_repository.test.name
+	environment    = github_repository_environment.test.environment
+	tag_pattern    = ""
+}
+`, repoName)
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnauthenticated(t) },
@@ -813,64 +570,9 @@ resource "github_repository_environment_deployment_policy" "test" {
 			Steps: []resource.TestStep{
 				{
 					Config:      config,
-					ExpectError: regexp.MustCompile("`tag_pattern` must be a valid non-empty string"),
+					ExpectError: regexp.MustCompile(`expected "tag_pattern" to not be an empty string`),
 				},
 			},
 		})
 	})
-}
-
-func testDeploymentPolicyId(resourceName string, id *string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("Resource ID is not set")
-		}
-
-		*id = rs.Primary.ID
-
-		return nil
-	}
-}
-
-func testSameDeploymentPolicyId(resourceName string, id *string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("Resource ID is not set")
-		}
-
-		if rs.Primary.ID != *id {
-			return fmt.Errorf("New resource does not match old resource id: %s, %s", rs.Primary.ID, *id)
-		}
-
-		return nil
-	}
-}
-
-func testNewDeploymentPolicyId(resourceName string, id *string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("Resource ID is not set")
-		}
-
-		if rs.Primary.ID == *id {
-			return fmt.Errorf("New resource matches old resource id: %s", rs.Primary.ID)
-		}
-
-		return nil
-	}
 }

--- a/github/resource_github_repository_environment_migration.go
+++ b/github/resource_github_repository_environment_migration.go
@@ -1,0 +1,115 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceGithubRepositoryEnvironmentV0() *schema.Resource {
+	return &schema.Resource{
+		SchemaVersion: 0,
+		Schema: map[string]*schema.Schema{
+			"repository": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The repository of the environment.",
+			},
+			"environment": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the environment.",
+			},
+			"can_admins_bypass": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Can Admins bypass deployment protections",
+			},
+			"prevent_self_review": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Prevent users from approving workflows runs that they triggered.",
+			},
+			"wait_timer": {
+				Type:             schema.TypeInt,
+				Optional:         true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.IntBetween(0, 43200)),
+				Description:      "Amount of time to delay a job after the job is initially triggered.",
+			},
+			"reviewers": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "The environment reviewers configuration.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"teams": {
+							Type:        schema.TypeSet,
+							Elem:        &schema.Schema{Type: schema.TypeInt},
+							Optional:    true,
+							MaxItems:    6,
+							Description: "Up to 6 IDs for teams who may review jobs that reference the environment. Reviewers must have at least read access to the repository. Only one of the required reviewers needs to approve the job for it to proceed.",
+						},
+						"users": {
+							Type:        schema.TypeSet,
+							Elem:        &schema.Schema{Type: schema.TypeInt},
+							Optional:    true,
+							MaxItems:    6,
+							Description: "Up to 6 IDs for users who may review jobs that reference the environment. Reviewers must have at least read access to the repository. Only one of the required reviewers needs to approve the job for it to proceed.",
+						},
+					},
+				},
+			},
+			"deployment_branch_policy": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "The deployment branch policy configuration",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"protected_branches": {
+							Type:        schema.TypeBool,
+							Required:    true,
+							Description: "Whether only branches with branch protection rules can deploy to this environment.",
+						},
+						"custom_branch_policies": {
+							Type:        schema.TypeBool,
+							Required:    true,
+							Description: "Whether only branches that match the specified name patterns can deploy to this environment.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceGithubRepositoryEnvironmentStateUpgradeV0(ctx context.Context, rawState map[string]any, m any) (map[string]any, error) {
+	meta := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
+
+	tflog.Debug(ctx, "Starting state upgrade for GitHub Repository Environment.", map[string]any{"raw_state": rawState})
+
+	repoName, ok := rawState["repository"].(string)
+	if !ok {
+		return nil, fmt.Errorf("repository not found or is not a string")
+	}
+
+	repo, _, err := client.Repositories.Get(ctx, owner, repoName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve repository %s: %w", repoName, err)
+	}
+
+	rawState["repository_id"] = int(repo.GetID())
+
+	tflog.Debug(ctx, "Completed state upgrade for GitHub Repository Environment.", map[string]any{"upgraded_state": rawState})
+
+	return rawState, nil
+}

--- a/github/resource_github_repository_environment_migration_test.go
+++ b/github/resource_github_repository_environment_migration_test.go
@@ -1,0 +1,61 @@
+package github
+
+// TODO: Enable this test once we have a pattern to create a mock client for the test.
+
+// import (
+// 	"testing"
+
+// 	"github.com/google/go-cmp/cmp"
+// )
+
+// func Test_resourceGithubRepositoryEnvironmenStateUpgradeV0(t *testing.T) {
+// 	t.Parallel()
+
+// 	for _, d := range []struct {
+// 		testName    string
+// 		rawState    map[string]any
+// 		want        map[string]any
+// 		shouldError bool
+// 	}{
+// 		{
+// 			testName: "valid",
+// 			rawState: map[string]any{
+// 				"id":             "my-repo:my-environment:123456",
+// 				"repository":     "my-repo",
+// 				"environment":    "my-environment",
+// 			},
+// 			want: map[string]any{
+// 				"id":             "my-repo:my-environment:123456",
+// 				"repository":     "my-repo",
+// 				"repository_id":  123456,
+// 				"environment":    "my-environment",
+// 			},
+// 			shouldError: false,
+// 		},
+// 		{
+// 			testName: "invalid_resource_id",
+// 			rawState: map[string]any{
+// 				"id":             "my-repo",
+// 				"repository":     "my-repo",
+// 				"environment":    "my-environment",
+// 			},
+// 			want:        nil,
+// 			shouldError: true,
+// 		},
+// 	} {
+// 		t.Run(d.testName, func(t *testing.T) {
+// 			t.Parallel()
+
+// 			got, err := resourceGithubRepositoryEnvironmentStateUpgradeV0(t.Context(), d.rawState, nil)
+// 			if (err != nil) != d.shouldError {
+// 				t.Fatalf("unexpected error state: %v", err)
+// 			}
+
+// 			if !d.shouldError {
+// 				if diff := cmp.Diff(d.want, got); diff != "" {
+// 					t.Errorf("resourceGithubRepositoryEnvironmentStateUpgradeV0() mismatch (-want +got):\n%s", diff)
+// 				}
+// 			}
+// 		})
+// 	}
+// }

--- a/github/resource_github_repository_environment_test.go
+++ b/github/resource_github_repository_environment_test.go
@@ -2,112 +2,164 @@ package github
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestAccGithubRepositoryEnvironment(t *testing.T) {
-	t.Run("creates a repository environment", func(t *testing.T) {
+	t.Run("create", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
-		envName := "environment / test"
+		envName := "test"
+
 		config := fmt.Sprintf(`
+resource "github_team" "test" {
+	name        = "%[1]s"
+	description = "test"
+	privacy     = "closed"
+}
 
-			data "github_user" "current" {
-				username = ""
-			}
+resource "github_repository" "test" {
+	name       = "%[1]s"
+	visibility = "public"
+}
 
-			resource "github_repository" "test" {
-				name      = "%s"
-				visibility = "public"
-			}
+resource "github_team_repository" "test" {
+	team_id    = github_team.test.id
+	repository = github_repository.test.name
+	permission = "pull"
+}
 
-			resource "github_repository_environment" "test" {
-				repository  = github_repository.test.name
-				environment = "%s"
+resource "github_repository_environment" "test" {
+	repository  = github_repository.test.name
+	environment = "%s"
 
-				can_admins_bypass   = false
-				wait_timer          = 10000
-				prevent_self_review = true
+	can_admins_bypass   = false
+	wait_timer          = 10000
+	prevent_self_review = true
 
-				reviewers {
-					users = [data.github_user.current.id]
-				}
+	reviewers {
+		teams = [github_team_repository.test.team_id]
+	}
 
-				deployment_branch_policy {
-					protected_branches     = true
-					custom_branch_policies = false
-				}
-			}
-
-		`, repoName, envName)
+	deployment_branch_policy {
+		protected_branches     = true
+		custom_branch_policies = false
+	}
+}
+`, repoName, envName)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnauthenticated(t) },
+			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
 					Config: config,
-					Check: resource.ComposeAggregateTestCheckFunc(
-						resource.TestCheckResourceAttr("github_repository_environment.test", "environment", envName),
-						resource.TestCheckResourceAttr("github_repository_environment.test", "can_admins_bypass", "false"),
-						resource.TestCheckResourceAttr("github_repository_environment.test", "prevent_self_review", "true"),
-						resource.TestCheckResourceAttr("github_repository_environment.test", "wait_timer", "10000"),
-					),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_environment.test", tfjsonpath.New("repository_id"), knownvalue.NotNull()),
+					},
 				},
 			},
 		})
 	})
 
-	t.Run("creates a repository environment with id separator", func(t *testing.T) {
+	t.Run("create_with_id_separator_in_name", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
-		envName := "environment:test"
+
 		config := fmt.Sprintf(`
+resource "github_repository" "test" {
+	name       = "%s"
+	visibility = "public"
+}
 
-			data "github_user" "current" {
-				username = ""
-			}
-
-			resource "github_repository" "test" {
-				name      = "%s"
-				visibility = "public"
-			}
-
-			resource "github_repository_environment" "test" {
-				repository  = github_repository.test.name
-				environment = "%s"
-
-				can_admins_bypass   = false
-				wait_timer          = 10000
-				prevent_self_review = true
-
-				reviewers {
-					users = [data.github_user.current.id]
-				}
-
-				deployment_branch_policy {
-					protected_branches     = true
-					custom_branch_policies = false
-				}
-			}
-
-		`, repoName, envName)
+resource "github_repository_environment" "test" {
+	repository  = github_repository.test.name
+	environment = "environment:test"
+}
+`, repoName)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnauthenticated(t) },
+			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
 					Config: config,
-					Check: resource.ComposeAggregateTestCheckFunc(
-						resource.TestCheckResourceAttr("github_repository_environment.test", "environment", envName),
-						resource.TestCheckResourceAttr("github_repository_environment.test", "can_admins_bypass", "false"),
-						resource.TestCheckResourceAttr("github_repository_environment.test", "prevent_self_review", "true"),
-						resource.TestCheckResourceAttr("github_repository_environment.test", "wait_timer", "10000"),
-					),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_environment.test", tfjsonpath.New("repository_id"), knownvalue.NotNull()),
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("update_to_remove_reviewers", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+		envName := "test"
+
+		preConfig := fmt.Sprintf(`
+resource "github_team" "test" {
+	name        = "%[1]s"
+	description = "test"
+	privacy     = "closed"
+}
+
+resource "github_repository" "test" {
+	name      = "%[1]s"
+	visibility = "public"
+}
+
+resource "github_team_repository" "test" {
+	team_id    = github_team.test.id
+	repository = github_repository.test.name
+	permission = "pull"
+}
+`, repoName)
+
+		config := fmt.Sprintf(`
+%s
+
+resource "github_repository_environment" "test" {
+	repository  = github_repository.test.name
+	environment = "%s"
+
+	reviewers {
+		teams = [github_team_repository.test.team_id]
+	}
+}
+`, preConfig, envName)
+
+		configUpdated := fmt.Sprintf(`
+%s
+
+resource "github_repository_environment" "test" {
+	repository  = github_repository.test.name
+	environment = "%s"
+}
+`, preConfig, envName)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessHasOrgs(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_environment.test", tfjsonpath.New("repository_id"), knownvalue.NotNull()),
+					},
+				},
+				{
+					Config: configUpdated,
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_environment.test", tfjsonpath.New("reviewers"), knownvalue.ListSizeExact(0)),
+					},
 				},
 			},
 		})
@@ -116,18 +168,18 @@ func TestAccGithubRepositoryEnvironment(t *testing.T) {
 	t.Run("import", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
-		envName := "environment / test"
-		config := fmt.Sprintf(`
-			resource "github_repository" "test" {
-				name      = "%s"
-				visibility = "public"
-			}
 
-			resource "github_repository_environment" "test" {
-				repository 	= github_repository.test.name
-				environment	= "%s"
-			}
-		`, repoName, envName)
+		config := fmt.Sprintf(`
+resource "github_repository" "test" {
+	name       = "%s"
+	visibility = "public"
+}
+
+resource "github_repository_environment" "test" {
+	repository 	= github_repository.test.name
+	environment	= "test"
+}
+`, repoName)
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnauthenticated(t) },
@@ -135,12 +187,82 @@ func TestAccGithubRepositoryEnvironment(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: config,
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_environment.test", tfjsonpath.New("repository_id"), knownvalue.NotNull()),
+					},
 				},
 				{
 					ResourceName:            "github_repository_environment.test",
 					ImportState:             true,
 					ImportStateVerify:       true,
 					ImportStateVerifyIgnore: []string{"can_admins_bypass", "prevent_self_review", "reviewers", "wait_timer", "deployment_branch_policy"},
+				},
+			},
+		})
+	})
+
+	t.Run("errors_with_more_than_six_reviewers", func(t *testing.T) {
+		if len(testAccConf.testOrgUser) == 0 {
+			t.Skip("skipping test that requires GH_TEST_ORG_USER env var to be set")
+		}
+
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+
+		config := fmt.Sprintf(`
+locals {
+	team_count = 6
+}
+
+data "github_user" "org" {
+	username = "%s"
+}
+
+resource "github_team" "test" {
+	count = local.team_count
+
+	name        = "%[1]s-${count.index}"
+	description = "test"
+	privacy     = "closed"
+}
+
+resource "github_repository" "test" {
+	name      = "%[1]s"
+	visibility = "public"
+}
+
+resource "github_team_repository" "test" {
+	count = local.team_count
+
+	team_id    = github_team.test[count.index].id
+	repository = github_repository.test.name
+	permission = "pull"
+}
+
+resource "github_repository_collaborator" "test_repo_collaborator" {
+	repository = github_repository.test.name
+	username   = data.github_user.org.login
+	permission = "push"
+}
+
+resource "github_repository_environment" "test" {
+	repository  = github_repository.test.name
+	environment = "test"
+
+	reviewers {
+		teams = github_team_repository.test[*].team_id
+		users = [data.github_user.org.id]
+	}
+}
+`, testAccConf.testOrgUser, repoName)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessHasOrgs(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:      config,
+					ExpectError: regexp.MustCompile(`reviewers can have at most 6 reviewers`),
 				},
 			},
 		})

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -716,7 +716,7 @@ resource "github_repository" "test" {
 				{
 					Config: config,
 					Check: resource.ComposeTestCheckFunc(
-						resource.TestCheckNoResourceAttr("github_repository.test", "vulnerability_alerts"),
+						resource.TestCheckNoResourceAttr("github_repository.test", "vulnerability_alerts"), // This will error if it's run as an unprivileged user but that shouldn't ever happen
 					),
 				},
 			},

--- a/website/docs/r/repository_environment.html.markdown
+++ b/website/docs/r/repository_environment.html.markdown
@@ -39,35 +39,54 @@ resource "github_repository_environment" "example" {
 
 The following arguments are supported:
 
-* `environment` - (Required) The name of the environment.
+- `environment` - (Required) The name of the environment.
 
-* `repository` - (Required) The repository of the environment.
+- `repository` - (Required) The repository of the environment.
 
-* `wait_timer` - (Optional) Amount of time to delay a job after the job is initially triggered.
+- `wait_timer` - (Optional) Amount of time to delay a job after the job is initially triggered.
 
-* `can_admins_bypass` - (Optional) Can repository admins bypass the environment protections. Defaults to `true`.
+- `can_admins_bypass` - (Optional) Can repository admins bypass the environment protections. Defaults to `true`.
 
-* `prevent_self_review` - (Optional) Whether or not a user who created the job is prevented from approving their own job. Defaults to `false`.
+- `prevent_self_review` - (Optional) Whether or not a user who created the job is prevented from approving their own job. Defaults to `false`.
 
 ### Reviewers
 
 The `reviewers` block supports the following:
 
-* `teams` - (Optional) Up to 6 IDs for teams who may review jobs that reference the environment. Reviewers must have at least read access to the repository. Only one of the required reviewers needs to approve the job for it to proceed.
+- `teams` - (Optional) Up to 6 IDs for teams who may review jobs that reference the environment. Reviewers must have at least read access to the repository. Only one of the required reviewers needs to approve the job for it to proceed.
 
-* `users` - (Optional) Up to 6 IDs for users who may review jobs that reference the environment. Reviewers must have at least read access to the repository. Only one of the required reviewers needs to approve the job for it to proceed.
+- `users` - (Optional) Up to 6 IDs for users who may review jobs that reference the environment. Reviewers must have at least read access to the repository. Only one of the required reviewers needs to approve the job for it to proceed.
 
 #### Deployment Branch Policy
 
 The `deployment_branch_policy` block supports the following:
 
-* `protected_branches` - (Required) Whether only branches with branch protection rules can deploy to this environment.
+- `protected_branches` - (Required) Whether only branches with branch protection rules can deploy to this environment.
 
-* `custom_branch_policies` - (Required) Whether only branches that match the specified name patterns can deploy to this environment.
+- `custom_branch_policies` - (Required) Whether only branches that match the specified name patterns can deploy to this environment.
+
+## Attributes Reference
+
+- `repository_id` - The ID of the repository.
 
 ## Import
 
-This resource can be imported using an ID made of the repository name, and environment name (any `:` in the name need to be escaped as `??`) separated by a `:`.
+This resource can be imported using an ID made of the repository name and environment name (any `:` in the environment name need to be escaped as `??`) separated by a `:`.
+
+### Import Block
+
+The following import block imports an environment called `myenv` for the repo `myrepo` to a `github_repository_environment` resource named `example`.
+
+```hcl
+import {
+  to = github_repository_environment.example
+  id = "myrepo:myenv"
+}
+```
+
+### Import Command
+
+The following command imports an environment called `myenv` for the repo `myrepo` to a `github_repository_environment` resource named `example`.
 
 ```shell
 terraform import github_repository_environment.example myrepo:myenv

--- a/website/docs/r/repository_environment_deployment_policy.html.markdown
+++ b/website/docs/r/repository_environment_deployment_policy.html.markdown
@@ -78,18 +78,38 @@ resource "github_repository_environment_deployment_policy" "test" {
 
 The following arguments are supported:
 
-* `environment` - (Required) The name of the environment.
+- `environment` - (Required) The name of the environment.
 
-* `repository` - (Required) The repository of the environment.
+- `repository` - (Required) The repository of the environment.
 
-* `branch_pattern` - (Optional) The name pattern that branches must match in order to deploy to the environment. If not specified, `tag_pattern` must be specified.
+- `branch_pattern` - (Optional) The name pattern that branches must match in order to deploy to the environment. If not specified, `tag_pattern` must be specified.
 
-* `tag_pattern` - (Optional) The name pattern that tags must match in order to deploy to the environment. If not specified, `branch_pattern` must be specified.
+- `tag_pattern` - (Optional) The name pattern that tags must match in order to deploy to the environment. If not specified, `branch_pattern` must be specified.
+
+## Attributes Reference
+
+- `repository_id` - The ID of the repository.
+- `policy_id` - The ID of the deployment policy.
 
 ## Import
 
-This resource can be imported using an ID made of the repository name, environment name (any `:` in the name need to be escaped as `??`), and deployment policy ID all separated by a `:`.
+This resource can be imported using an ID made of the repository name, environment name (any `:` in the environment name need to be escaped as `??`), and deployment policy ID name all separated by a `:`.
+
+### Import Block
+
+The following import block imports a deployment policy with the ID `123456` for the repo `myrepo` and environment `myenv` to a `github_repository_environment_deployment_policy` resource named `example`.
+
+```hcl
+import {
+  to = github_repository_environment_deployment_policy.example
+  id = "myrepo:myenv:123456"
+}
+```
+
+### Import Command
+
+The following command imports a deployment policy with the ID `123456` for the repo `myrepo` and environment `myenv` to a `github_repository_environment_deployment_policy` resource named `example`.
 
 ```shell
-terraform import github_repository_environment.example myrepo:myenv:123456
+terraform import github_repository_environment_deployment_policy.example myrepo:myenv:123456
 ```


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- `github_repository_environment` resource logic for reviewers had incorrect constraints
- `github_repository_environment_deployment_policy` resource missing policy ID attribute

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `github_repository_environment` has correct constraints for reviewers, including validation for the sum of users and teams
- `github_repository_environment_deployment_policy` has new `policy_id` attribute
- Improved tests
- Improved repository diff logic to support gradual adoption of `repository_id`

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
