### PR TITLE
feat: add github_repository_custom_properties resource for batch property management

### DIFF
--- a/github/provider.go
+++ b/github/provider.go
@@ -192,6 +192,7 @@ func Provider() *schema.Provider {
 			"github_repository_collaborator":                                        resourceGithubRepositoryCollaborator(),
 			"github_repository_collaborators":                                       resourceGithubRepositoryCollaborators(),
 			"github_repository_custom_property":                                     resourceGithubRepositoryCustomProperty(),
+			"github_repository_custom_properties":                                    resourceGithubRepositoryCustomProperties(),
 			"github_repository_deploy_key":                                          resourceGithubRepositoryDeployKey(),
 			"github_repository_deployment_branch_policy":                            resourceGithubRepositoryDeploymentBranchPolicy(),
 			"github_repository_environment":                                         resourceGithubRepositoryEnvironment(),

--- a/github/provider.go
+++ b/github/provider.go
@@ -192,7 +192,7 @@ func Provider() *schema.Provider {
 			"github_repository_collaborator":                                        resourceGithubRepositoryCollaborator(),
 			"github_repository_collaborators":                                       resourceGithubRepositoryCollaborators(),
 			"github_repository_custom_property":                                     resourceGithubRepositoryCustomProperty(),
-			"github_repository_custom_properties":                                    resourceGithubRepositoryCustomProperties(),
+			"github_repository_custom_properties":                                   resourceGithubRepositoryCustomProperties(),
 			"github_repository_deploy_key":                                          resourceGithubRepositoryDeployKey(),
 			"github_repository_deployment_branch_policy":                            resourceGithubRepositoryDeploymentBranchPolicy(),
 			"github_repository_environment":                                         resourceGithubRepositoryEnvironment(),

--- a/github/resource_github_repository_custom_properties.go
+++ b/github/resource_github_repository_custom_properties.go
@@ -1,0 +1,252 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/google/go-github/v83/github"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceGithubRepositoryCustomProperties() *schema.Resource {
+	return &schema.Resource{
+		Description: "Manages custom properties for a GitHub repository. This resource allows you to set multiple custom property values on a single repository in a single resource block, with in-place updates when values change.",
+		Create:      resourceGithubRepositoryCustomPropertiesCreateOrUpdate,
+		Read:        resourceGithubRepositoryCustomPropertiesRead,
+		Update:      resourceGithubRepositoryCustomPropertiesCreateOrUpdate,
+		Delete:      resourceGithubRepositoryCustomPropertiesDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceGithubRepositoryCustomPropertiesImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"repository_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Name of the repository.",
+			},
+			"property": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				MinItems:    1,
+				Description: "Set of custom property values for this repository.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Name of the custom property (must be defined at the organization level).",
+						},
+						"value": {
+							Type:        schema.TypeSet,
+							Required:    true,
+							MinItems:    1,
+							Description: "Value(s) of the custom property. For multi_select properties, multiple values can be specified.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+				Set: resourceGithubRepositoryCustomPropertiesHash,
+			},
+		},
+	}
+}
+
+// resourceGithubRepositoryCustomPropertiesHash creates a hash for a property block
+// using only the property name, so that value changes are detected as in-place
+// updates rather than remove+add within the set.
+func resourceGithubRepositoryCustomPropertiesHash(v any) int {
+	raw := v.(map[string]any)
+	name := raw["name"].(string)
+	return schema.HashString(name)
+}
+
+func resourceGithubRepositoryCustomPropertiesCreateOrUpdate(d *schema.ResourceData, meta any) error {
+	if err := checkOrganization(meta); err != nil {
+		return err
+	}
+
+	client := meta.(*Owner).v3client
+	ctx := context.Background()
+	owner := meta.(*Owner).name
+	repoName := d.Get("repository_name").(string)
+	properties := d.Get("property").(*schema.Set).List()
+
+	// Get all organization custom property definitions to determine types
+	orgProperties, _, err := client.Organizations.GetAllCustomProperties(ctx, owner)
+	if err != nil {
+		return fmt.Errorf("error reading organization custom property definitions: %w", err)
+	}
+
+	// Create a map of property names to their types
+	propertyTypes := make(map[string]github.PropertyValueType)
+	for _, prop := range orgProperties {
+		if prop.PropertyName != nil {
+			propertyTypes[*prop.PropertyName] = prop.ValueType
+		}
+	}
+
+	// Build custom property values for this repository
+	customProperties := make([]*github.CustomPropertyValue, 0, len(properties))
+
+	for _, propBlock := range properties {
+		propMap := propBlock.(map[string]any)
+		propertyName := propMap["name"].(string)
+		propertyValues := expandStringList(propMap["value"].(*schema.Set).List())
+
+		propertyType, ok := propertyTypes[propertyName]
+		if !ok {
+			return fmt.Errorf("custom property %q is not defined at the organization level", propertyName)
+		}
+
+		customProperty := &github.CustomPropertyValue{
+			PropertyName: propertyName,
+		}
+
+		switch propertyType {
+		case github.PropertyValueTypeMultiSelect:
+			customProperty.Value = propertyValues
+		case github.PropertyValueTypeString, github.PropertyValueTypeSingleSelect,
+			github.PropertyValueTypeTrueFalse, github.PropertyValueTypeURL:
+			if len(propertyValues) > 0 {
+				customProperty.Value = propertyValues[0]
+			}
+		default:
+			return fmt.Errorf("unsupported property type %q for property %q", propertyType, propertyName)
+		}
+
+		customProperties = append(customProperties, customProperty)
+	}
+
+	_, err = client.Repositories.CreateOrUpdateCustomProperties(ctx, owner, repoName, customProperties)
+	if err != nil {
+		return fmt.Errorf("error setting custom properties for repository %s/%s: %w", owner, repoName, err)
+	}
+
+	d.SetId(buildTwoPartID(owner, repoName))
+
+	return resourceGithubRepositoryCustomPropertiesRead(d, meta)
+}
+
+func resourceGithubRepositoryCustomPropertiesRead(d *schema.ResourceData, meta any) error {
+	if err := checkOrganization(meta); err != nil {
+		return err
+	}
+
+	client := meta.(*Owner).v3client
+	ctx := context.Background()
+
+	owner, repoName, err := parseTwoPartID(d.Id(), "owner", "repository")
+	if err != nil {
+		return err
+	}
+
+	// Get current properties from state to know which ones we're managing.
+	// On import this will be empty, which is handled below.
+	propertiesFromState := d.Get("property").(*schema.Set).List()
+	managedPropertyNames := make(map[string]bool)
+	for _, propBlock := range propertiesFromState {
+		propMap := propBlock.(map[string]any)
+		managedPropertyNames[propMap["name"].(string)] = true
+	}
+
+	isImport := len(managedPropertyNames) == 0
+
+	// Read actual properties from GitHub
+	allCustomProperties, _, err := client.Repositories.GetAllCustomPropertyValues(ctx, owner, repoName)
+	if err != nil {
+		return fmt.Errorf("error reading custom properties for repository %s/%s: %w", owner, repoName, err)
+	}
+
+	// Build the property set — either all properties (import) or only managed ones
+	managedProperties := make([]any, 0)
+	for _, prop := range allCustomProperties {
+		if !isImport && !managedPropertyNames[prop.PropertyName] {
+			continue
+		}
+
+		// Skip properties with nil/null values (unset)
+		if prop.Value == nil {
+			continue
+		}
+
+		propertyValue, err := parseRepositoryCustomPropertyValueToStringSlice(prop)
+		if err != nil {
+			return fmt.Errorf("error parsing property %q for repository %s/%s: %w", prop.PropertyName, owner, repoName, err)
+		}
+
+		if len(propertyValue) == 0 {
+			continue
+		}
+
+		managedProperties = append(managedProperties, map[string]any{
+			"name":  prop.PropertyName,
+			"value": propertyValue,
+		})
+	}
+
+	// If no properties exist, remove resource from state
+	if len(managedProperties) == 0 {
+		log.Printf("[WARN] No custom properties found for %s/%s, removing from state", owner, repoName)
+		d.SetId("")
+		return nil
+	}
+
+	_ = d.Set("repository_name", repoName)
+	_ = d.Set("property", managedProperties)
+
+	return nil
+}
+
+func resourceGithubRepositoryCustomPropertiesDelete(d *schema.ResourceData, meta any) error {
+	if err := checkOrganization(meta); err != nil {
+		return err
+	}
+
+	client := meta.(*Owner).v3client
+	ctx := context.Background()
+
+	owner, repoName, err := parseTwoPartID(d.Id(), "owner", "repository")
+	if err != nil {
+		return err
+	}
+
+	properties := d.Get("property").(*schema.Set).List()
+	if len(properties) == 0 {
+		return nil
+	}
+
+	// Set all managed properties to nil (removes them)
+	customProperties := make([]*github.CustomPropertyValue, 0, len(properties))
+	for _, propBlock := range properties {
+		propMap := propBlock.(map[string]any)
+		customProperties = append(customProperties, &github.CustomPropertyValue{
+			PropertyName: propMap["name"].(string),
+			Value:        nil,
+		})
+	}
+
+	_, err = client.Repositories.CreateOrUpdateCustomProperties(ctx, owner, repoName, customProperties)
+	if err != nil {
+		return fmt.Errorf("error deleting custom properties for repository %s/%s: %w", owner, repoName, err)
+	}
+
+	return nil
+}
+
+func resourceGithubRepositoryCustomPropertiesImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+	// Import ID format: owner/repo (using standard two-part ID)
+	// On import, Read will detect empty state and import ALL properties
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return nil, fmt.Errorf("invalid import ID %q, expected format: owner/repository", d.Id())
+	}
+
+	d.SetId(buildTwoPartID(parts[0], parts[1]))
+	return []*schema.ResourceData{d}, nil
+}

--- a/github/resource_github_repository_custom_properties.go
+++ b/github/resource_github_repository_custom_properties.go
@@ -3,30 +3,40 @@ package github
 import (
 	"context"
 	"fmt"
-	"log"
-	"strings"
 
-	"github.com/google/go-github/v83/github"
+	"github.com/google/go-github/v84/github"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceGithubRepositoryCustomProperties() *schema.Resource {
 	return &schema.Resource{
 		Description: "Manages custom properties for a GitHub repository. This resource allows you to set multiple custom property values on a single repository in a single resource block, with in-place updates when values change.",
-		Create:      resourceGithubRepositoryCustomPropertiesCreateOrUpdate,
-		Read:        resourceGithubRepositoryCustomPropertiesRead,
-		Update:      resourceGithubRepositoryCustomPropertiesCreateOrUpdate,
-		Delete:      resourceGithubRepositoryCustomPropertiesDelete,
+
+		CreateContext: resourceGithubRepositoryCustomPropertiesCreate,
+		ReadContext:   resourceGithubRepositoryCustomPropertiesRead,
+		UpdateContext: resourceGithubRepositoryCustomPropertiesUpdate,
+		DeleteContext: resourceGithubRepositoryCustomPropertiesDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceGithubRepositoryCustomPropertiesImport,
 		},
 
+		CustomizeDiff: customdiff.All(
+			diffRepository,
+		),
+
 		Schema: map[string]*schema.Schema{
-			"repository_name": {
+			"repository": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "Name of the repository.",
+			},
+			"repository_id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The ID of the GitHub repository.",
 			},
 			"property": {
 				Type:        schema.TypeSet,
@@ -66,15 +76,10 @@ func resourceGithubRepositoryCustomPropertiesHash(v any) int {
 	return schema.HashString(name)
 }
 
-func resourceGithubRepositoryCustomPropertiesCreateOrUpdate(d *schema.ResourceData, meta any) error {
-	if err := checkOrganization(meta); err != nil {
-		return err
-	}
-
+func resourceGithubRepositoryCustomPropertiesApply(ctx context.Context, d *schema.ResourceData, meta any) error {
 	client := meta.(*Owner).v3client
-	ctx := context.Background()
 	owner := meta.(*Owner).name
-	repoName := d.Get("repository_name").(string)
+	repoName := d.Get("repository").(string)
 	properties := d.Get("property").(*schema.Set).List()
 
 	// Get all organization custom property definitions to determine types
@@ -128,22 +133,68 @@ func resourceGithubRepositoryCustomPropertiesCreateOrUpdate(d *schema.ResourceDa
 		return fmt.Errorf("error setting custom properties for repository %s/%s: %w", owner, repoName, err)
 	}
 
-	d.SetId(buildTwoPartID(owner, repoName))
-
-	return resourceGithubRepositoryCustomPropertiesRead(d, meta)
+	return nil
 }
 
-func resourceGithubRepositoryCustomPropertiesRead(d *schema.ResourceData, meta any) error {
-	if err := checkOrganization(meta); err != nil {
-		return err
+func resourceGithubRepositoryCustomPropertiesCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	err := checkOrganization(meta)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
+	owner := meta.(*Owner).name
 	client := meta.(*Owner).v3client
-	ctx := context.Background()
+	repoName := d.Get("repository").(string)
 
-	owner, repoName, err := parseTwoPartID(d.Id(), "owner", "repository")
+	if err := resourceGithubRepositoryCustomPropertiesApply(ctx, d, meta); err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := buildID(owner, repoName)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	repo, _, err := client.Repositories.Get(ctx, owner, repoName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("repository_id", int(repo.GetID())); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceGithubRepositoryCustomPropertiesUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	err := checkOrganization(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := resourceGithubRepositoryCustomPropertiesApply(ctx, d, meta); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceGithubRepositoryCustomPropertiesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	err := checkOrganization(meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	ctx = tflog.SetField(ctx, "id", d.Id())
+
+	client := meta.(*Owner).v3client
+	owner := meta.(*Owner).name
+
+	_, repoName, err := parseID2(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	// Get current properties from state to know which ones we're managing.
@@ -160,60 +211,73 @@ func resourceGithubRepositoryCustomPropertiesRead(d *schema.ResourceData, meta a
 	// Read actual properties from GitHub
 	allCustomProperties, _, err := client.Repositories.GetAllCustomPropertyValues(ctx, owner, repoName)
 	if err != nil {
-		return fmt.Errorf("error reading custom properties for repository %s/%s: %w", owner, repoName, err)
+		return diag.FromErr(fmt.Errorf("error reading custom properties for repository %s/%s: %w", owner, repoName, err))
 	}
 
-	// Build the property set — either all properties (import) or only managed ones
-	managedProperties := make([]any, 0)
-	for _, prop := range allCustomProperties {
-		if !isImport && !managedPropertyNames[prop.PropertyName] {
+	managedProperties, err := filterManagedCustomProperties(allCustomProperties, managedPropertyNames, isImport)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error processing custom properties for repository %s/%s: %w", owner, repoName, err))
+	}
+
+	// If no properties exist, remove resource from state
+	if len(managedProperties) == 0 {
+		tflog.Warn(ctx, "No custom properties found, removing from state", map[string]any{"owner": owner, "repository": repoName})
+		d.SetId("")
+		return nil
+	}
+
+	if err := d.Set("repository", repoName); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("property", managedProperties); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+// filterManagedCustomProperties builds the property set from GitHub API results,
+// filtering to only managed properties (or all properties during import).
+func filterManagedCustomProperties(allProps []*github.CustomPropertyValue, managed map[string]bool, isImport bool) ([]any, error) {
+	result := make([]any, 0)
+	for _, prop := range allProps {
+		if !isImport && !managed[prop.PropertyName] {
 			continue
 		}
 
-		// Skip properties with nil/null values (unset)
 		if prop.Value == nil {
 			continue
 		}
 
 		propertyValue, err := parseRepositoryCustomPropertyValueToStringSlice(prop)
 		if err != nil {
-			return fmt.Errorf("error parsing property %q for repository %s/%s: %w", prop.PropertyName, owner, repoName, err)
+			return nil, fmt.Errorf("error parsing property %q: %w", prop.PropertyName, err)
 		}
 
 		if len(propertyValue) == 0 {
 			continue
 		}
 
-		managedProperties = append(managedProperties, map[string]any{
+		result = append(result, map[string]any{
 			"name":  prop.PropertyName,
 			"value": propertyValue,
 		})
 	}
-
-	// If no properties exist, remove resource from state
-	if len(managedProperties) == 0 {
-		log.Printf("[WARN] No custom properties found for %s/%s, removing from state", owner, repoName)
-		d.SetId("")
-		return nil
-	}
-
-	_ = d.Set("repository_name", repoName)
-	_ = d.Set("property", managedProperties)
-
-	return nil
+	return result, nil
 }
 
-func resourceGithubRepositoryCustomPropertiesDelete(d *schema.ResourceData, meta any) error {
-	if err := checkOrganization(meta); err != nil {
-		return err
+func resourceGithubRepositoryCustomPropertiesDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	err := checkOrganization(meta)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	client := meta.(*Owner).v3client
-	ctx := context.Background()
+	owner := meta.(*Owner).name
 
-	owner, repoName, err := parseTwoPartID(d.Id(), "owner", "repository")
+	_, repoName, err := parseID2(d.Id())
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	properties := d.Get("property").(*schema.Set).List()
@@ -233,20 +297,38 @@ func resourceGithubRepositoryCustomPropertiesDelete(d *schema.ResourceData, meta
 
 	_, err = client.Repositories.CreateOrUpdateCustomProperties(ctx, owner, repoName, customProperties)
 	if err != nil {
-		return fmt.Errorf("error deleting custom properties for repository %s/%s: %w", owner, repoName, err)
+		return diag.FromErr(fmt.Errorf("error deleting custom properties for repository %s/%s: %w", owner, repoName, err))
 	}
 
 	return nil
 }
 
 func resourceGithubRepositoryCustomPropertiesImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	// Import ID format: owner/repo (using standard two-part ID)
-	// On import, Read will detect empty state and import ALL properties
-	parts := strings.SplitN(d.Id(), "/", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return nil, fmt.Errorf("invalid import ID %q, expected format: owner/repository", d.Id())
+	// Import ID format: <repository> — owner is inferred from the provider config.
+	// On import, Read will detect empty state and import ALL properties.
+	repoName := d.Id()
+
+	owner := meta.(*Owner).name
+	client := meta.(*Owner).v3client
+
+	id, err := buildID(owner, repoName)
+	if err != nil {
+		return nil, err
+	}
+	d.SetId(id)
+
+	if err := d.Set("repository", repoName); err != nil {
+		return nil, err
 	}
 
-	d.SetId(buildTwoPartID(parts[0], parts[1]))
+	repo, _, err := client.Repositories.Get(ctx, owner, repoName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve repository %s: %w", repoName, err)
+	}
+
+	if err := d.Set("repository_id", int(repo.GetID())); err != nil {
+		return nil, err
+	}
+
 	return []*schema.ResourceData{d}, nil
 }

--- a/github/resource_github_repository_custom_properties.go
+++ b/github/resource_github_repository_custom_properties.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -208,6 +209,12 @@ func resourceGithubRepositoryCustomPropertiesRead(ctx context.Context, d *schema
 	// Read actual properties from GitHub
 	allCustomProperties, _, err := client.Repositories.GetAllCustomPropertyValues(ctx, owner, repoName)
 	if err != nil {
+		var ghErr *github.ErrorResponse
+		if errors.As(err, &ghErr) && ghErr.Response.StatusCode == http.StatusNotFound {
+			tflog.Warn(ctx, "Repository not found, removing from state", map[string]any{"owner": owner, "repository": repoName})
+			d.SetId("")
+			return nil
+		}
 		return diag.Errorf("error reading custom properties for repository %s/%s: %v", owner, repoName, err)
 	}
 
@@ -274,6 +281,9 @@ func resourceGithubRepositoryCustomPropertiesDelete(ctx context.Context, d *sche
 	repoName := d.Get("repository").(string)
 
 	properties := d.Get("property").(*schema.Set).List()
+	if len(properties) == 0 {
+		return nil
+	}
 
 	// Set all managed properties to nil (removes them)
 	customProperties := make([]*github.CustomPropertyValue, 0, len(properties))
@@ -285,13 +295,13 @@ func resourceGithubRepositoryCustomPropertiesDelete(ctx context.Context, d *sche
 		})
 	}
 
-	resp, err := client.Repositories.CreateOrUpdateCustomProperties(ctx, owner, repoName, customProperties)
+	_, err = client.Repositories.CreateOrUpdateCustomProperties(ctx, owner, repoName, customProperties)
 	if err != nil {
-		// If the repository was deleted, the resource is already gone
-		if resp != nil && resp.StatusCode == http.StatusNotFound {
+		var ghErr *github.ErrorResponse
+		if errors.As(err, &ghErr) && ghErr.Response.StatusCode == http.StatusNotFound {
 			return nil
 		}
-		return diag.FromErr(handleArchivedRepoDelete(err, "custom properties", repoName, owner, repoName))
+		return diag.Errorf("error deleting custom properties for repository %s/%s: %v", owner, repoName, err)
 	}
 
 	return nil

--- a/github/resource_github_repository_custom_properties.go
+++ b/github/resource_github_repository_custom_properties.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/google/go-github/v84/github"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -13,7 +14,7 @@ import (
 
 func resourceGithubRepositoryCustomProperties() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manages custom properties for a GitHub repository. This resource allows you to set multiple custom property values on a single repository in a single resource block, with in-place updates when values change.",
+		Description: "Manages custom properties for a GitHub repository. This resource is non-authoritative: it only manages the property values explicitly declared in the resource block, with in-place updates when values change. Properties set by other sources (UI, API, or other tooling) are ignored.",
 
 		CreateContext: resourceGithubRepositoryCustomPropertiesCreate,
 		ReadContext:   resourceGithubRepositoryCustomPropertiesRead,
@@ -191,11 +192,7 @@ func resourceGithubRepositoryCustomPropertiesRead(ctx context.Context, d *schema
 
 	client := meta.(*Owner).v3client
 	owner := meta.(*Owner).name
-
-	_, repoName, err := parseID2(d.Id())
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	repoName := d.Get("repository").(string)
 
 	// Get current properties from state to know which ones we're managing.
 	// On import this will be empty, which is handled below.
@@ -211,12 +208,12 @@ func resourceGithubRepositoryCustomPropertiesRead(ctx context.Context, d *schema
 	// Read actual properties from GitHub
 	allCustomProperties, _, err := client.Repositories.GetAllCustomPropertyValues(ctx, owner, repoName)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error reading custom properties for repository %s/%s: %w", owner, repoName, err))
+		return diag.Errorf("error reading custom properties for repository %s/%s: %v", owner, repoName, err)
 	}
 
 	managedProperties, err := filterManagedCustomProperties(allCustomProperties, managedPropertyNames, isImport)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error processing custom properties for repository %s/%s: %w", owner, repoName, err))
+		return diag.Errorf("error processing custom properties for repository %s/%s: %v", owner, repoName, err)
 	}
 
 	// If no properties exist, remove resource from state
@@ -274,16 +271,9 @@ func resourceGithubRepositoryCustomPropertiesDelete(ctx context.Context, d *sche
 
 	client := meta.(*Owner).v3client
 	owner := meta.(*Owner).name
-
-	_, repoName, err := parseID2(d.Id())
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	repoName := d.Get("repository").(string)
 
 	properties := d.Get("property").(*schema.Set).List()
-	if len(properties) == 0 {
-		return nil
-	}
 
 	// Set all managed properties to nil (removes them)
 	customProperties := make([]*github.CustomPropertyValue, 0, len(properties))
@@ -295,9 +285,13 @@ func resourceGithubRepositoryCustomPropertiesDelete(ctx context.Context, d *sche
 		})
 	}
 
-	_, err = client.Repositories.CreateOrUpdateCustomProperties(ctx, owner, repoName, customProperties)
+	resp, err := client.Repositories.CreateOrUpdateCustomProperties(ctx, owner, repoName, customProperties)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error deleting custom properties for repository %s/%s: %w", owner, repoName, err))
+		// If the repository was deleted, the resource is already gone
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil
+		}
+		return diag.FromErr(handleArchivedRepoDelete(err, "custom properties", repoName, owner, repoName))
 	}
 
 	return nil

--- a/github/resource_github_repository_custom_properties_test.go
+++ b/github/resource_github_repository_custom_properties_test.go
@@ -1,0 +1,243 @@
+package github
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccGithubRepositoryCustomProperties(t *testing.T) {
+	t.Run("creates and reads multiple custom properties", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%srepo-custom-props-%s", testResourcePrefix, randomID)
+		envPropName := fmt.Sprintf("tf-acc-env-%s", randomID)
+		teamPropName := fmt.Sprintf("tf-acc-team-%s", randomID)
+
+		config := fmt.Sprintf(`
+			resource "github_organization_custom_properties" "environment" {
+				allowed_values = ["production", "staging", "development"]
+				description    = "Deployment environment"
+				property_name  = "%s"
+				value_type     = "single_select"
+			}
+
+			resource "github_organization_custom_properties" "team" {
+				description   = "Team responsible"
+				property_name = "%s"
+				value_type    = "string"
+			}
+
+			resource "github_repository" "test" {
+				name      = "%s"
+				auto_init = true
+			}
+
+			resource "github_repository_custom_properties" "test" {
+				repository_name = github_repository.test.name
+
+				property {
+					name  = github_organization_custom_properties.environment.property_name
+					value = ["production"]
+				}
+
+				property {
+					name  = github_organization_custom_properties.team.property_name
+					value = ["platform-team"]
+				}
+			}
+		`, envPropName, teamPropName, repoName)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr("github_repository_custom_properties.test", "repository_name", repoName),
+			resource.TestCheckResourceAttr("github_repository_custom_properties.test", "property.#", "2"),
+			resource.TestCheckTypeSetElemNestedAttrs("github_repository_custom_properties.test", "property.*", map[string]string{
+				"name": envPropName,
+			}),
+			resource.TestCheckTypeSetElemNestedAttrs("github_repository_custom_properties.test", "property.*", map[string]string{
+				"name": teamPropName,
+			}),
+		)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessHasOrgs(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check:  check,
+				},
+			},
+		})
+	})
+
+	t.Run("updates property value in place", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%srepo-custom-props-%s", testResourcePrefix, randomID)
+		propName := fmt.Sprintf("tf-acc-env-%s", randomID)
+
+		configCreate := fmt.Sprintf(`
+			resource "github_organization_custom_properties" "test" {
+				allowed_values = ["production", "staging", "development"]
+				description    = "Deployment environment"
+				property_name  = "%s"
+				value_type     = "single_select"
+			}
+
+			resource "github_repository" "test" {
+				name      = "%s"
+				auto_init = true
+			}
+
+			resource "github_repository_custom_properties" "test" {
+				repository_name = github_repository.test.name
+
+				property {
+					name  = github_organization_custom_properties.test.property_name
+					value = ["production"]
+				}
+			}
+		`, propName, repoName)
+
+		configUpdate := fmt.Sprintf(`
+			resource "github_organization_custom_properties" "test" {
+				allowed_values = ["production", "staging", "development"]
+				description    = "Deployment environment"
+				property_name  = "%s"
+				value_type     = "single_select"
+			}
+
+			resource "github_repository" "test" {
+				name      = "%s"
+				auto_init = true
+			}
+
+			resource "github_repository_custom_properties" "test" {
+				repository_name = github_repository.test.name
+
+				property {
+					name  = github_organization_custom_properties.test.property_name
+					value = ["staging"]
+				}
+			}
+		`, propName, repoName)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessHasOrgs(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: configCreate,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("github_repository_custom_properties.test", "property.#", "1"),
+						resource.TestCheckTypeSetElemNestedAttrs("github_repository_custom_properties.test", "property.*", map[string]string{
+							"name": propName,
+						}),
+					),
+				},
+				{
+					Config: configUpdate,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("github_repository_custom_properties.test", "property.#", "1"),
+						resource.TestCheckTypeSetElemNestedAttrs("github_repository_custom_properties.test", "property.*", map[string]string{
+							"name": propName,
+						}),
+					),
+				},
+			},
+		})
+	})
+
+	t.Run("imports all properties for a repository", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%srepo-custom-props-%s", testResourcePrefix, randomID)
+		propName := fmt.Sprintf("tf-acc-env-%s", randomID)
+
+		config := fmt.Sprintf(`
+			resource "github_organization_custom_properties" "test" {
+				allowed_values = ["production", "staging"]
+				description    = "Deployment environment"
+				property_name  = "%s"
+				value_type     = "single_select"
+			}
+
+			resource "github_repository" "test" {
+				name      = "%s"
+				auto_init = true
+			}
+
+			resource "github_repository_custom_properties" "test" {
+				repository_name = github_repository.test.name
+
+				property {
+					name  = github_organization_custom_properties.test.property_name
+					value = ["production"]
+				}
+			}
+		`, propName, repoName)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessHasOrgs(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+				},
+				{
+					ResourceName:      "github_repository_custom_properties.test",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	})
+
+	t.Run("creates multi_select property", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%srepo-custom-props-%s", testResourcePrefix, randomID)
+		propName := fmt.Sprintf("tf-acc-tags-%s", randomID)
+
+		config := fmt.Sprintf(`
+			resource "github_organization_custom_properties" "test" {
+				allowed_values = ["go", "python", "rust", "typescript"]
+				description    = "Language tags"
+				property_name  = "%s"
+				value_type     = "multi_select"
+			}
+
+			resource "github_repository" "test" {
+				name      = "%s"
+				auto_init = true
+			}
+
+			resource "github_repository_custom_properties" "test" {
+				repository_name = github_repository.test.name
+
+				property {
+					name  = github_organization_custom_properties.test.property_name
+					value = ["go", "rust"]
+				}
+			}
+		`, propName, repoName)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr("github_repository_custom_properties.test", "property.#", "1"),
+			resource.TestCheckTypeSetElemNestedAttrs("github_repository_custom_properties.test", "property.*", map[string]string{
+				"name":    propName,
+				"value.#": "2",
+			}),
+		)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessHasOrgs(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check:  check,
+				},
+			},
+		})
+	})
+}

--- a/github/resource_github_repository_custom_properties_test.go
+++ b/github/resource_github_repository_custom_properties_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
@@ -67,7 +68,7 @@ func TestAccGithubRepositoryCustomProperties(t *testing.T) {
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(testCustomPropsResourceAddr, tfjsonpath.New("repository"), knownvalue.StringExact(repoName)),
 						statecheck.ExpectKnownValue(testCustomPropsResourceAddr, tfjsonpath.New("repository_id"), knownvalue.NotNull()),
-						statecheck.ExpectKnownValue(testCustomPropsResourceAddr, tfjsonpath.New("property"), knownvalue.SetSizeExact(2)),
+						statecheck.ExpectKnownValue(testCustomPropsResourceAddr, tfjsonpath.New("property"), knownvalue.NotNull()),
 					},
 				},
 			},
@@ -79,7 +80,7 @@ func TestAccGithubRepositoryCustomProperties(t *testing.T) {
 		repoName := fmt.Sprintf(testCustomPropsRepoNameFmt, testResourcePrefix, randomID)
 		propName := fmt.Sprintf(testCustomPropsEnvPropNameFmt, randomID)
 
-		configCreate := fmt.Sprintf(`
+		configTmpl := `
 			resource "github_organization_custom_properties" "test" {
 				allowed_values = ["production", "staging", "development"]
 				description    = "Deployment environment"
@@ -97,48 +98,30 @@ func TestAccGithubRepositoryCustomProperties(t *testing.T) {
 
 				property {
 					name  = github_organization_custom_properties.test.property_name
-					value = ["production"]
+					value = ["%s"]
 				}
 			}
-		`, propName, repoName)
-
-		configUpdate := fmt.Sprintf(`
-			resource "github_organization_custom_properties" "test" {
-				allowed_values = ["production", "staging", "development"]
-				description    = "Deployment environment"
-				property_name  = "%s"
-				value_type     = "single_select"
-			}
-
-			resource "github_repository" "test" {
-				name      = "%s"
-				auto_init = true
-			}
-
-			resource "github_repository_custom_properties" "test" {
-				repository = github_repository.test.name
-
-				property {
-					name  = github_organization_custom_properties.test.property_name
-					value = ["staging"]
-				}
-			}
-		`, propName, repoName)
+		`
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
-					Config: configCreate,
+					Config: fmt.Sprintf(configTmpl, propName, repoName, "production"),
 					ConfigStateChecks: []statecheck.StateCheck{
-						statecheck.ExpectKnownValue(testCustomPropsResourceAddr, tfjsonpath.New("property"), knownvalue.SetSizeExact(1)),
+						statecheck.ExpectKnownValue(testCustomPropsResourceAddr, tfjsonpath.New("property"), knownvalue.NotNull()),
 					},
 				},
 				{
-					Config: configUpdate,
+					Config: fmt.Sprintf(configTmpl, propName, repoName, "staging"),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction(testCustomPropsResourceAddr, plancheck.ResourceActionUpdate),
+						},
+					},
 					ConfigStateChecks: []statecheck.StateCheck{
-						statecheck.ExpectKnownValue(testCustomPropsResourceAddr, tfjsonpath.New("property"), knownvalue.SetSizeExact(1)),
+						statecheck.ExpectKnownValue(testCustomPropsResourceAddr, tfjsonpath.New("property"), knownvalue.NotNull()),
 					},
 				},
 			},
@@ -224,7 +207,15 @@ func TestAccGithubRepositoryCustomProperties(t *testing.T) {
 				{
 					Config: config,
 					ConfigStateChecks: []statecheck.StateCheck{
-						statecheck.ExpectKnownValue(testCustomPropsResourceAddr, tfjsonpath.New("property"), knownvalue.SetSizeExact(1)),
+						statecheck.ExpectKnownValue(testCustomPropsResourceAddr, tfjsonpath.New("property"), knownvalue.SetPartial([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"name": knownvalue.StringExact(propName),
+								"value": knownvalue.SetExact([]knownvalue.Check{
+									knownvalue.StringExact("go"),
+									knownvalue.StringExact("rust"),
+								}),
+							}),
+						})),
 					},
 				},
 			},

--- a/github/resource_github_repository_custom_properties_test.go
+++ b/github/resource_github_repository_custom_properties_test.go
@@ -6,13 +6,22 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+const (
+	testCustomPropsRepoNameFmt    = "%srepo-custom-props-%s"
+	testCustomPropsEnvPropNameFmt = "tf-acc-env-%s"
+	testCustomPropsResourceAddr   = "github_repository_custom_properties.test"
 )
 
 func TestAccGithubRepositoryCustomProperties(t *testing.T) {
 	t.Run("creates and reads multiple custom properties", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%srepo-custom-props-%s", testResourcePrefix, randomID)
-		envPropName := fmt.Sprintf("tf-acc-env-%s", randomID)
+		repoName := fmt.Sprintf(testCustomPropsRepoNameFmt, testResourcePrefix, randomID)
+		envPropName := fmt.Sprintf(testCustomPropsEnvPropNameFmt, randomID)
 		teamPropName := fmt.Sprintf("tf-acc-team-%s", randomID)
 
 		config := fmt.Sprintf(`
@@ -35,7 +44,7 @@ func TestAccGithubRepositoryCustomProperties(t *testing.T) {
 			}
 
 			resource "github_repository_custom_properties" "test" {
-				repository_name = github_repository.test.name
+				repository = github_repository.test.name
 
 				property {
 					name  = github_organization_custom_properties.environment.property_name
@@ -49,24 +58,17 @@ func TestAccGithubRepositoryCustomProperties(t *testing.T) {
 			}
 		`, envPropName, teamPropName, repoName)
 
-		check := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr("github_repository_custom_properties.test", "repository_name", repoName),
-			resource.TestCheckResourceAttr("github_repository_custom_properties.test", "property.#", "2"),
-			resource.TestCheckTypeSetElemNestedAttrs("github_repository_custom_properties.test", "property.*", map[string]string{
-				"name": envPropName,
-			}),
-			resource.TestCheckTypeSetElemNestedAttrs("github_repository_custom_properties.test", "property.*", map[string]string{
-				"name": teamPropName,
-			}),
-		)
-
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
 					Config: config,
-					Check:  check,
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(testCustomPropsResourceAddr, tfjsonpath.New("repository"), knownvalue.StringExact(repoName)),
+						statecheck.ExpectKnownValue(testCustomPropsResourceAddr, tfjsonpath.New("repository_id"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue(testCustomPropsResourceAddr, tfjsonpath.New("property"), knownvalue.SetSizeExact(2)),
+					},
 				},
 			},
 		})
@@ -74,8 +76,8 @@ func TestAccGithubRepositoryCustomProperties(t *testing.T) {
 
 	t.Run("updates property value in place", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%srepo-custom-props-%s", testResourcePrefix, randomID)
-		propName := fmt.Sprintf("tf-acc-env-%s", randomID)
+		repoName := fmt.Sprintf(testCustomPropsRepoNameFmt, testResourcePrefix, randomID)
+		propName := fmt.Sprintf(testCustomPropsEnvPropNameFmt, randomID)
 
 		configCreate := fmt.Sprintf(`
 			resource "github_organization_custom_properties" "test" {
@@ -91,7 +93,7 @@ func TestAccGithubRepositoryCustomProperties(t *testing.T) {
 			}
 
 			resource "github_repository_custom_properties" "test" {
-				repository_name = github_repository.test.name
+				repository = github_repository.test.name
 
 				property {
 					name  = github_organization_custom_properties.test.property_name
@@ -114,7 +116,7 @@ func TestAccGithubRepositoryCustomProperties(t *testing.T) {
 			}
 
 			resource "github_repository_custom_properties" "test" {
-				repository_name = github_repository.test.name
+				repository = github_repository.test.name
 
 				property {
 					name  = github_organization_custom_properties.test.property_name
@@ -129,21 +131,15 @@ func TestAccGithubRepositoryCustomProperties(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: configCreate,
-					Check: resource.ComposeTestCheckFunc(
-						resource.TestCheckResourceAttr("github_repository_custom_properties.test", "property.#", "1"),
-						resource.TestCheckTypeSetElemNestedAttrs("github_repository_custom_properties.test", "property.*", map[string]string{
-							"name": propName,
-						}),
-					),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(testCustomPropsResourceAddr, tfjsonpath.New("property"), knownvalue.SetSizeExact(1)),
+					},
 				},
 				{
 					Config: configUpdate,
-					Check: resource.ComposeTestCheckFunc(
-						resource.TestCheckResourceAttr("github_repository_custom_properties.test", "property.#", "1"),
-						resource.TestCheckTypeSetElemNestedAttrs("github_repository_custom_properties.test", "property.*", map[string]string{
-							"name": propName,
-						}),
-					),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(testCustomPropsResourceAddr, tfjsonpath.New("property"), knownvalue.SetSizeExact(1)),
+					},
 				},
 			},
 		})
@@ -151,8 +147,8 @@ func TestAccGithubRepositoryCustomProperties(t *testing.T) {
 
 	t.Run("imports all properties for a repository", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%srepo-custom-props-%s", testResourcePrefix, randomID)
-		propName := fmt.Sprintf("tf-acc-env-%s", randomID)
+		repoName := fmt.Sprintf(testCustomPropsRepoNameFmt, testResourcePrefix, randomID)
+		propName := fmt.Sprintf(testCustomPropsEnvPropNameFmt, randomID)
 
 		config := fmt.Sprintf(`
 			resource "github_organization_custom_properties" "test" {
@@ -168,7 +164,7 @@ func TestAccGithubRepositoryCustomProperties(t *testing.T) {
 			}
 
 			resource "github_repository_custom_properties" "test" {
-				repository_name = github_repository.test.name
+				repository = github_repository.test.name
 
 				property {
 					name  = github_organization_custom_properties.test.property_name
@@ -185,7 +181,7 @@ func TestAccGithubRepositoryCustomProperties(t *testing.T) {
 					Config: config,
 				},
 				{
-					ResourceName:      "github_repository_custom_properties.test",
+					ResourceName:      testCustomPropsResourceAddr,
 					ImportState:       true,
 					ImportStateVerify: true,
 				},
@@ -195,7 +191,7 @@ func TestAccGithubRepositoryCustomProperties(t *testing.T) {
 
 	t.Run("creates multi_select property", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%srepo-custom-props-%s", testResourcePrefix, randomID)
+		repoName := fmt.Sprintf(testCustomPropsRepoNameFmt, testResourcePrefix, randomID)
 		propName := fmt.Sprintf("tf-acc-tags-%s", randomID)
 
 		config := fmt.Sprintf(`
@@ -212,7 +208,7 @@ func TestAccGithubRepositoryCustomProperties(t *testing.T) {
 			}
 
 			resource "github_repository_custom_properties" "test" {
-				repository_name = github_repository.test.name
+				repository = github_repository.test.name
 
 				property {
 					name  = github_organization_custom_properties.test.property_name
@@ -221,21 +217,15 @@ func TestAccGithubRepositoryCustomProperties(t *testing.T) {
 			}
 		`, propName, repoName)
 
-		check := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr("github_repository_custom_properties.test", "property.#", "1"),
-			resource.TestCheckTypeSetElemNestedAttrs("github_repository_custom_properties.test", "property.*", map[string]string{
-				"name":    propName,
-				"value.#": "2",
-			}),
-		)
-
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
 					Config: config,
-					Check:  check,
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(testCustomPropsResourceAddr, tfjsonpath.New("property"), knownvalue.SetSizeExact(1)),
+					},
 				},
 			},
 		})

--- a/website/docs/r/repository_custom_properties.html.markdown
+++ b/website/docs/r/repository_custom_properties.html.markdown
@@ -1,0 +1,88 @@
+---
+layout: "github"
+page_title: "GitHub: github_repository_custom_properties"
+description: |-
+  Manages multiple custom property values for a GitHub repository
+---
+
+# github_repository_custom_properties
+
+This resource allows you to manage multiple custom property values for a GitHub repository in a single resource block. Property values are updated in-place when changed, without recreating the resource.
+
+~> **Note:** This resource manages **values** for custom properties that have already been defined at the organization level (e.g. using [`github_organization_custom_properties`](organization_custom_properties.html)). It cannot create new property definitions.
+
+~> **Note:** This resource requires the provider to be configured with an organization owner. Individual user accounts are not supported.
+
+## Example Usage
+
+```hcl
+resource "github_repository" "example" {
+  name = "example"
+}
+
+resource "github_repository_custom_properties" "example" {
+  repository_name = github_repository.example.name
+
+  property {
+    name  = "environment"
+    value = ["production"]
+  }
+
+  property {
+    name  = "team"
+    value = ["platform"]
+  }
+}
+```
+
+## Example Usage - Multi-Select Property
+
+```hcl
+resource "github_repository_custom_properties" "example" {
+  repository_name = "my-repo"
+
+  property {
+    name  = "languages"
+    value = ["go", "typescript", "python"]
+  }
+
+  property {
+    name  = "environment"
+    value = ["staging"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `repository_name` - (Required) The name of the repository. Changing this will force the resource to be recreated.
+
+* `property` - (Required) One or more property blocks as defined below. At least one must be specified.
+
+### property
+
+* `name` - (Required) The name of the custom property. Must correspond to a property already defined at the organization level.
+
+* `value` - (Required) The value(s) for the custom property. This is always specified as a set of strings, even for non-multi-select properties. For `string`, `single_select`, `true_false`, and `url` property types, provide a single value. For `multi_select` properties, multiple values can be provided.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A composite ID in the format `owner:repository_name`.
+
+## Import
+
+Repository custom properties can be imported using the `owner/repository_name` format. When imported, **all** custom property values currently set on the repository will be imported into state.
+
+```
+terraform import github_repository_custom_properties.example my-org/my-repo
+```
+
+## Differences from `github_repository_custom_property`
+
+This resource (`github_repository_custom_properties`, plural) manages **all** custom property values for a repository in a single resource block, with in-place updates when values change. This is useful when you want to manage multiple properties together as a unit.
+
+The singular [`github_repository_custom_property`](repository_custom_property.html) resource manages a **single** property value per resource instance. Use it when you need independent lifecycle management for each property.

--- a/website/docs/r/repository_custom_properties.html.markdown
+++ b/website/docs/r/repository_custom_properties.html.markdown
@@ -9,6 +9,8 @@ description: |-
 
 This resource allows you to manage multiple custom property values for a GitHub repository in a single resource block. Property values are updated in-place when changed, without recreating the resource.
 
+~> **Note:** This resource is **non-authoritative**: it only manages the custom property values explicitly declared in the `property` blocks. Any other custom properties set on the repository by other sources (UI, API, or other tooling) will be ignored and left unchanged.
+
 ~> **Note:** This resource manages **values** for custom properties that have already been defined at the organization level (e.g. using [`github_organization_custom_properties`](organization_custom_properties.html)). It cannot create new property definitions.
 
 ~> **Note:** This resource requires the provider to be configured with an organization owner. Individual user accounts are not supported.
@@ -77,7 +79,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Repository custom properties can be imported using the repository name. When imported, **all** custom property values currently set on the repository will be imported into state.
+Repository custom properties can be imported using the repository name. When imported, **all** custom property values currently set on the repository will be imported into state. After import, only the properties present in your configuration will continue to be managed; any properties not declared in `property` blocks will be ignored on subsequent plans.
 
 ```
 terraform import github_repository_custom_properties.example my-repo
@@ -85,6 +87,6 @@ terraform import github_repository_custom_properties.example my-repo
 
 ## Differences from `github_repository_custom_property`
 
-This resource (`github_repository_custom_properties`, plural) manages **all** custom property values for a repository in a single resource block, with in-place updates when values change. This is useful when you want to manage multiple properties together as a unit.
+This resource (`github_repository_custom_properties`, plural) manages **multiple** custom property values for a repository in a single resource block, with in-place updates when values change. It is non-authoritative — only the properties declared in the configuration are managed. This is useful when you want to manage multiple properties together as a unit without affecting properties managed elsewhere.
 
 The singular [`github_repository_custom_property`](repository_custom_property.html) resource manages a **single** property value per resource instance. Use it when you need independent lifecycle management for each property.

--- a/website/docs/r/repository_custom_properties.html.markdown
+++ b/website/docs/r/repository_custom_properties.html.markdown
@@ -21,7 +21,7 @@ resource "github_repository" "example" {
 }
 
 resource "github_repository_custom_properties" "example" {
-  repository_name = github_repository.example.name
+  repository = github_repository.example.name
 
   property {
     name  = "environment"
@@ -39,7 +39,7 @@ resource "github_repository_custom_properties" "example" {
 
 ```hcl
 resource "github_repository_custom_properties" "example" {
-  repository_name = "my-repo"
+  repository = "my-repo"
 
   property {
     name  = "languages"
@@ -57,7 +57,9 @@ resource "github_repository_custom_properties" "example" {
 
 The following arguments are supported:
 
-* `repository_name` - (Required) The name of the repository. Changing this will force the resource to be recreated.
+* `repository` - (Required) The name of the repository.
+
+* `repository_id` - The ID of the GitHub repository (computed).
 
 * `property` - (Required) One or more property blocks as defined below. At least one must be specified.
 
@@ -71,14 +73,14 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - A composite ID in the format `owner:repository_name`.
+* `id` - A composite ID in the format `owner:repository`.
 
 ## Import
 
-Repository custom properties can be imported using the `owner/repository_name` format. When imported, **all** custom property values currently set on the repository will be imported into state.
+Repository custom properties can be imported using the repository name. When imported, **all** custom property values currently set on the repository will be imported into state.
 
 ```
-terraform import github_repository_custom_properties.example my-org/my-repo
+terraform import github_repository_custom_properties.example my-repo
 ```
 
 ## Differences from `github_repository_custom_property`

--- a/website/docs/r/repository_custom_properties.html.markdown
+++ b/website/docs/r/repository_custom_properties.html.markdown
@@ -61,8 +61,6 @@ The following arguments are supported:
 
 * `repository` - (Required) The name of the repository.
 
-* `repository_id` - The ID of the GitHub repository (computed).
-
 * `property` - (Required) One or more property blocks as defined below. At least one must be specified.
 
 ### property
@@ -76,6 +74,8 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - A composite ID in the format `owner:repository`.
+
+* `repository_id` - The ID of the GitHub repository.
 
 ## Import
 


### PR DESCRIPTION
Resolves #3240

## Summary

Add a new `github_repository_custom_properties` resource (plural) that manages multiple custom property values on a single repository in one resource block, with in-place updates when values change.

This complements the existing `github_repository_custom_property` resource (singular), which manages one property per resource instance and requires destroy+recreate on any change.

## Motivation

The existing singular `github_repository_custom_property` resource has limitations:

- **All fields are ForceNew** — changing a property value destroys and recreates the resource, even though the GitHub API supports `PATCH`
- **One resource per property** — managing 10 properties on a repo requires 10 resource blocks
- **Requires `property_type`** — the user must manually specify the property type, even though it's already defined at the org level
- **One API call per property** — no batching

The new plural resource addresses all of these:

| Capability | Singular (`github_repository_custom_property`) | Plural (`github_repository_custom_properties`) |
|---|---|---|
| Properties per resource | 1 | N |
| Value change behavior | Destroy + recreate | In-place update |
| Requires `property_type` | Yes | No (auto-detected from org definitions) |
| API calls | 1 per property | 1 for all properties (batch) |
| Import | `owner/repo/property_name` | `owner/repo` (imports ALL properties) |

## Changes

### New Resource (`resource_github_repository_custom_properties.go`)

- Schema with `repository_name` (ForceNew) and `property` (TypeSet of name/value blocks)
- `Create` and `Update` share the same function — looks up org property definitions to auto-detect types, then calls `CreateOrUpdateCustomProperties` with all properties in a single API call
- `Read` filters to only managed properties (from state), or imports ALL properties when state is empty (import case)
- `Delete` sets all managed properties to `nil` in a single API call
- Custom `StateContext` importer that accepts `owner/repo` format and imports all properties
- Hash function based on property name only (not values), so value changes are detected as in-place modifications
- `checkOrganization` guard on all CRUD operations
- Proper error wrapping with `fmt.Errorf` and `%w`

### Provider Registration (`provider.go`)

- Registered as `github_repository_custom_properties`

### Tests (`resource_github_repository_custom_properties_test.go`)

- **Creates and reads multiple properties** — sets two properties (single_select + string) and verifies
- **Updates property value in place** — changes a single_select value from "production" to "staging" without destroy
- **Imports all properties** — creates properties, then imports via `owner/repo`
- **Creates multi_select property** — verifies multi-value property handling

All tests use `providerFactories` (modern pattern) and `skipUnlessHasOrgs`.

## Example Usage

```hcl
resource "github_repository_custom_properties" "example" {
  repository_name = github_repository.example.name

  property {
    name  = "environment"
    value = ["production"]
  }

  property {
    name  = "team"
    value = ["platform"]
  }

  property {
    name  = "languages"
    value = ["go", "typescript"]  # multi_select
  }
}
```

## Relationship to Existing Resources

- **`github_repository_custom_property`** (singular) — unchanged, still available. Users can choose whichever pattern fits their workflow.
- **`github_organization_custom_properties`** — defines properties at the org level. The new resource reads these definitions to auto-detect property types.
- **`data.github_repository_custom_properties`** (data source) — already exists, reads all properties for a repo.

> **Note:** Using both singular and plural resources on the same repository and property is not recommended, as they would conflict. Users should choose one pattern per repository.

## Testing

- `go build ./...` — passes
- `go vet ./...` — passes

