### PR TITLE
Add support for EnterpriseOwner

### DIFF
--- a/github/resource_github_organization_ruleset.go
+++ b/github/resource_github_organization_ruleset.go
@@ -63,13 +63,13 @@ func resourceGithubOrganizationRuleset() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Default:     nil,
-							Description: "The ID of the actor that can bypass a ruleset. When `actor_type` is `OrganizationAdmin`, this should be set to `1`. Some resources such as DeployKey do not have an ID and this should be omitted.",
+							Description: "The ID of the actor that can bypass a ruleset. When `actor_type` is `OrganizationAdmin`, this should be set to `1`. When it is `EnterpriseOwner` it should be 0. Some resources such as DeployKey do not have an ID and this should be omitted.",
 						},
 						"actor_type": {
 							Type:             schema.TypeString,
 							Required:         true,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"Integration", "OrganizationAdmin", "RepositoryRole", "Team", "DeployKey"}, false)),
-							Description:      "The type of actor that can bypass a ruleset. Can be one of: `Integration`, `OrganizationAdmin`, `RepositoryRole`, `Team`, or `DeployKey`.",
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"Integration", "OrganizationAdmin", "RepositoryRole", "Team", "DeployKey", "EnterpriseOwner"}, false)),
+							Description:      "The type of actor that can bypass a ruleset. Can be one of: `Integration`, `OrganizationAdmin`, `RepositoryRole`, `Team`, `DeployKey` or `EnterpriseOwner`.",
 						},
 						"bypass_mode": {
 							Type:             schema.TypeString,

--- a/github/resource_github_organization_ruleset.go
+++ b/github/resource_github_organization_ruleset.go
@@ -63,7 +63,7 @@ func resourceGithubOrganizationRuleset() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Default:     nil,
-							Description: "The ID of the actor that can bypass a ruleset. When `actor_type` is `OrganizationAdmin`, this should be set to `1`. When it is `EnterpriseOwner` it should be 0. Some resources such as DeployKey do not have an ID and this should be omitted.",
+							Description: "The ID of the actor that can bypass a ruleset. Some actor types such as OrganizationAdmin/EnterpriseOwner/DeployKey do not have an ID and this should be omitted.",
 						},
 						"actor_type": {
 							Type:             schema.TypeString,

--- a/github/resource_github_organization_ruleset_test.go
+++ b/github/resource_github_organization_ruleset_test.go
@@ -76,11 +76,6 @@ resource "github_organization_ruleset" "test" {
 		bypass_mode = "always"
 	}
 
-	bypass_actors {
-		actor_type  = "EnterpriseOwner"
-		bypass_mode = "always"
-	}
-
 	conditions {
 		repository_name {
 			include = ["~ALL"]
@@ -165,7 +160,7 @@ resource "github_organization_ruleset" "test" {
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "name", rulesetName),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "target", "branch"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "enforcement", "active"),
-						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.#", "4"),
+						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.#", "3"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.0.actor_type", "DeployKey"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.0.bypass_mode", "always"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.1.actor_id", "5"),
@@ -173,8 +168,6 @@ resource "github_organization_ruleset" "test" {
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.1.bypass_mode", "always"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.2.actor_type", "OrganizationAdmin"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.2.bypass_mode", "always"),
-						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.3.actor_type", "EnterpriseOwner"),
-						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.3.bypass_mode", "always"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "rules.0.pull_request.0.allowed_merge_methods.#", "3"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "rules.0.required_workflows.0.do_not_enforce_on_create", "true"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "rules.0.required_workflows.0.required_workflow.0.path", workflowFilePath),
@@ -1398,6 +1391,62 @@ resource "github_organization_ruleset" "test" {
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "rules.0.pull_request.0.required_reviewers.0.file_patterns.0", "*.go"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "rules.0.pull_request.0.required_reviewers.1.minimum_approvals", "1"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "rules.0.pull_request.0.required_reviewers.1.file_patterns.#", "2"),
+					),
+				},
+			},
+		})
+	})
+
+	t.Run("create_branch_ruleset_with_enterprise_features", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		rulesetName := fmt.Sprintf("%s-branch-ruleset-%s", testResourcePrefix, randomID)
+
+		config := fmt.Sprintf(`
+	resource "github_organization_ruleset" "test" {
+		name        = "%s"
+		target      = "branch"
+		enforcement = "active"
+
+		conditions {
+			ref_name {
+				include = ["~ALL"]
+				exclude = []
+			}
+
+			repository_name {
+				include = ["~ALL"]
+				exclude = []
+			}
+		}
+
+		bypass_actors {
+			actor_type  = "EnterpriseOwner"
+			bypass_mode = "always"
+		}
+
+		rules {
+			branch_name_pattern {
+				name     = "test"
+				negate   = false
+				operator = "starts_with"
+				pattern  = "test"
+			}
+		}
+	}
+`, rulesetName)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessEnterprise(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("github_organization_ruleset.test", "name", rulesetName),
+						resource.TestCheckResourceAttr("github_organization_ruleset.test", "enforcement", "active"),
+						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.#", "1"),
+						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.0.actor_type", "EnterpriseOwner"),
+						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.0.bypass_mode", "always"),
 					),
 				},
 			},

--- a/github/resource_github_organization_ruleset_test.go
+++ b/github/resource_github_organization_ruleset_test.go
@@ -1441,13 +1441,12 @@ resource "github_organization_ruleset" "test" {
 			Steps: []resource.TestStep{
 				{
 					Config: config,
-					Check: resource.ComposeTestCheckFunc(
-						resource.TestCheckResourceAttr("github_organization_ruleset.test", "name", rulesetName),
-						resource.TestCheckResourceAttr("github_organization_ruleset.test", "enforcement", "active"),
-						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.#", "1"),
-						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.0.actor_type", "EnterpriseOwner"),
-						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.0.bypass_mode", "always"),
-					),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_organization_ruleset.test", tfjsonpath.New("name"), knownvalue.StringExact(rulesetName)),
+						statecheck.ExpectKnownValue("github_organization_ruleset.test", tfjsonpath.New("enforcement"), knownvalue.StringExact("active")),
+						statecheck.ExpectKnownValue("github_organization_ruleset.test", tfjsonpath.New("bypass_actors").AtSliceIndex(0).AtMapKey("actor_type"), knownvalue.StringExact("EnterpriseOwner")),
+						statecheck.ExpectKnownValue("github_organization_ruleset.test", tfjsonpath.New("bypass_actors").AtSliceIndex(0).AtMapKey("bypass_mode"), knownvalue.StringExact("always")),
+					},
 				},
 			},
 		})

--- a/github/resource_github_organization_ruleset_test.go
+++ b/github/resource_github_organization_ruleset_test.go
@@ -72,13 +72,11 @@ resource "github_organization_ruleset" "test" {
 	}
 
 	bypass_actors {
-		actor_id    = 1
 		actor_type  = "OrganizationAdmin"
 		bypass_mode = "always"
 	}
 
 	bypass_actors {
-		actor_id    = 0
 		actor_type  = "EnterpriseOwner"
 		bypass_mode = "always"
 	}
@@ -173,10 +171,8 @@ resource "github_organization_ruleset" "test" {
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.1.actor_id", "5"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.1.actor_type", "RepositoryRole"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.1.bypass_mode", "always"),
-						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.2.actor_id", "1"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.2.actor_type", "OrganizationAdmin"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.2.bypass_mode", "always"),
-						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.3.actor_id", "0"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.3.actor_type", "EnterpriseOwner"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.3.bypass_mode", "always"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "rules.0.pull_request.0.allowed_merge_methods.#", "3"),
@@ -636,7 +632,6 @@ resource "github_organization_ruleset" "test" {
 	}
 
 	bypass_actors {
-		actor_id    = 1
 		actor_type  = "OrganizationAdmin"
 		bypass_mode = "always"
 	}
@@ -716,7 +711,6 @@ resource "github_organization_ruleset" "test" {
 	enforcement = "active"
 
 	bypass_actors {
-		actor_id    = 1
 		actor_type  = "OrganizationAdmin"
 		bypass_mode = "%s"
 	}

--- a/github/resource_github_organization_ruleset_test.go
+++ b/github/resource_github_organization_ruleset_test.go
@@ -77,6 +77,12 @@ resource "github_organization_ruleset" "test" {
 		bypass_mode = "always"
 	}
 
+	bypass_actors {
+		actor_id    = 0
+		actor_type  = "EnterpriseOwner"
+		bypass_mode = "always"
+	}
+
 	conditions {
 		repository_name {
 			include = ["~ALL"]
@@ -170,6 +176,9 @@ resource "github_organization_ruleset" "test" {
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.2.actor_id", "1"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.2.actor_type", "OrganizationAdmin"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.2.bypass_mode", "always"),
+						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.3.actor_id", "0"),
+						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.3.actor_type", "EnterpriseOwner"),
+						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.3.bypass_mode", "always"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "rules.0.pull_request.0.allowed_merge_methods.#", "3"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "rules.0.required_workflows.0.do_not_enforce_on_create", "true"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "rules.0.required_workflows.0.required_workflow.0.path", workflowFilePath),

--- a/github/resource_github_organization_ruleset_test.go
+++ b/github/resource_github_organization_ruleset_test.go
@@ -165,7 +165,7 @@ resource "github_organization_ruleset" "test" {
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "name", rulesetName),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "target", "branch"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "enforcement", "active"),
-						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.#", "3"),
+						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.#", "4"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.0.actor_type", "DeployKey"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.0.bypass_mode", "always"),
 						resource.TestCheckResourceAttr("github_organization_ruleset.test", "bypass_actors.1.actor_id", "5"),

--- a/github/resource_github_repository_ruleset.go
+++ b/github/resource_github_repository_ruleset.go
@@ -68,12 +68,12 @@ func resourceGithubRepositoryRuleset() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Default:     nil,
-							Description: "The ID of the actor that can bypass a ruleset. When `actor_type` is `OrganizationAdmin`, this should be set to `1`. Some resources such as DeployKey do not have an ID and this should be omitted.",
+							Description: "The ID of the actor that can bypass a ruleset. Some actor types such as OrganizationAdmin/EnterpriseOwner/DeployKey do not have an ID and this should be omitted.",
 						},
 						"actor_type": {
 							Type:             schema.TypeString,
 							Required:         true,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"RepositoryRole", "Team", "Integration", "OrganizationAdmin", "DeployKey"}, false)),
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"RepositoryRole", "Team", "Integration", "OrganizationAdmin", "DeployKey", "EnterpriseOwner"}, false)),
 							Description:      "The type of actor that can bypass a ruleset. See https://docs.github.com/en/rest/repos/rules for more information.",
 						},
 						"bypass_mode": {

--- a/github/resource_github_repository_ruleset_test.go
+++ b/github/resource_github_repository_ruleset_test.go
@@ -173,6 +173,11 @@ resource "github_repository_ruleset" "test" {
 			}
 		}
 
+		bypass_actors {
+			actor_type  = "EnterpriseOwner"
+			bypass_mode = "always"
+		}
+
 		rules {
 			branch_name_pattern {
 				name     = "test"
@@ -193,6 +198,9 @@ resource "github_repository_ruleset" "test" {
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "name", "test"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "enforcement", "active"),
+						resource.TestCheckResourceAttr("github_repository_ruleset.test", "bypass_actors.#", "1"),
+						resource.TestCheckResourceAttr("github_repository_ruleset.test", "bypass_actors.0.actor_type", "EnterpriseOwner"),
+						resource.TestCheckResourceAttr("github_repository_ruleset.test", "bypass_actors.0.bypass_mode", "always"),
 					),
 				},
 			},

--- a/github/resource_github_repository_ruleset_test.go
+++ b/github/resource_github_repository_ruleset_test.go
@@ -190,7 +190,7 @@ resource "github_repository_ruleset" "test" {
 `, repoName, testAccConf.testRepositoryVisibility)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnauthenticated(t) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{

--- a/website/docs/r/organization_ruleset.html.markdown
+++ b/website/docs/r/organization_ruleset.html.markdown
@@ -349,7 +349,7 @@ The `rules` block supports the following:
 
 #### bypass_actors ####
 
-- `actor_id` - (Optional) (Number) The ID of the actor that can bypass a ruleset. Some actor types such as `DeployKey` do not have an ID.
+- `actor_id` - (Optional) (Number) The ID of the actor that can bypass a ruleset. Some actor types such as `OrganizationAdmin`, `EnterpriseOwner` and `DeployKey` do not have an ID - this argument should not be set in those cases as the GitHub API will ignore it.
 
 - `actor_type` (String) The type of actor that can bypass a ruleset. Can be one of: `RepositoryRole`, `Team`, `Integration`, `OrganizationAdmin`, `EnterpriseOwner`.
 
@@ -357,8 +357,6 @@ The `rules` block supports the following:
 
 ~>Note: at the time of writing this, the following actor types correspond to the following actor IDs:
 
-- `EnterpriseOwner` -> `0`
-- `OrganizationAdmin` -> `1`
 - `RepositoryRole` (This is the actor type, the following are the base repository roles and their associated IDs.)
     - `maintain` -> `2`
     - `write` -> `4`

--- a/website/docs/r/organization_ruleset.html.markdown
+++ b/website/docs/r/organization_ruleset.html.markdown
@@ -351,12 +351,13 @@ The `rules` block supports the following:
 
 - `actor_id` - (Optional) (Number) The ID of the actor that can bypass a ruleset. Some actor types such as `DeployKey` do not have an ID.
 
-- `actor_type` (String) The type of actor that can bypass a ruleset. Can be one of: `RepositoryRole`, `Team`, `Integration`, `OrganizationAdmin`.
+- `actor_type` (String) The type of actor that can bypass a ruleset. Can be one of: `RepositoryRole`, `Team`, `Integration`, `OrganizationAdmin`, `EnterpriseOwner`.
 
 - `bypass_mode` - (Optional) (String) When the specified actor can bypass the ruleset. pull_request means that an actor can only bypass rules on pull requests. Can be one of: `always`, `pull_request`, `exempt`.
 
 ~>Note: at the time of writing this, the following actor types correspond to the following actor IDs:
 
+- `EnterpriseOwner` -> `0`
 - `OrganizationAdmin` -> `1`
 - `RepositoryRole` (This is the actor type, the following are the base repository roles and their associated IDs.)
     - `maintain` -> `2`

--- a/website/docs/r/repository_ruleset.html.markdown
+++ b/website/docs/r/repository_ruleset.html.markdown
@@ -296,9 +296,9 @@ The `rules` block supports the following:
 
 #### bypass_actors ####
 
-- `actor_id` - (Optional) (Number) The ID of the actor that can bypass a ruleset. If `actor_type` is `Integration`, `actor_id` is a GitHub App ID. App ID can be obtained by following instructions from the [Get an App API docs](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-app). Some actor types such as `OrganizationAdmin` and `DeployKey` do not have an ID.
+- `actor_id` - (Optional) (Number) The ID of the actor that can bypass a ruleset. If `actor_type` is `Integration`, `actor_id` is a GitHub App ID. App ID can be obtained by following instructions from the [Get an App API docs](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-app). Some actor types such as `OrganizationAdmin`, `EnterpriseOwner` and `DeployKey` do not have an ID.
 
-- `actor_type` (String) The type of actor that can bypass a ruleset. Can be one of: `RepositoryRole`, `Team`, `Integration`, `OrganizationAdmin`, `DeployKey`.
+- `actor_type` (String) The type of actor that can bypass a ruleset. Can be one of: `RepositoryRole`, `Team`, `Integration`, `OrganizationAdmin`, `DeployKey`, `EnterpriseOwner`.
 
 - `bypass_mode` - (Optional) (String) When the specified actor can bypass the ruleset. pull_request means that an actor can only bypass rules on pull requests. Can be one of: `always`, `pull_request`, `exempt`.
 

--- a/website/docs/r/repository_ruleset.html.markdown
+++ b/website/docs/r/repository_ruleset.html.markdown
@@ -296,7 +296,7 @@ The `rules` block supports the following:
 
 #### bypass_actors ####
 
-- `actor_id` - (Optional) (Number) The ID of the actor that can bypass a ruleset. If `actor_type` is `Integration`, `actor_id` is a GitHub App ID. App ID can be obtained by following instructions from the [Get an App API docs](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-app). Some actor types such as `DeployKey` do not have an ID.
+- `actor_id` - (Optional) (Number) The ID of the actor that can bypass a ruleset. If `actor_type` is `Integration`, `actor_id` is a GitHub App ID. App ID can be obtained by following instructions from the [Get an App API docs](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-app). Some actor types such as `OrganizationAdmin` and `DeployKey` do not have an ID.
 
 - `actor_type` (String) The type of actor that can bypass a ruleset. Can be one of: `RepositoryRole`, `Team`, `Integration`, `OrganizationAdmin`, `DeployKey`.
 
@@ -304,7 +304,6 @@ The `rules` block supports the following:
 
 ~> Note: at the time of writing this, the following actor types correspond to the following actor IDs:
 
-- `OrganizationAdmin` -> `1`
 - `RepositoryRole` (This is the actor type, the following are the base repository roles and their associated IDs.)
     - `maintain` -> `2`
     - `write` -> `4`


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #3210 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- Adds support for setting EnterpriseOwner in rulesets

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The EnterpriseOwner value can be set as a bypass_actor

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
