### PR TITLE
fix: Only send allow_forking on change

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -630,9 +630,11 @@ func resourceGithubRepositoryObject(d *schema.ResourceData) *github.Repository {
 	}
 
 	// only configure allow forking if repository is not public
-	if allowForking, ok := d.GetOkExists("allow_forking"); ok && visibility != "public" { //nolint:staticcheck,SA1019 // We sometimes need to use GetOkExists for booleans
-		if val, ok := allowForking.(bool); ok {
-			repository.AllowForking = github.Ptr(val)
+	if visibility != "public" && (d.IsNewResource() || d.HasChange("allow_forking")) {
+		if allowForking, ok := d.GetOkExists("allow_forking"); ok { //nolint:staticcheck,SA1019 // We sometimes need to use GetOkExists for booleans
+			if val, ok := allowForking.(bool); ok {
+				repository.AllowForking = github.Ptr(val)
+			}
 		}
 	}
 

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -1078,20 +1078,15 @@ resource "github_repository" "test" {
 			}
 		`, testRepoName)
 
-		check := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(
-				"github_repository.private", "visibility",
-				"private",
-			),
-		)
-
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnauthenticated(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
-					Config: config,
-					Check:  check,
+					Config: fmt.Sprintf(config, testRepoName, "foo"),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("github_repository.private", "visibility", "private"),
+					),
 				},
 			},
 		})
@@ -1107,20 +1102,15 @@ resource "github_repository" "test" {
 			}
 		`, testRepoName)
 
-		check := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(
-				"github_repository.test", "visibility",
-				"internal",
-			),
-		)
-
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessMode(t, enterprise) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
 					Config: config,
-					Check:  check,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("github_repository.test", "visibility", "internal"),
+					),
 				},
 			},
 		})
@@ -1323,6 +1313,68 @@ resource "github_repository" "test" {
 						resource.TestCheckResourceAttr("github_repository.test", "visibility", "internal"),
 						resource.TestCheckResourceAttr("github_repository.test", "private", "true"),
 					),
+				},
+			},
+		})
+	})
+
+	t.Run("check_allow_forking_not_set", func(t *testing.T) {
+		t.Skip("This test should be run manually after confirming that the test organization has been correctly configured to disable setting forking at the repo level.")
+
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		testRepoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+
+		config := `
+resource "github_repository" "private" {
+	name        = "%s"
+	description = "%s"
+	visibility  = "private"
+}
+`
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(config, testRepoName, "foo"),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("github_repository.private", "allow_forking", "false"),
+					),
+				},
+				{
+					Config: fmt.Sprintf(config, testRepoName, "bar"),
+				},
+			},
+		})
+	})
+
+	t.Run("check_vulnerability_alerts_not_set", func(t *testing.T) {
+		t.Skip("This test should be run manually after confirming that the test organization has been correctly configured to disable setting vulnerability alerts at the repo level.")
+
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		testRepoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+
+		config := `
+resource "github_repository" "private" {
+	name        = "%s"
+	description = "%s"
+	visibility  = "public"
+}
+`
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(config, testRepoName, "foo"),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("github_repository.private", "vulnerability_alerts", "true"),
+					),
+				},
+				{
+					Config: fmt.Sprintf(config, testRepoName, "bar"),
 				},
 			},
 		})


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #3173

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- After `allow_forking` has been computed it used when modifying the repo

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `allow_forking` is only used when modifying the repo after it has explicitly changed in the plan

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
