### PR TITLE
fix: correct typo in retry_delay_ms configuration

### DIFF
--- a/github/provider.go
+++ b/github/provider.go
@@ -441,7 +441,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 		}
 		log.Printf("[DEBUG] Setting read_delay_ms to %d", readDelay)
 
-		retryDelay := d.Get("read_delay_ms").(int)
+		retryDelay := d.Get("retry_delay_ms").(int)
 		if retryDelay < 0 {
 			return nil, diag.Errorf("retry_delay_ms must be greater than or equal to 0ms")
 		}


### PR DESCRIPTION
I think this is just a typo or a copy-paste bug.

----

### Before the change?

- `read_delay_ms` is read into `retryDelay` instead of the corresponding `rerty_delay_ms`. 

### After the change?

- `retryDelay` is set to the `rerty_delay_ms` argument

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [x] No

----
