### PR TITLE
[MAINT] Fix test of Org Repo Roles

### DIFF
--- a/github/data_source_github_organization_repository_role.go
+++ b/github/data_source_github_organization_repository_role.go
@@ -2,10 +2,8 @@ package github
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
-	"github.com/google/go-github/v82/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -53,26 +51,9 @@ func dataSourceGithubOrganizationRepositoryRoleRead(ctx context.Context, d *sche
 
 	roleId := int64(d.Get("role_id").(int))
 
-	// TODO: Use this code when go-github is at v68+
-	// role, _, err := client.Organizations.GetCustomRepoRole(ctx, orgName, roleId)
-	// if err != nil {
-	// 	return diag.FromErr(err)
-	// }
-
-	roles, _, err := client.Organizations.ListCustomRepoRoles(ctx, orgName)
+	role, _, err := client.Organizations.GetCustomRepoRole(ctx, orgName, roleId)
 	if err != nil {
 		return diag.FromErr(err)
-	}
-
-	var role *github.CustomRepoRoles
-	for _, r := range roles.CustomRepoRoles {
-		if r.GetID() == roleId {
-			role = r
-			break
-		}
-	}
-	if role == nil {
-		return diag.FromErr(fmt.Errorf("custom organization repo role with ID %d not found", roleId))
 	}
 
 	r := map[string]any{

--- a/github/data_source_github_organization_repository_role_test.go
+++ b/github/data_source_github_organization_repository_role_test.go
@@ -11,7 +11,7 @@ import (
 func TestAccGithubOrganizationRepositoryRoleDataSource(t *testing.T) {
 	t.Run("queries an organization repository role", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		roleName := fmt.Sprintf(`tf-acc-test-%s`, randomID)
+		roleName := fmt.Sprintf(`%s%s`, testResourcePrefix, randomID)
 
 		config := fmt.Sprintf(`
 			resource "github_organization_repository_role" "test" {

--- a/github/resource_github_organization_repository_role.go
+++ b/github/resource_github_organization_repository_role.go
@@ -2,8 +2,9 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"log"
+	"net/http"
 	"slices"
 	"strconv"
 
@@ -107,36 +108,20 @@ func resourceGithubOrganizationRepositoryRoleRead(ctx context.Context, d *schema
 		return diag.FromErr(err)
 	}
 
-	// TODO: Use this code when go-github is v68+
-	// role, _, err := client.Organizations.GetCustomRepoRole(ctx, orgName, roleId)
-	// if err != nil {
-	// 	if ghErr, ok := err.(*github.ErrorResponse); ok {
-	// 		if ghErr.Response.StatusCode == http.StatusNotFound {
-	// 			log.Printf("[WARN] GitHub organization repository role (%s/%d) not found, removing from state", orgName, roleId)
-	// 			d.SetId("")
-	// 			return nil
-	// 		}
-	// 	}
-	// 	return err
-	// }
-
-	roles, _, err := client.Organizations.ListCustomRepoRoles(ctx, orgName)
+	role, _, err := client.Organizations.GetCustomRepoRole(ctx, orgName, roleId)
 	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	var role *github.CustomRepoRoles
-	for _, r := range roles.CustomRepoRoles {
-		if r.GetID() == roleId {
-			role = r
-			break
+		var ghErr *github.ErrorResponse
+		if errors.As(err, &ghErr) {
+			if ghErr.Response.StatusCode == http.StatusNotFound {
+				tflog.Warn(ctx, "GitHub organization repository role not found, removing from state", map[string]any{
+					"orgName": orgName,
+					"roleId":  roleId,
+				})
+				d.SetId("")
+				return nil
+			}
 		}
-	}
-
-	if role == nil {
-		log.Printf("[WARN] GitHub organization repository role (%s/%d) not found, removing from state", orgName, roleId)
-		d.SetId("")
-		return nil
+		return diag.FromErr(err)
 	}
 
 	if err = d.Set("role_id", role.GetID()); err != nil {

--- a/github/resource_github_organization_repository_role.go
+++ b/github/resource_github_organization_repository_role.go
@@ -170,13 +170,9 @@ func resourceGithubOrganizationRepositoryRoleUpdate(ctx context.Context, d *sche
 		Permissions: permissionsStr,
 	}
 
-	role, _, err := client.Organizations.UpdateCustomRepoRole(ctx, orgName, roleId, update)
+	_, _, err = client.Organizations.UpdateCustomRepoRole(ctx, orgName, roleId, update)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating GitHub organization repository role (%s/%s): %w", orgName, d.Get("name").(string), err))
-	}
-
-	if err = d.Set("role_id", role.GetID()); err != nil {
-		return diag.FromErr(err)
 	}
 
 	return nil

--- a/github/resource_github_organization_repository_role.go
+++ b/github/resource_github_organization_repository_role.go
@@ -81,6 +81,10 @@ func resourceGithubOrganizationRepositoryRoleCreate(ctx context.Context, d *sche
 		return diag.FromErr(fmt.Errorf("error creating GitHub organization repository role (%s/%s): %w", orgName, d.Get("name").(string), err))
 	}
 
+	if err = d.Set("role_id", role.GetID()); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(fmt.Sprint(role.GetID()))
 	return nil
 }
@@ -177,9 +181,13 @@ func resourceGithubOrganizationRepositoryRoleUpdate(ctx context.Context, d *sche
 		Permissions: permissionsStr,
 	}
 
-	_, _, err = client.Organizations.UpdateCustomRepoRole(ctx, orgName, roleId, update)
+	role, _, err := client.Organizations.UpdateCustomRepoRole(ctx, orgName, roleId, update)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error updating GitHub organization repository role (%s/%s): %w", orgName, d.Get("name").(string), err))
+	}
+
+	if err = d.Set("role_id", role.GetID()); err != nil {
+		return diag.FromErr(err)
 	}
 
 	return nil

--- a/github/resource_github_organization_repository_role_test.go
+++ b/github/resource_github_organization_repository_role_test.go
@@ -13,7 +13,7 @@ func TestAccGithubOrganizationRepositoryRole(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		name := fmt.Sprintf("tf-acc-org-repo-role-%s", randomID)
 		description := "This is a test org repo role."
-		baseRole := "write"
+		baseRole := "read"
 		permission0 := "reopen_issue"
 		permission1 := "reopen_pull_request"
 
@@ -59,6 +59,7 @@ func TestAccGithubOrganizationRepositoryRole(t *testing.T) {
 		config := fmt.Sprintf(`
 			resource "github_organization_repository_role" "test" {
 				name        = "%s"
+				base_role   = "read"
 				permissions = [
 				"%s"
 				]


### PR DESCRIPTION
----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- Computed fields were not being set correctly in `resource_github_organization_repository_role`
- Tests for `resource_github_organization_repository_role` were failing due to configuration issues
- TODO comments for `github_organization_repository_role` about upgrading to v68+

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Corrected behaviour of Computed fields
- Fixed tests
- Added validation for the `permissions` field in. `resource_github_organization_repository_role`
- Update to use new SDK functions

### Pull request checklist

- [ ] ~Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))~
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
