### PR TITLE
docs: swap group_id & team_slug in import

### DIFF
--- a/website/docs/r/emu_group_mapping.html.markdown
+++ b/website/docs/r/emu_group_mapping.html.markdown
@@ -27,8 +27,8 @@ The following arguments are supported:
 
 ## Import
 
-GitHub EMU External Group Mappings can be imported using the `team_slug` and external `group_id` separated by a colon, e.g.
+GitHub EMU External Group Mappings can be imported using the external `group_id` and `team_slug` separated by a colon, e.g.
 
 ```sh
-$ terraform import github_emu_group_mapping.example_emu_group_mapping emu-test-team:28836
+$ terraform import github_emu_group_mapping.example_emu_group_mapping 28836:emu-test-team
 ```


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves N/A
----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

Trying to use import as documented:
```
import {
  to = github_emu_group_mapping.this
  id = "some-team:123456"
}
```
Would result in a cryptic error:
```
Error: strconv.Atoi: parsing "some-team": invalid syntax
```
### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Documentation updated in line with the [actual code](https://github.com/integrations/terraform-provider-github/blob/main/github/resource_github_emu_group_mapping.go#L316C1-L316C27) and the import works as expected:

```
import {
  to = github_emu_group_mapping.this
  id = "123456:some-team"
}
```

### Pull request checklist

- [ ] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
