### PR TITLE
[MAINT] Fix missing docs links

### DIFF
--- a/website/github.erb
+++ b/website/github.erb
@@ -56,7 +56,7 @@
               <a href="/docs/providers/github/d/app.html">github_app</a>
             </li>
             <li>
-              <a href="/docs/providers/github/d/app_token.html"></a>
+              <a href="/docs/providers/github/d/app_token.html">github_app_token</a>
             </li>
             <li>
               <a href="/docs/providers/github/d/branch.html">github_branch</a>
@@ -72,9 +72,6 @@
             </li>
             <li>
               <a href="/docs/providers/github/d/codespaces_organization_secrets.html">github_codespaces_organization_secrets</a>
-            </li>
-            <li>
-              <a href="/docs/providers/github/d/codespaces_organization_secret_repositories.html">github_codespaces_organization_secret_repositories</a>
             </li>
             <li>
               <a href="/docs/providers/github/d/codespaces_public_key.html">github_codespaces_public_key</a>
@@ -93,6 +90,9 @@
             </li>
             <li>
               <a href="/docs/providers/github/d/dependabot_organization_secrets.html">github_dependabot_organization_secrets</a>
+            </li>
+            <li>
+              <a href="/docs/providers/github/d/dependabot_public_key.html">github_dependabot_public_key</a>
             </li>
             <li>
               <a href="/docs/providers/github/d/dependabot_secrets.html">github_dependabot_secrets</a>
@@ -114,6 +114,9 @@
             </li>
             <li>
               <a href="/docs/providers/github/d/organization.html">github_organization</a>
+            </li>
+            <li>
+              <a href="/docs/providers/github/d/organization_app_installations.html">github_organization_app_installations</a>
             </li>
             <li>
               <a href="/docs/providers/github/d/organization_custom_role.html">github_organization_custom_role</a>
@@ -164,31 +167,46 @@
               <a href="/docs/providers/github/d/release.html">github_release</a>
             </li>
             <li>
+              <a href="/docs/providers/github/d/release_asset.html">github_release_asset</a>
+            </li>
+            <li>
               <a href="/docs/providers/github/d/repositories.html">github_repositories</a>
             </li>
             <li>
               <a href="/docs/providers/github/d/repository.html">github_repository</a>
             </li>
             <li>
-              <a href="/docs/providers/github/d/repository_autolink_references.html.markdown">github_repository_autolink_references</a>
+              <a href="/docs/providers/github/d/repository_autolink_references.html">github_repository_autolink_references</a>
             </li>
             <li>
               <a href="/docs/providers/github/d/repository_branches.html">github_repository_branches</a>
             </li>
             <li>
+              <a href="/docs/providers/github/d/repository_custom_properties.html">github_repository_custom_properties</a>
+            </li>
+            <li>
               <a href="/docs/providers/github/d/repository_deployment_branch_policies.html">github_repository_deployment_branch_policies</a>
+            </li>
+            <li>
+              <a href="/docs/providers/github/d/repository_environment_deployment_policies.html">github_repository_environment_deployment_policies</a>
             </li>
             <li>
               <a href="/docs/providers/github/d/repository_deploy_keys.html">github_repository_deploy_keys</a>
             </li>
             <li>
-              <a href="/docs/providers/github/d/repository_environments.html.markdown">github_repository_environments</a>
+              <a href="/docs/providers/github/d/repository_environments.html">github_repository_environments</a>
             </li>
             <li>
               <a href="/docs/providers/github/d/repository_file.html">github_repository_file</a>
             </li>
             <li>
               <a href="/docs/providers/github/d/repository_milestone.html">github_repository_milestone</a>
+            </li>
+            <li>
+              <a href="/docs/providers/github/d/repository_pull_request.html">github_repository_pull_request</a>
+            </li>
+            <li>
+              <a href="/docs/providers/github/d/repository_pull_requests.html">github_repository_pull_requests</a>
             </li>
             <li>
               <a href="/docs/providers/github/d/repository_teams.html">github_repository_teams</a>
@@ -248,6 +266,9 @@
               <a href="/docs/providers/github/r/actions_organization_variable_repository.html">github_actions_organization_variable_repository</a>
             </li>
             <li>
+              <a href="/docs/providers/github/r/actions_organization_workflow_permissions.html">github_actions_organization_workflow_permissions</a>
+            </li>
+            <li>
               <a href="/docs/providers/github/r/actions_repository_access_level.html">github_actions_repository_access_level</a>
             </li>
             <li>
@@ -278,6 +299,9 @@
               <a href="/docs/providers/github/r/branch.html">github_branch</a>
             </li>
             <li>
+              <a href="/docs/providers/github/r/branch_default.html">github_branch_default</a>
+            </li>
+            <li>
               <a href="/docs/providers/github/r/branch_protection.html">github_branch_protection</a>
             </li>
             <li>
@@ -285,6 +309,9 @@
             </li>
             <li>
               <a href="/docs/providers/github/r/codespaces_organization_secret.html">github_codespaces_organization_secret</a>
+            </li>
+            <li>
+              <a href="/docs/providers/github/r/codespaces_organization_secret_repositories.html">github_codespaces_organization_secret_repositories</a>
             </li>
             <li>
               <a href="/docs/providers/github/r/codespaces_secret.html">github_codespaces_secret</a>
@@ -302,10 +329,16 @@
               <a href="/docs/providers/github/r/dependabot_organization_secret_repository.html">github_dependabot_organization_secret_repository</a>
             </li>
             <li>
+              <a href="/docs/providers/github/r/dependabot_secret.html">github_dependabot_secret</a>
+            </li>
+            <li>
               <a href="/docs/providers/github/r/enterprise_actions_runner_group.html">github_enterprise_actions_runner_group</a>
             </li>
             <li>
               <a href="/docs/providers/github/r/enterprise_actions_permissions.html">github_enterprise_actions_permissions</a>
+            </li>
+            <li>
+              <a href="/docs/providers/github/r/enterprise_actions_workflow_permissions.html">github_enterprise_actions_workflow_permissions</a>
             </li>
             <li>
               <a href="/docs/providers/github/r/enterprise_organization.html">github_enterprise_organization</a>
@@ -389,6 +422,9 @@
               <a href="/docs/providers/github/r/repository_collaborators.html">github_repository_collaborators</a>
             </li>
             <li>
+              <a href="/docs/providers/github/r/repository_custom_property.html">github_repository_custom_property</a>
+            </li>
+            <li>
               <a href="/docs/providers/github/r/repository_deployment_branch_policy.html">github_repository_deployment_branch_policy</a>
             </li>
             <li>
@@ -401,10 +437,10 @@
               <a href="/docs/providers/github/r/repository_environment_deployment_policy.html">github_repository_environment_deployment_policy</a>
             </li>
             <li>
-              <a href="/docs/providers/github/r/repository_environment_secret.html">github_repository_environment_secret</a>
+              <a href="/docs/providers/github/r/actions_environment_secret.html">github_actions_environment_secret</a>
             </li>
             <li>
-              <a href="/docs/providers/github/r/repository_environment_variable.html">github_repository_environment_variable</a>
+              <a href="/docs/providers/github/r/actions_environment_variable.html">github_actions_environment_variable</a>
             </li>
             <li>
               <a href="/docs/providers/github/r/repository_file.html">github_repository_file</a>
@@ -414,6 +450,9 @@
             </li>
             <li>
               <a href="/docs/providers/github/r/repository_project.html">github_repository_project</a>
+            </li>
+            <li>
+              <a href="/docs/providers/github/r/repository_pull_request.html">github_repository_pull_request</a>
             </li>
             <li>
               <a href="/docs/providers/github/r/repository_ruleset.html">github_repository_ruleset</a>
@@ -440,6 +479,9 @@
               <a href="/docs/providers/github/r/team_sync_group_mapping.html">github_team_sync_group_mapping</a>
             </li>
             <li>
+              <a href="/docs/providers/github/r/team_settings.html">github_team_settings</a>
+            </li>
+            <li>
               <a href="/docs/providers/github/r/emu_group_mapping.html">github_emu_group_mapping</a>
             </li>
             <li>
@@ -450,6 +492,9 @@
             </li>
             <li>
               <a href="/docs/providers/github/r/user_ssh_key.html">github_user_ssh_key</a>
+            </li>
+            <li>
+              <a href="/docs/providers/github/r/workflow_repository_permissions.html">github_workflow_repository_permissions</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- I noticed that at least one docs page is not being linked to in the provider docs: https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/organization_app_installations

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updated `github.erb` with all missing docs links in hopes of getting docs to show up

### Pull request checklist

- [ ] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
