### PR TITLE
fix(data_source_github_release_asset): Fix #2514 remove accept header…

### DIFF
--- a/github/data_source_github_release_asset.go
+++ b/github/data_source_github_release_asset.go
@@ -147,7 +147,6 @@ func dataSourceGithubReleaseAssetRead(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	req.Header.Set("Accept", "application/octet-stream")
 	resp, err := clientCopy.Do(req)
 	if err != nil {
 		return diag.FromErr(err)

--- a/website/docs/d/release_asset.html.markdown
+++ b/website/docs/d/release_asset.html.markdown
@@ -25,10 +25,10 @@ into a `file` attribute on the data source:
 
 ```hcl
 data "github_release_asset" "example" {
-    repository    = "example-repository"
-    owner         = "example-owner"
-    asset_id      = 12345
-    download_file = true
+    repository             = "example-repository"
+    owner                  = "example-owner"
+    asset_id               = 12345
+    download_file_contents = true
 }
 ```
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2514 and  #2513

Fixes #2514 remove accept header that's cause http error `406 Not Acceptable` when trying to download the asset.

The new data source `github_release_asset` introduced in provider version 6.11, which adds the functionality to download the file asset, but it wasn't working due to the `req.Header.Set("Accept", "application/octet-stream")` which was causing the GitHub API to return a `406 Not Acceptable`.

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- The data source `github_release_asset` returns `406 Not Acceptable` when trying to download the asset.
- Doc has a mismatch attribute for the data source

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The data source `github_release_asset` is able to download the specified asset.
- Doc is updated

### Pull request checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
