### PR TITLE
feat: add organization immutable releases resource

### DIFF
--- a/github/provider.go
+++ b/github/provider.go
@@ -173,6 +173,7 @@ func Provider() *schema.Provider {
 			"github_organization_block":                                             resourceOrganizationBlock(),
 			"github_organization_custom_role":                                       resourceGithubOrganizationCustomRole(),
 			"github_organization_custom_properties":                                 resourceGithubOrganizationCustomProperties(),
+			"github_organization_immutable_releases":                                resourceGithubOrganizationImmutableReleases(),
 			"github_organization_project":                                           resourceGithubOrganizationProject(),
 			"github_organization_repository_role":                                   resourceGithubOrganizationRepositoryRole(),
 			"github_organization_role":                                              resourceGithubOrganizationRole(),

--- a/github/resource_github_organization_immutable_releases.go
+++ b/github/resource_github_organization_immutable_releases.go
@@ -1,0 +1,158 @@
+package github
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/go-github/v82/github"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceGithubOrganizationImmutableReleases() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGithubOrganizationImmutableReleasesCreateOrUpdate,
+		Read:   resourceGithubOrganizationImmutableReleasesRead,
+		Update: resourceGithubOrganizationImmutableReleasesCreateOrUpdate,
+		Delete: resourceGithubOrganizationImmutableReleasesDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"enforced_repositories": {
+				Type:             schema.TypeString,
+				Required:         true,
+				Description:      "The policy that controls which repositories in the organization have immutable releases enforced. Can be one of: 'all', 'none', or 'selected'.",
+				ValidateDiagFunc: toDiagFunc(validation.StringInSlice([]string{"all", "none", "selected"}, false), "enforced_repositories"),
+			},
+			"selected_repository_ids": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "An array of repository IDs for which immutable releases enforcement should be applied. Only valid when 'enforced_repositories' is set to 'selected'.",
+				Elem:        &schema.Schema{Type: schema.TypeInt},
+			},
+		},
+	}
+}
+
+func resourceGithubOrganizationImmutableReleasesCreateOrUpdate(d *schema.ResourceData, meta any) error {
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
+	ctx := context.Background()
+	if !d.IsNewResource() {
+		ctx = context.WithValue(ctx, ctxId, d.Id())
+	}
+
+	err := checkOrganization(meta)
+	if err != nil {
+		return err
+	}
+
+	enforcedRepositories := d.Get("enforced_repositories").(string)
+
+	policy := github.ImmutableReleasePolicy{
+		EnforcedRepositories: &enforcedRepositories,
+	}
+
+	if enforcedRepositories == "selected" {
+		repoIDs, err := expandSelectedRepositoryIDs(d)
+		if err != nil {
+			return err
+		}
+		policy.SelectedRepositoryIDs = repoIDs
+	}
+
+	_, err = client.Organizations.UpdateImmutableReleasesSettings(ctx, orgName, policy)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(orgName)
+	return resourceGithubOrganizationImmutableReleasesRead(d, meta)
+}
+
+func resourceGithubOrganizationImmutableReleasesRead(d *schema.ResourceData, meta any) error {
+	client := meta.(*Owner).v3client
+	ctx := context.Background()
+
+	err := checkOrganization(meta)
+	if err != nil {
+		return err
+	}
+
+	settings, _, err := client.Organizations.GetImmutableReleasesSettings(ctx, d.Id())
+	if err != nil {
+		return err
+	}
+
+	if err = d.Set("enforced_repositories", settings.GetEnforcedRepositories()); err != nil {
+		return err
+	}
+
+	if settings.GetEnforcedRepositories() == "selected" {
+		opts := github.ListOptions{PerPage: 100, Page: 1}
+		var repoIDs []int64
+
+		for {
+			repos, resp, err := client.Organizations.ListImmutableReleaseRepositories(ctx, d.Id(), &opts)
+			if err != nil {
+				return err
+			}
+			for _, repo := range repos.Repositories {
+				repoIDs = append(repoIDs, repo.GetID())
+			}
+
+			if resp.NextPage == 0 {
+				break
+			}
+			opts.Page = resp.NextPage
+		}
+
+		if err = d.Set("selected_repository_ids", repoIDs); err != nil {
+			return err
+		}
+	} else {
+		if err = d.Set("selected_repository_ids", []int64{}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func resourceGithubOrganizationImmutableReleasesDelete(d *schema.ResourceData, meta any) error {
+	client := meta.(*Owner).v3client
+	orgName := meta.(*Owner).name
+	ctx := context.WithValue(context.Background(), ctxId, d.Id())
+
+	err := checkOrganization(meta)
+	if err != nil {
+		return err
+	}
+
+	none := "none"
+	_, err = client.Organizations.UpdateImmutableReleasesSettings(ctx, orgName, github.ImmutableReleasePolicy{
+		EnforcedRepositories: &none,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func expandSelectedRepositoryIDs(d *schema.ResourceData) ([]int64, error) {
+	raw, ok := d.GetOk("selected_repository_ids")
+	if !ok {
+		return nil, errors.New("selected_repository_ids must be specified when enforced_repositories is set to 'selected'")
+	}
+
+	set := raw.(*schema.Set)
+	ids := make([]int64, 0, set.Len())
+	for _, v := range set.List() {
+		ids = append(ids, int64(v.(int)))
+	}
+
+	return ids, nil
+}

--- a/github/resource_github_organization_immutable_releases_test.go
+++ b/github/resource_github_organization_immutable_releases_test.go
@@ -1,0 +1,183 @@
+package github
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccGithubOrganizationImmutableReleases(t *testing.T) {
+	t.Run("test setting enforced_repositories to all", func(t *testing.T) {
+		config := `
+			resource "github_organization_immutable_releases" "test" {
+				enforced_repositories = "all"
+			}
+		`
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_organization_immutable_releases.test", "enforced_repositories", "all",
+			),
+		)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessHasOrgs(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check:  check,
+				},
+			},
+		})
+	})
+
+	t.Run("test setting enforced_repositories to none", func(t *testing.T) {
+		config := `
+			resource "github_organization_immutable_releases" "test" {
+				enforced_repositories = "none"
+			}
+		`
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_organization_immutable_releases.test", "enforced_repositories", "none",
+			),
+		)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessHasOrgs(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check:  check,
+				},
+			},
+		})
+	})
+
+	t.Run("test setting enforced_repositories to selected with repository IDs", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%srepo-immutable-rel-%s", testResourcePrefix, randomID)
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name        = "%[1]s"
+				description = "Terraform acceptance tests %[1]s"
+				topics      = ["terraform", "testing"]
+			}
+
+			resource "github_organization_immutable_releases" "test" {
+				enforced_repositories  = "selected"
+				selected_repository_ids = [github_repository.test.repo_id]
+			}
+		`, repoName)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_organization_immutable_releases.test", "enforced_repositories", "selected",
+			),
+			resource.TestCheckResourceAttr(
+				"github_organization_immutable_releases.test", "selected_repository_ids.#", "1",
+			),
+		)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessHasOrgs(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check:  check,
+				},
+			},
+		})
+	})
+
+	t.Run("test import of organization immutable releases", func(t *testing.T) {
+		config := `
+			resource "github_organization_immutable_releases" "test" {
+				enforced_repositories = "all"
+			}
+		`
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_organization_immutable_releases.test", "enforced_repositories", "all",
+			),
+		)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessHasOrgs(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check:  check,
+				},
+				{
+					ResourceName:      "github_organization_immutable_releases.test",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	})
+
+	t.Run("test updating enforced_repositories from all to selected", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%srepo-immutable-rel-%s", testResourcePrefix, randomID)
+
+		configAll := `
+			resource "github_organization_immutable_releases" "test" {
+				enforced_repositories = "all"
+			}
+		`
+
+		configSelected := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name        = "%[1]s"
+				description = "Terraform acceptance tests %[1]s"
+				topics      = ["terraform", "testing"]
+			}
+
+			resource "github_organization_immutable_releases" "test" {
+				enforced_repositories  = "selected"
+				selected_repository_ids = [github_repository.test.repo_id]
+			}
+		`, repoName)
+
+		checkAll := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_organization_immutable_releases.test", "enforced_repositories", "all",
+			),
+		)
+
+		checkSelected := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_organization_immutable_releases.test", "enforced_repositories", "selected",
+			),
+			resource.TestCheckResourceAttr(
+				"github_organization_immutable_releases.test", "selected_repository_ids.#", "1",
+			),
+		)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessHasOrgs(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: configAll,
+					Check:  checkAll,
+				},
+				{
+					Config: configSelected,
+					Check:  checkSelected,
+				},
+			},
+		})
+	})
+}

--- a/website/docs/r/organization_immutable_releases.html.markdown
+++ b/website/docs/r/organization_immutable_releases.html.markdown
@@ -1,0 +1,59 @@
+---
+layout: "github"
+page_title: "GitHub: github_organization_immutable_releases"
+description: |-
+  Creates and manages immutable releases settings within a GitHub organization
+---
+
+# github_organization_immutable_releases
+
+This resource allows you to create and manage immutable releases settings within your GitHub organization.
+You must have admin access to an organization to use this resource.
+
+When immutable releases are enforced, release assets and metadata cannot be modified or deleted after publication.
+
+## Example Usage
+
+### Enforce immutable releases for all repositories
+
+```hcl
+resource "github_organization_immutable_releases" "example" {
+  enforced_repositories = "all"
+}
+```
+
+### Enforce immutable releases for selected repositories
+
+```hcl
+resource "github_repository" "example" {
+  name = "my-repository"
+}
+
+resource "github_organization_immutable_releases" "example" {
+  enforced_repositories  = "selected"
+  selected_repository_ids = [github_repository.example.repo_id]
+}
+```
+
+### Disable immutable releases enforcement
+
+```hcl
+resource "github_organization_immutable_releases" "example" {
+  enforced_repositories = "none"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `enforced_repositories` - (Required) The policy that controls which repositories in the organization have immutable releases enforced. Can be one of: `all`, `none`, or `selected`.
+* `selected_repository_ids` - (Optional) An array of repository IDs for which immutable releases enforcement should be applied. Only valid when `enforced_repositories` = `selected`.
+
+## Import
+
+This resource can be imported using the name of the GitHub organization:
+
+```
+$ terraform import github_organization_immutable_releases.example github_organization_name
+```


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

See also https://github.com/integrations/terraform-provider-github/issues/2746 issue.

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- Unable to manage immutable releases settings at the organization level.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Add `github_organization_immutable_releases` resource to manage immutable releases settings at the organization level. Supports `enforced_repositories` policy (all, none, selected) with optional `selected_repository_ids` for granular control.

Include acceptance tests and website documentation.

Fix https://github.com/integrations/terraform-provider-github/issues/3228.

### Pull request checklist

- [ ] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----
