### PR TITLE
Validate autolink prefix

### DIFF
--- a/github/resource_github_repository_autolink_reference.go
+++ b/github/resource_github_repository_autolink_reference.go
@@ -65,10 +65,11 @@ func resourceGithubRepositoryAutolinkReference() *schema.Resource {
 				Description: "The repository name",
 			},
 			"key_prefix": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: "This prefix appended by a number will generate a link any time it is found in an issue, pull request, or commit",
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				Description:      "This prefix appended by a number will generate a link any time it is found in an issue, pull request, or commit",
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringMatch(regexp.MustCompile(`^.*?[^\d]$`), "must not end with a number")),
 			},
 			"target_url_template": {
 				Type:             schema.TypeString,

--- a/github/resource_github_repository_autolink_reference.go
+++ b/github/resource_github_repository_autolink_reference.go
@@ -69,7 +69,7 @@ func resourceGithubRepositoryAutolinkReference() *schema.Resource {
 				Required:         true,
 				ForceNew:         true,
 				Description:      "This prefix appended by a number will generate a link any time it is found in an issue, pull request, or commit",
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringMatch(regexp.MustCompile(`^.*?[^\d]$`), "must not end with a number")),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringMatch(regexp.MustCompile(`[^\d]$`), "must not end with a number")),
 			},
 			"target_url_template": {
 				Type:             schema.TypeString,

--- a/github/resource_github_repository_autolink_reference_test.go
+++ b/github/resource_github_repository_autolink_reference_test.go
@@ -268,6 +268,35 @@ func TestAccGithubRepositoryAutolinkReference(t *testing.T) {
 		})
 	})
 
+	t.Run("errors when key_prefix ends with a number", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%srepo-autolink-%s", testResourcePrefix, randomID)
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name        = "%s"
+				description = "Test autolink creation"
+			}
+
+			resource "github_repository_autolink_reference" "autolink_invalid" {
+				repository = github_repository.test.name
+
+				key_prefix          = "TEST-1"
+				target_url_template = "https://example.com/TEST-<num>"
+			}
+		`, repoName)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:      config,
+					ExpectError: regexp.MustCompile(`must not end with a number`),
+				},
+			},
+		})
+	})
+
 	t.Run("deletes repository autolink reference without error", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		repoName := fmt.Sprintf("%srepo-autolink-%s", testResourcePrefix, randomID)


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #3176

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

-  Before there was no validation that the key_prefix had to not end in a number but from issue #3176 if it did then you'd receive this error on apply but not on plan: 

> 422 Validation Failed [{Resource:KeyLink Field:key_prefix Code:custom Message:key_prefix must not end with a number} {Resource:KeyLink Field:key_prefix Code:custom Message:key_prefix must only contain letters, numbers, or .-_+=:/#}]


### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Terraform plan will throw an error during plan due to a failure to validate key_prefix

### Pull request checklist

- [ ] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
