### PR TITLE
[MAINT] Use `gofmt` to rewrite unwanted patterns

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,6 +70,8 @@ formatters:
           replacement: skipUnlessEnterprise(t)
         - pattern: parseTwoPartID(a, b, c)
           replacement: parseID2(a)
+        - pattern: parseThreePartID(a, b, c, d)
+          replacement: parseID3(a)
     gofumpt:
       module-path: github.com/integrations/terraform-provider-github
       extra-rules: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,6 +66,8 @@ formatters:
           replacement: any
         - pattern: a[b:len(a)]
           replacement: a[b:]
+        - pattern: skipUnlessMode(t, enterprise)
+          replacement: skipUnlessEnterprise(t)
     gofumpt:
       module-path: github.com/integrations/terraform-provider-github
       extra-rules: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,6 +76,9 @@ formatters:
           replacement: diag.Errorf(a)
         - pattern: wrapErrors([]error{fmt.Errorf(a, b)})
           replacement: diag.Errorf(a, b)
+        - pattern: diag.FromErr(fmt.Errorf(a))
+          replacement: diag.Errorf(a)
+
     gofumpt:
       module-path: github.com/integrations/terraform-provider-github
       extra-rules: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,6 +76,8 @@ formatters:
           replacement: diag.Errorf(a)
         - pattern: wrapErrors([]error{fmt.Errorf(a, b)})
           replacement: diag.Errorf(a, b)
+        - pattern: wrapErrors([]error{err})
+          replacement: diag.FromErr(err)
         - pattern: diag.FromErr(fmt.Errorf(a))
           replacement: diag.Errorf(a)
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,6 +68,8 @@ formatters:
           replacement: a[b:]
         - pattern: skipUnlessMode(t, enterprise)
           replacement: skipUnlessEnterprise(t)
+        - pattern: parseTwoPartID(a, b, c)
+          replacement: parseID2(a)
     gofumpt:
       module-path: github.com/integrations/terraform-provider-github
       extra-rules: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,6 +72,10 @@ formatters:
           replacement: parseID2(a)
         - pattern: parseThreePartID(a, b, c, d)
           replacement: parseID3(a)
+        - pattern: wrapErrors([]error{fmt.Errorf(a)})
+          replacement: diag.Errorf(a)
+        - pattern: wrapErrors([]error{fmt.Errorf(a, b)})
+          replacement: diag.Errorf(a, b)
     gofumpt:
       module-path: github.com/integrations/terraform-provider-github
       extra-rules: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,8 +64,6 @@ formatters:
       rewrite-rules:
         - pattern: interface{}
           replacement: any
-        - pattern: a[b:len(a)]
-          replacement: a[b:]
         - pattern: skipUnlessMode(t, enterprise)
           replacement: skipUnlessEnterprise(t)
         - pattern: parseTwoPartID(a, b, c)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,8 +62,6 @@ formatters:
     gofmt:
       simplify: true
       rewrite-rules:
-        - pattern: interface{}
-          replacement: any
         - pattern: skipUnlessMode(t, enterprise)
           replacement: skipUnlessEnterprise(t)
         - pattern: parseTwoPartID(a, b, c)

--- a/github/acc_test.go
+++ b/github/acc_test.go
@@ -318,7 +318,7 @@ func skipUnlessHasAppInstallations(t *testing.T) {
 		t.Fatalf("failed to get test meta: %s", err)
 	}
 
-	installations, _, err := meta.v3client.Organizations.ListInstallations(context.Background(), meta.name, nil)
+	installations, _, err := meta.v3client.Organizations.ListInstallations(t.Context(), meta.name, nil)
 	if err != nil {
 		t.Fatalf("failed to list app installations: %s", err)
 	}

--- a/github/config_test.go
+++ b/github/config_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -171,7 +170,7 @@ func TestAccConfigMeta(t *testing.T) {
 			t.Fatalf("failed to return meta without error: %s", err.Error())
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		client := meta.(*Owner).v3client
 		_, _, err = client.Meta.Get(ctx)
 		if err != nil {
@@ -191,7 +190,7 @@ func TestAccConfigMeta(t *testing.T) {
 			t.Fatalf("failed to return meta without error: %s", err.Error())
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		client := meta.(*Owner).v3client
 		_, _, err = client.Meta.Get(ctx)
 		if err != nil {
@@ -216,7 +215,7 @@ func TestAccConfigMeta(t *testing.T) {
 			t.Fatalf("failed to return meta without error: %s", err.Error())
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		client := meta.(*Owner).v3client
 		_, _, err = client.Meta.Get(ctx)
 		if err != nil {
@@ -242,7 +241,7 @@ func TestAccConfigMeta(t *testing.T) {
 				GitHubServicesSha githubv4.String
 			}
 		}
-		err = client.Query(context.Background(), &query, nil)
+		err = client.Query(t.Context(), &query, nil)
 		if err != nil {
 			t.Fatalf("failed to validate returned client without error: %s", err.Error())
 		}
@@ -261,7 +260,7 @@ func TestAccConfigMeta(t *testing.T) {
 			t.Fatalf("failed to return meta without error: %s", err.Error())
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		client := meta.(*Owner).v3client
 		_, _, err = client.Organizations.Get(ctx, testAccConf.owner)
 		if err != nil {
@@ -292,7 +291,7 @@ func TestAccConfigMeta(t *testing.T) {
 		variables := map[string]any{
 			"login": githubv4.String(testAccConf.owner),
 		}
-		err = client.Query(context.Background(), &query, variables)
+		err = client.Query(t.Context(), &query, variables)
 		if err != nil {
 			t.Fatalf("failed to validate returned client without error: %s", err.Error())
 		}

--- a/github/data_source_github_enterprise_test.go
+++ b/github/data_source_github_enterprise_test.go
@@ -24,7 +24,7 @@ func TestAccGithubEnterpriseDataSource(t *testing.T) {
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { skipUnlessMode(t, enterprise) },
+		PreCheck:          func() { skipUnlessEnterprise(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/github/data_source_github_organization_external_identities_test.go
+++ b/github/data_source_github_organization_external_identities_test.go
@@ -17,7 +17,7 @@ func TestAccGithubOrganizationExternalIdentities(t *testing.T) {
 		)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{

--- a/github/data_source_github_organization_repository_role_test.go
+++ b/github/data_source_github_organization_repository_role_test.go
@@ -32,7 +32,7 @@ func TestAccGithubOrganizationRepositoryRoleDataSource(t *testing.T) {
 		`, roleName)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{

--- a/github/data_source_github_organization_repository_roles_test.go
+++ b/github/data_source_github_organization_repository_roles_test.go
@@ -45,7 +45,7 @@ func TestAccDataSourceGithubOrganizationRepositoryRoles(t *testing.T) {
 		`
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{

--- a/github/data_source_github_organization_team_sync_groups_test.go
+++ b/github/data_source_github_organization_team_sync_groups_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestAccGithubOrganizationTeamSyncGroupsDataSource_existing(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { skipUnlessMode(t, enterprise) },
+		PreCheck:          func() { skipUnlessEnterprise(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/github/data_source_github_user_external_identity_test.go
+++ b/github/data_source_github_user_external_identity_test.go
@@ -18,7 +18,7 @@ func TestAccGithubUserExternalIdentity(t *testing.T) {
 		)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{

--- a/github/provider.go
+++ b/github/provider.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/url"
 	"os"
@@ -444,13 +443,13 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 
 		retryDelay := d.Get("read_delay_ms").(int)
 		if retryDelay < 0 {
-			return nil, diag.FromErr(fmt.Errorf("retry_delay_ms must be greater than or equal to 0ms"))
+			return nil, diag.Errorf("retry_delay_ms must be greater than or equal to 0ms")
 		}
 		log.Printf("[DEBUG] Setting retry_delay_ms to %d", retryDelay)
 
 		maxRetries := d.Get("max_retries").(int)
 		if maxRetries < 0 {
-			return nil, diag.FromErr(fmt.Errorf("max_retries must be greater than or equal to 0"))
+			return nil, diag.Errorf("max_retries must be greater than or equal to 0")
 		}
 		log.Printf("[DEBUG] Setting max_retries to %d", maxRetries)
 		retryableErrors := make(map[int]bool)
@@ -469,7 +468,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 
 		_maxPerPage := d.Get("max_per_page").(int)
 		if _maxPerPage <= 0 {
-			return nil, diag.FromErr(fmt.Errorf("max_per_page must be greater than than 0"))
+			return nil, diag.Errorf("max_per_page must be greater than than 0")
 		}
 		log.Printf("[DEBUG] Setting max_per_page to %d", _maxPerPage)
 		maxPerPage = _maxPerPage

--- a/github/provider.go
+++ b/github/provider.go
@@ -418,7 +418,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 
 			appToken, err := GenerateOAuthTokenFromApp(baseURL.JoinPath(apiPath), appID, appInstallationID, appPemFile)
 			if err != nil {
-				return nil, wrapErrors([]error{err})
+				return nil, diag.FromErr(err)
 			}
 
 			token = appToken
@@ -493,7 +493,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 
 		meta, err := config.Meta()
 		if err != nil {
-			return nil, wrapErrors([]error{err})
+			return nil, diag.FromErr(err)
 		}
 
 		return meta, nil

--- a/github/provider.go
+++ b/github/provider.go
@@ -390,13 +390,13 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 			if v, ok := appAuthAttr["id"].(string); ok && v != "" {
 				appID = v
 			} else {
-				return nil, wrapErrors([]error{fmt.Errorf("app_auth.id must be set and contain a non-empty value")})
+				return nil, diag.Errorf("app_auth.id must be set and contain a non-empty value")
 			}
 
 			if v, ok := appAuthAttr["installation_id"].(string); ok && v != "" {
 				appInstallationID = v
 			} else {
-				return nil, wrapErrors([]error{fmt.Errorf("app_auth.installation_id must be set and contain a non-empty value")})
+				return nil, diag.Errorf("app_auth.installation_id must be set and contain a non-empty value")
 			}
 
 			if v, ok := appAuthAttr["pem_file"].(string); ok && v != "" {
@@ -409,7 +409,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 				// actual new line character before decoding.
 				appPemFile = strings.ReplaceAll(v, `\n`, "\n")
 			} else {
-				return nil, wrapErrors([]error{fmt.Errorf("app_auth.pem_file must be set and contain a non-empty value")})
+				return nil, diag.Errorf("app_auth.pem_file must be set and contain a non-empty value")
 			}
 
 			apiPath := ""
@@ -432,13 +432,13 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 
 		writeDelay := d.Get("write_delay_ms").(int)
 		if writeDelay <= 0 {
-			return nil, wrapErrors([]error{fmt.Errorf("write_delay_ms must be greater than 0ms")})
+			return nil, diag.Errorf("write_delay_ms must be greater than 0ms")
 		}
 		log.Printf("[INFO] Setting write_delay_ms to %d", writeDelay)
 
 		readDelay := d.Get("read_delay_ms").(int)
 		if readDelay < 0 {
-			return nil, wrapErrors([]error{fmt.Errorf("read_delay_ms must be greater than or equal to 0ms")})
+			return nil, diag.Errorf("read_delay_ms must be greater than or equal to 0ms")
 		}
 		log.Printf("[DEBUG] Setting read_delay_ms to %d", readDelay)
 

--- a/github/provider.go
+++ b/github/provider.go
@@ -468,7 +468,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 
 		_maxPerPage := d.Get("max_per_page").(int)
 		if _maxPerPage <= 0 {
-			return nil, diag.Errorf("max_per_page must be greater than than 0")
+			return nil, diag.Errorf("max_per_page must be greater than 0")
 		}
 		log.Printf("[DEBUG] Setting max_per_page to %d", _maxPerPage)
 		maxPerPage = _maxPerPage

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -167,7 +167,7 @@ data "github_ip_ranges" "test" {}
 
 		resource.Test(t, resource.TestCase{
 			PreCheck: func() {
-				skipUnlessMode(t, enterprise)
+				skipUnlessEnterprise(t)
 				if testAccConf.baseURL.Host != "api.github.com" {
 					t.Skip("Skipping as test mode is not GHES")
 				}

--- a/github/resource_github_actions_environment_secret_migration_test.go
+++ b/github/resource_github_actions_environment_secret_migration_test.go
@@ -40,7 +40,7 @@ package github
 // 		t.Run(d.testName, func(t *testing.T) {
 // 			t.Parallel()
 
-// 			got, err := resourceGithubActionsEnvironmentSecretStateUpgradeV0(context.Background(), d.rawState, nil)
+// 			got, err := resourceGithubActionsEnvironmentSecretStateUpgradeV0(t.Context(), d.rawState, nil)
 // 			if (err != nil) != d.shouldError {
 // 				t.Fatalf("unexpected error state")
 // 			}

--- a/github/resource_github_actions_environment_secret_test.go
+++ b/github/resource_github_actions_environment_secret_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"encoding/base64"
 	"fmt"
 	"net/url"
@@ -342,7 +341,7 @@ resource "github_actions_environment_secret" "test" {
 						}
 						client := meta.v3client
 						owner := meta.name
-						ctx := context.Background()
+						ctx := t.Context()
 
 						escapedEnvName := url.PathEscape(envName)
 
@@ -438,7 +437,7 @@ resource "github_actions_environment_secret" "test" {
 						}
 						client := meta.v3client
 						owner := meta.name
-						ctx := context.Background()
+						ctx := t.Context()
 
 						escapedEnvName := url.PathEscape(envName)
 

--- a/github/resource_github_actions_environment_variable_migration_test.go
+++ b/github/resource_github_actions_environment_variable_migration_test.go
@@ -40,7 +40,7 @@ package github
 // 		t.Run(d.testName, func(t *testing.T) {
 // 			t.Parallel()
 
-// 			got, err := resourceGithubActionsEnvironmentVariableStateUpgradeV0(context.Background(), d.rawState, nil)
+// 			got, err := resourceGithubActionsEnvironmentVariableStateUpgradeV0(t.Context(), d.rawState, nil)
 // 			if (err != nil) != d.shouldError {
 // 				t.Fatalf("unexpected error state")
 // 			}

--- a/github/resource_github_actions_environment_variable_test.go
+++ b/github/resource_github_actions_environment_variable_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -434,7 +433,7 @@ resource "github_actions_environment_variable" "test" {
 						}
 						client := meta.v3client
 						owner := meta.name
-						ctx := context.Background()
+						ctx := t.Context()
 
 						_, err = client.Actions.CreateEnvVariable(ctx, owner, repoName, url.PathEscape(envName), &github.ActionsVariable{
 							Name:  varName,
@@ -453,7 +452,7 @@ resource "github_actions_environment_variable" "test" {
 						}
 						client := meta.v3client
 						owner := meta.name
-						ctx := context.Background()
+						ctx := t.Context()
 
 						_, err = client.Actions.DeleteEnvVariable(ctx, owner, repoName, url.PathEscape(envName), varName)
 						return err

--- a/github/resource_github_actions_organization_secret_migration_test.go
+++ b/github/resource_github_actions_organization_secret_migration_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"reflect"
 	"testing"
 )
@@ -62,7 +61,7 @@ func Test_resourceGithubActionsOrganizationSecretStateUpgradeV0(t *testing.T) {
 		t.Run(d.testName, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := resourceGithubActionsOrganizationSecretStateUpgradeV0(context.Background(), d.rawState, nil)
+			got, err := resourceGithubActionsOrganizationSecretStateUpgradeV0(t.Context(), d.rawState, nil)
 			if (err != nil) != d.shouldError {
 				t.Fatalf("unexpected error state")
 			}

--- a/github/resource_github_actions_organization_secret_test.go
+++ b/github/resource_github_actions_organization_secret_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"encoding/base64"
 	"fmt"
 	"regexp"
@@ -455,7 +454,7 @@ resource "github_actions_organization_secret" "test" {
 						}
 						client := meta.v3client
 						owner := meta.name
-						ctx := context.Background()
+						ctx := t.Context()
 
 						keyID, _, err := getOrganizationPublicKeyDetails(ctx, meta)
 						if err != nil {
@@ -533,7 +532,7 @@ resource "github_actions_organization_secret" "test" {
 						}
 						client := meta.v3client
 						owner := meta.name
-						ctx := context.Background()
+						ctx := t.Context()
 
 						keyID, _, err := getOrganizationPublicKeyDetails(ctx, meta)
 						if err != nil {

--- a/github/resource_github_actions_organization_variable_test.go
+++ b/github/resource_github_actions_organization_variable_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"regexp"
 	"testing"
@@ -356,7 +355,7 @@ resource "github_actions_organization_variable" "test" {
 						}
 						client := meta.v3client
 						owner := meta.name
-						ctx := context.Background()
+						ctx := t.Context()
 
 						_, err = client.Actions.CreateOrgVariable(ctx, owner, &github.ActionsVariable{
 							Name:       varName,
@@ -376,7 +375,7 @@ resource "github_actions_organization_variable" "test" {
 						}
 						client := meta.v3client
 						owner := meta.name
-						ctx := context.Background()
+						ctx := t.Context()
 
 						_, err = client.Actions.DeleteOrgVariable(ctx, owner, varName)
 						return err

--- a/github/resource_github_actions_secret_migration_test.go
+++ b/github/resource_github_actions_secret_migration_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"reflect"
 	"testing"
 )
@@ -62,7 +61,7 @@ func Test_resourceGithubActionsSecretStateUpgradeV0(t *testing.T) {
 		t.Run(d.testName, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := resourceGithubActionsSecretStateUpgradeV0(context.Background(), d.rawState, nil)
+			got, err := resourceGithubActionsSecretStateUpgradeV0(t.Context(), d.rawState, nil)
 			if (err != nil) != d.shouldError {
 				t.Fatalf("unexpected error state")
 			}
@@ -111,7 +110,7 @@ func Test_resourceGithubActionsSecretStateUpgradeV0(t *testing.T) {
 // 		t.Run(d.testName, func(t *testing.T) {
 // 			t.Parallel()
 
-// 			got, err := resourceGithubActionsSecretStateUpgradeV1(context.Background(), d.rawState, nil)
+// 			got, err := resourceGithubActionsSecretStateUpgradeV1(t.Context(), d.rawState, nil)
 // 			if (err != nil) != d.shouldError {
 // 				t.Fatalf("unexpected error state")
 // 			}

--- a/github/resource_github_actions_secret_test.go
+++ b/github/resource_github_actions_secret_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"encoding/base64"
 	"fmt"
 	"testing"
@@ -251,7 +250,7 @@ resource "github_actions_secret" "test" {
 						}
 						client := meta.v3client
 						owner := meta.name
-						ctx := context.Background()
+						ctx := t.Context()
 
 						keyID, _, err := getPublicKeyDetails(ctx, meta, repoName)
 						if err != nil {
@@ -332,7 +331,7 @@ resource "github_actions_secret" "test" {
 						}
 						client := meta.v3client
 						owner := meta.name
-						ctx := context.Background()
+						ctx := t.Context()
 
 						keyID, _, err := getPublicKeyDetails(ctx, meta, repoName)
 						if err != nil {

--- a/github/resource_github_actions_variable_migration_test.go
+++ b/github/resource_github_actions_variable_migration_test.go
@@ -38,7 +38,7 @@ package github
 // 		t.Run(d.testName, func(t *testing.T) {
 // 			t.Parallel()
 
-// 			got, err := resourceGithubActionsVariableStateUpgradeV0(context.Background(), d.rawState, nil)
+// 			got, err := resourceGithubActionsVariableStateUpgradeV0(t.Context(), d.rawState, nil)
 // 			if (err != nil) != d.shouldError {
 // 				t.Fatalf("unexpected error state")
 // 			}

--- a/github/resource_github_actions_variable_test.go
+++ b/github/resource_github_actions_variable_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"fmt"
 	"regexp"
 	"testing"
@@ -318,7 +317,7 @@ resource "github_actions_variable" "test" {
 						}
 						client := meta.v3client
 						owner := meta.name
-						ctx := context.Background()
+						ctx := t.Context()
 
 						_, err = client.Actions.CreateRepoVariable(ctx, owner, repoName, &github.ActionsVariable{
 							Name:  varName,
@@ -337,7 +336,7 @@ resource "github_actions_variable" "test" {
 						}
 						client := meta.v3client
 						owner := meta.name
-						ctx := context.Background()
+						ctx := t.Context()
 
 						_, err = client.Actions.DeleteRepoVariable(ctx, owner, repoName, varName)
 						return err

--- a/github/resource_github_app_installation_repository.go
+++ b/github/resource_github_app_installation_repository.go
@@ -67,7 +67,7 @@ func resourceGithubAppInstallationRepositoryCreate(d *schema.ResourceData, meta 
 
 func resourceGithubAppInstallationRepositoryRead(d *schema.ResourceData, meta any) error {
 	client := meta.(*Owner).v3client
-	installationIDString, repoName, err := parseTwoPartID(d.Id(), "installation_id", "repository")
+	installationIDString, repoName, err := parseID2(d.Id())
 	if err != nil {
 		return err
 	}

--- a/github/resource_github_branch.go
+++ b/github/resource_github_branch.go
@@ -122,7 +122,7 @@ func resourceGithubBranchRead(d *schema.ResourceData, meta any) error {
 
 	client := meta.(*Owner).v3client
 	orgName := meta.(*Owner).name
-	repoName, branchName, err := parseTwoPartID(d.Id(), "repository", "branch")
+	repoName, branchName, err := parseID2(d.Id())
 	if err != nil {
 		return err
 	}
@@ -171,7 +171,7 @@ func resourceGithubBranchDelete(d *schema.ResourceData, meta any) error {
 
 	client := meta.(*Owner).v3client
 	orgName := meta.(*Owner).name
-	repoName, branchName, err := parseTwoPartID(d.Id(), "repository", "branch")
+	repoName, branchName, err := parseID2(d.Id())
 	if err != nil {
 		return err
 	}
@@ -194,7 +194,7 @@ func resourceGithubBranchUpdate(d *schema.ResourceData, meta any) error {
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 	client := meta.(*Owner).v3client
 	orgName := meta.(*Owner).name
-	repoName, oldBranchName, err := parseTwoPartID(d.Id(), "repository", "branch")
+	repoName, oldBranchName, err := parseID2(d.Id())
 	if err != nil {
 		return err
 	}
@@ -210,14 +210,14 @@ func resourceGithubBranchUpdate(d *schema.ResourceData, meta any) error {
 }
 
 func resourceGithubBranchImport(d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	repoName, branchName, err := parseTwoPartID(d.Id(), "repository", "branch")
+	repoName, branchName, err := parseID2(d.Id())
 	if err != nil {
 		return nil, err
 	}
 
 	sourceBranch := "main"
 	if strings.Contains(branchName, ":") {
-		branchName, sourceBranch, err = parseTwoPartID(branchName, "branch", "source_branch")
+		branchName, sourceBranch, err = parseID2(branchName)
 		if err != nil {
 			return nil, err
 		}

--- a/github/resource_github_branch_protection.go
+++ b/github/resource_github_branch_protection.go
@@ -461,7 +461,7 @@ func resourceGithubBranchProtectionDelete(d *schema.ResourceData, meta any) erro
 }
 
 func resourceGithubBranchProtectionImport(d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	repoName, pattern, err := parseTwoPartID(d.Id(), "repository", "pattern")
+	repoName, pattern, err := parseID2(d.Id())
 	if err != nil {
 		return nil, err
 	}

--- a/github/resource_github_branch_protection_migration_test.go
+++ b/github/resource_github_branch_protection_migration_test.go
@@ -1,0 +1,35 @@
+package github
+
+import (
+	"reflect"
+	"testing"
+)
+
+func testGithubBranchProtectionStateDataV1() map[string]any {
+	return map[string]any{
+		"blocks_creations":  true,
+		"push_restrictions": [...]string{"/example-user"},
+	}
+}
+
+func testGithubBranchProtectionStateDataV2() map[string]any {
+	restrictions := []any{map[string]any{
+		"blocks_creations": true,
+		"push_allowances":  [...]string{"/example-user"},
+	}}
+	return map[string]any{
+		"restrict_pushes": restrictions,
+	}
+}
+
+func Test_resourceGithubBranchProtectionStateUpgradeV1(t *testing.T) {
+	expected := testGithubBranchProtectionStateDataV2()
+	actual, err := resourceGithubBranchProtectionUpgradeV1(t.Context(), testGithubBranchProtectionStateDataV1(), nil)
+	if err != nil {
+		t.Fatalf("error migrating state: %s", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", expected, actual)
+	}
+}

--- a/github/resource_github_branch_protection_test.go
+++ b/github/resource_github_branch_protection_test.go
@@ -1,9 +1,7 @@
 package github
 
 import (
-	"context"
 	"fmt"
-	"reflect"
 	"regexp"
 	"testing"
 
@@ -747,34 +745,5 @@ func importBranchProtectionByRepoID(repoLogicalName, pattern string) resource.Im
 			return "", fmt.Errorf("repository %s does not have a node_id in terraform state", repo.Primary.ID)
 		}
 		return fmt.Sprintf("%s:%s", repoID, pattern), nil
-	}
-}
-
-func testGithubBranchProtectionStateDataV1() map[string]any {
-	return map[string]any{
-		"blocks_creations":  true,
-		"push_restrictions": [...]string{"/example-user"},
-	}
-}
-
-func testGithubBranchProtectionStateDataV2() map[string]any {
-	restrictions := []any{map[string]any{
-		"blocks_creations": true,
-		"push_allowances":  [...]string{"/example-user"},
-	}}
-	return map[string]any{
-		"restrict_pushes": restrictions,
-	}
-}
-
-func TestAccGithubBranchProtectionV4StateUpgradeV1(t *testing.T) {
-	expected := testGithubBranchProtectionStateDataV2()
-	actual, err := resourceGithubBranchProtectionUpgradeV1(context.Background(), testGithubBranchProtectionStateDataV1(), nil)
-	if err != nil {
-		t.Fatalf("error migrating state: %s", err)
-	}
-
-	if !reflect.DeepEqual(expected, actual) {
-		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", expected, actual)
 	}
 }

--- a/github/resource_github_branch_protection_v3.go
+++ b/github/resource_github_branch_protection_v3.go
@@ -268,7 +268,7 @@ func resourceGithubBranchProtectionV3Read(d *schema.ResourceData, meta any) erro
 
 	client := meta.(*Owner).v3client
 
-	repoName, branch, err := parseTwoPartID(d.Id(), "repository", "branch")
+	repoName, branch, err := parseID2(d.Id())
 	if err != nil {
 		return err
 	}
@@ -345,7 +345,7 @@ func resourceGithubBranchProtectionV3Update(d *schema.ResourceData, meta any) er
 	}
 
 	client := meta.(*Owner).v3client
-	repoName, branch, err := parseTwoPartID(d.Id(), "repository", "branch")
+	repoName, branch, err := parseID2(d.Id())
 	if err != nil {
 		return err
 	}
@@ -399,7 +399,7 @@ func resourceGithubBranchProtectionV3Delete(d *schema.ResourceData, meta any) er
 	}
 
 	client := meta.(*Owner).v3client
-	repoName, branch, err := parseTwoPartID(d.Id(), "repository", "branch")
+	repoName, branch, err := parseID2(d.Id())
 	if err != nil {
 		return err
 	}

--- a/github/resource_github_branch_protection_v3_utils.go
+++ b/github/resource_github_branch_protection_v3_utils.go
@@ -81,7 +81,7 @@ func flattenAndSetRequiredStatusChecks(d *schema.ResourceData, protection *githu
 func requireSignedCommitsRead(d *schema.ResourceData, meta any) error {
 	client := meta.(*Owner).v3client
 
-	repoName, branch, err := parseTwoPartID(d.Id(), "repository", "branch")
+	repoName, branch, err := parseID2(d.Id())
 	if err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func requireSignedCommitsUpdate(d *schema.ResourceData, meta any) (err error) {
 	requiredSignedCommit := d.Get("require_signed_commits").(bool)
 	client := meta.(*Owner).v3client
 
-	repoName, branch, err := parseTwoPartID(d.Id(), "repository", "branch")
+	repoName, branch, err := parseID2(d.Id())
 	if err != nil {
 		return err
 	}

--- a/github/resource_github_codespaces_secret.go
+++ b/github/resource_github_codespaces_secret.go
@@ -112,7 +112,7 @@ func resourceGithubCodespacesSecretRead(d *schema.ResourceData, meta any) error 
 	owner := meta.(*Owner).name
 	ctx := context.Background()
 
-	repoName, secretName, err := parseTwoPartID(d.Id(), "repository", "secret_name")
+	repoName, secretName, err := parseID2(d.Id())
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func resourceGithubCodespacesSecretDelete(d *schema.ResourceData, meta any) erro
 	orgName := meta.(*Owner).name
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
-	repoName, secretName, err := parseTwoPartID(d.Id(), "repository", "secret_name")
+	repoName, secretName, err := parseID2(d.Id())
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func resourceGithubCodespacesSecretImport(d *schema.ResourceData, meta any) ([]*
 
 	d.SetId(buildTwoPartID(parts[0], parts[1]))
 
-	repoName, secretName, err := parseTwoPartID(d.Id(), "repository", "secret_name")
+	repoName, secretName, err := parseID2(d.Id())
 	if err != nil {
 		return nil, err
 	}

--- a/github/resource_github_dependabot_organization_secret_test.go
+++ b/github/resource_github_dependabot_organization_secret_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"encoding/base64"
 	"fmt"
 	"regexp"
@@ -455,7 +454,7 @@ resource "github_dependabot_organization_secret" "test" {
 						}
 						client := meta.v3client
 						owner := meta.name
-						ctx := context.Background()
+						ctx := t.Context()
 
 						keyID, _, err := getOrganizationPublicKeyDetails(ctx, meta)
 						if err != nil {
@@ -533,7 +532,7 @@ resource "github_dependabot_organization_secret" "test" {
 						}
 						client := meta.v3client
 						owner := meta.name
-						ctx := context.Background()
+						ctx := t.Context()
 
 						keyID, _, err := getOrganizationPublicKeyDetails(ctx, meta)
 						if err != nil {

--- a/github/resource_github_dependabot_secret_migration_test.go
+++ b/github/resource_github_dependabot_secret_migration_test.go
@@ -38,7 +38,7 @@ package github
 // 		t.Run(d.testName, func(t *testing.T) {
 // 			t.Parallel()
 
-// 			got, err := resourceGithubDependabotSecretStateUpgradeV0(context.Background(), d.rawState, nil)
+// 			got, err := resourceGithubDependabotSecretStateUpgradeV0(t.Context(), d.rawState, nil)
 // 			if (err != nil) != d.shouldError {
 // 				t.Fatalf("unexpected error state")
 // 			}

--- a/github/resource_github_dependabot_secret_test.go
+++ b/github/resource_github_dependabot_secret_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"context"
 	"encoding/base64"
 	"fmt"
 	"testing"
@@ -252,7 +251,7 @@ resource "github_dependabot_secret" "test" {
 						}
 						client := meta.v3client
 						owner := meta.name
-						ctx := context.Background()
+						ctx := t.Context()
 
 						keyID, _, err := getDependabotPublicKeyDetails(ctx, meta, repoName)
 						if err != nil {
@@ -333,7 +332,7 @@ resource "github_dependabot_secret" "test" {
 						}
 						client := meta.v3client
 						owner := meta.name
-						ctx := context.Background()
+						ctx := t.Context()
 
 						keyID, _, err := getDependabotPublicKeyDetails(ctx, meta, repoName)
 						if err != nil {

--- a/github/resource_github_enterprise_actions_permissions_test.go
+++ b/github/resource_github_enterprise_actions_permissions_test.go
@@ -31,7 +31,7 @@ func TestAccGithubActionsEnterprisePermissions(t *testing.T) {
 		)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -101,7 +101,7 @@ func TestAccGithubActionsEnterprisePermissions(t *testing.T) {
 		)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -149,7 +149,7 @@ func TestAccGithubActionsEnterprisePermissions(t *testing.T) {
 		)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -221,7 +221,7 @@ func TestAccGithubActionsEnterprisePermissions(t *testing.T) {
 		)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{

--- a/github/resource_github_enterprise_actions_runner_group_test.go
+++ b/github/resource_github_enterprise_actions_runner_group_test.go
@@ -44,7 +44,7 @@ func TestAccGithubActionsEnterpriseRunnerGroup(t *testing.T) {
 		)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -96,7 +96,7 @@ func TestAccGithubActionsEnterpriseRunnerGroup(t *testing.T) {
 		)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -129,7 +129,7 @@ func TestAccGithubActionsEnterpriseRunnerGroup(t *testing.T) {
 		)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -177,7 +177,7 @@ func TestAccGithubActionsEnterpriseRunnerGroup(t *testing.T) {
 		)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{

--- a/github/resource_github_enterprise_organization_test.go
+++ b/github/resource_github_enterprise_organization_test.go
@@ -128,7 +128,7 @@ func TestAccGithubEnterpriseOrganization(t *testing.T) {
 		}
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -169,7 +169,7 @@ func TestAccGithubEnterpriseOrganization(t *testing.T) {
 			`, testAccConf.enterpriseSlug, orgName)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -249,7 +249,7 @@ func TestAccGithubEnterpriseOrganization(t *testing.T) {
 		}
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -380,7 +380,7 @@ func TestAccGithubEnterpriseOrganization(t *testing.T) {
 		}
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -440,7 +440,7 @@ func TestAccGithubEnterpriseOrganization(t *testing.T) {
 		check := resource.ComposeTestCheckFunc()
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -484,7 +484,7 @@ func TestAccGithubEnterpriseOrganization(t *testing.T) {
 		check := resource.ComposeTestCheckFunc()
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -528,7 +528,7 @@ func TestAccGithubEnterpriseOrganization(t *testing.T) {
 		check := resource.ComposeTestCheckFunc()
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{

--- a/github/resource_github_issue.go
+++ b/github/resource_github_issue.go
@@ -133,7 +133,7 @@ func resourceGithubIssueCreateOrUpdate(d *schema.ResourceData, meta any) error {
 
 func resourceGithubIssueRead(d *schema.ResourceData, meta any) error {
 	client := meta.(*Owner).v3client
-	repoName, idNumber, err := parseTwoPartID(d.Id(), "repository", "issue_number")
+	repoName, idNumber, err := parseID2(d.Id())
 	if err != nil {
 		return err
 	}

--- a/github/resource_github_issue_label.go
+++ b/github/resource_github_issue_label.go
@@ -93,7 +93,7 @@ func resourceGithubIssueLabelCreateOrUpdate(d *schema.ResourceData, meta any) er
 		originalName = name
 	} else {
 		var err error
-		_, originalName, err = parseTwoPartID(d.Id(), "repository", "name")
+		_, originalName, err = parseID2(d.Id())
 		if err != nil {
 			return err
 		}
@@ -115,7 +115,7 @@ func resourceGithubIssueLabelCreateOrUpdate(d *schema.ResourceData, meta any) er
 			originalName = name
 		} else {
 			var err error
-			_, originalName, err = parseTwoPartID(d.Id(), "repository", "name")
+			_, originalName, err = parseID2(d.Id())
 			if err != nil {
 				return err
 			}
@@ -145,7 +145,7 @@ func resourceGithubIssueLabelCreateOrUpdate(d *schema.ResourceData, meta any) er
 
 func resourceGithubIssueLabelRead(d *schema.ResourceData, meta any) error {
 	client := meta.(*Owner).v3client
-	repoName, name, err := parseTwoPartID(d.Id(), "repository", "name")
+	repoName, name, err := parseID2(d.Id())
 	if err != nil {
 		return err
 	}

--- a/github/resource_github_membership.go
+++ b/github/resource_github_membership.go
@@ -95,7 +95,7 @@ func resourceGithubMembershipRead(ctx context.Context, d *schema.ResourceData, m
 	client := meta.(*Owner).v3client
 
 	orgName := meta.(*Owner).name
-	_, username, err := parseTwoPartID(d.Id(), "organization", "username")
+	_, username, err := parseID2(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/github/resource_github_membership_test.go
+++ b/github/resource_github_membership_test.go
@@ -119,7 +119,7 @@ func testAccCheckGithubMembershipDestroy(s *terraform.State) error {
 			continue
 		}
 
-		orgName, username, err := parseTwoPartID(rs.Primary.ID, "organization", "username")
+		orgName, username, err := parseID2(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -170,7 +170,7 @@ func testAccCheckGithubMembershipExists(ctx context.Context, n string, membershi
 		}
 		conn := meta.v3client
 
-		orgName, username, err := parseTwoPartID(rs.Primary.ID, "organization", "username")
+		orgName, username, err := parseID2(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -201,7 +201,7 @@ func testAccCheckGithubMembershipRoleState(ctx context.Context, n string, member
 		}
 		conn := meta.v3client
 
-		orgName, username, err := parseTwoPartID(rs.Primary.ID, "organization", "username")
+		orgName, username, err := parseID2(rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/github/resource_github_organization_project_test.go
+++ b/github/resource_github_organization_project_test.go
@@ -68,7 +68,7 @@ package github
 // 			return err
 // 		}
 
-// 		project, res, err := conn.Projects.GetProject(context.Background(), projectID)
+// 		project, res, err := conn.Projects.GetProject(t.Context(), projectID)
 // 		if err == nil {
 // 			if project != nil &&
 // 				project.GetID() == projectID {
@@ -101,7 +101,7 @@ package github
 // 		}
 // 		conn := meta.v3client
 
-// 		gotProject, _, err := conn.Projects.GetProject(context.Background(), projectID)
+// 		gotProject, _, err := conn.Projects.GetProject(t.Context(), projectID)
 // 		if err != nil {
 // 			return err
 // 		}

--- a/github/resource_github_organization_repository_role_test.go
+++ b/github/resource_github_organization_repository_role_test.go
@@ -30,7 +30,7 @@ func TestAccGithubOrganizationRepositoryRole(t *testing.T) {
 		`, name, description, baseRole, permission0, permission1)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -67,7 +67,7 @@ func TestAccGithubOrganizationRepositoryRole(t *testing.T) {
 		`, name, permission0)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{

--- a/github/resource_github_organization_role_team.go
+++ b/github/resource_github_organization_role_team.go
@@ -70,7 +70,7 @@ func resourceGithubOrganizationRoleTeamRead(ctx context.Context, d *schema.Resou
 	client := meta.(*Owner).v3client
 	orgName := meta.(*Owner).name
 
-	roleIdString, teamSlug, err := parseTwoPartID(d.Id(), "role_id", "team_slug")
+	roleIdString, teamSlug, err := parseID2(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/github/resource_github_organization_role_team_assignment.go
+++ b/github/resource_github_organization_role_team_assignment.go
@@ -74,7 +74,7 @@ func resourceGithubOrganizationRoleTeamAssignmentRead(d *schema.ResourceData, me
 	ctx := context.Background()
 	orgName := meta.(*Owner).name
 
-	teamSlug, roleIDString, err := parseTwoPartID(d.Id(), "team_slug", "role_id")
+	teamSlug, roleIDString, err := parseID2(d.Id())
 	if err != nil {
 		return err
 	}
@@ -135,7 +135,7 @@ func resourceGithubOrganizationRoleTeamAssignmentDelete(d *schema.ResourceData, 
 	orgName := meta.(*Owner).name
 	ctx := context.Background()
 
-	teamSlug, roleIDString, err := parseTwoPartID(d.Id(), "team_slug", "role_id")
+	teamSlug, roleIDString, err := parseID2(d.Id())
 	if err != nil {
 		return err
 	}

--- a/github/resource_github_organization_role_test.go
+++ b/github/resource_github_organization_role_test.go
@@ -20,7 +20,7 @@ func TestAccGithubOrganizationRole(t *testing.T) {
 		`, name)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -52,7 +52,7 @@ func TestAccGithubOrganizationRole(t *testing.T) {
 		`, name, baseRole)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -86,7 +86,7 @@ func TestAccGithubOrganizationRole(t *testing.T) {
 		`, name, baseRole, permission0)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -122,7 +122,7 @@ func TestAccGithubOrganizationRole(t *testing.T) {
 		`, name, description, baseRole, permission0)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -162,7 +162,7 @@ func TestAccGithubOrganizationRole(t *testing.T) {
 		`, name, description, baseRole, permission0, permission1)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{

--- a/github/resource_github_organization_role_user.go
+++ b/github/resource_github_organization_role_user.go
@@ -70,7 +70,7 @@ func resourceGithubOrganizationRoleUserRead(ctx context.Context, d *schema.Resou
 	client := meta.(*Owner).v3client
 	orgName := meta.(*Owner).name
 
-	roleIdString, login, err := parseTwoPartID(d.Id(), "role_id", "login")
+	roleIdString, login, err := parseID2(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/github/resource_github_project_column_test.go
+++ b/github/resource_github_project_column_test.go
@@ -69,7 +69,7 @@ package github
 // 			return err
 // 		}
 
-// 		column, res, err := conn.Projects.GetProjectColumn(context.Background(), columnID)
+// 		column, res, err := conn.Projects.GetProjectColumn(t.Context(), columnID)
 // 		if err == nil {
 // 			if column != nil &&
 // 				column.GetID() == columnID {
@@ -101,7 +101,7 @@ package github
 // 		}
 // 		conn := meta.v3client
 
-// 		gotColumn, _, err := conn.Projects.GetProjectColumn(context.Background(), columnID)
+// 		gotColumn, _, err := conn.Projects.GetProjectColumn(t.Context(), columnID)
 // 		if err != nil {
 // 			return err
 // 		}

--- a/github/resource_github_release.go
+++ b/github/resource_github_release.go
@@ -252,7 +252,7 @@ func resourceGithubReleaseDelete(ctx context.Context, d *schema.ResourceData, me
 }
 
 func resourceGithubReleaseImport(d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	repoName, releaseIDStr, err := parseTwoPartID(d.Id(), "repository", "release")
+	repoName, releaseIDStr, err := parseID2(d.Id())
 	if err != nil {
 		return []*schema.ResourceData{d}, err
 	}

--- a/github/resource_github_repository_collaborator.go
+++ b/github/resource_github_repository_collaborator.go
@@ -96,7 +96,7 @@ func resourceGithubRepositoryCollaboratorCreate(d *schema.ResourceData, meta any
 func resourceGithubRepositoryCollaboratorRead(d *schema.ResourceData, meta any) error {
 	client := meta.(*Owner).v3client
 
-	repoName, username, err := parseTwoPartID(d.Id(), "repository", "username")
+	repoName, username, err := parseID2(d.Id())
 	owner, repoNameWithoutOwner := parseRepoName(repoName, meta.(*Owner).name)
 	if err != nil {
 		return err

--- a/github/resource_github_repository_custom_property.go
+++ b/github/resource_github_repository_custom_property.go
@@ -90,7 +90,7 @@ func resourceGithubRepositoryCustomPropertyRead(d *schema.ResourceData, meta any
 	client := meta.(*Owner).v3client
 	ctx := context.Background()
 
-	owner, repoName, propertyName, err := parseThreePartID(d.Id(), "owner", "repoName", "propertyName")
+	owner, repoName, propertyName, err := parseID3(d.Id())
 	if err != nil {
 		return err
 	}
@@ -117,7 +117,7 @@ func resourceGithubRepositoryCustomPropertyDelete(d *schema.ResourceData, meta a
 	client := meta.(*Owner).v3client
 	ctx := context.Background()
 
-	owner, repoName, propertyName, err := parseThreePartID(d.Id(), "owner", "repoName", "propertyName")
+	owner, repoName, propertyName, err := parseID3(d.Id())
 	if err != nil {
 		return err
 	}

--- a/github/resource_github_repository_deploy_key.go
+++ b/github/resource_github_repository_deploy_key.go
@@ -88,7 +88,7 @@ func resourceGithubRepositoryDeployKeyRead(d *schema.ResourceData, meta any) err
 	client := meta.(*Owner).v3client
 
 	owner := meta.(*Owner).name
-	repoName, idString, err := parseTwoPartID(d.Id(), "repository", "ID")
+	repoName, idString, err := parseID2(d.Id())
 	if err != nil {
 		return err
 	}
@@ -142,7 +142,7 @@ func resourceGithubRepositoryDeployKeyDelete(d *schema.ResourceData, meta any) e
 	client := meta.(*Owner).v3client
 
 	owner := meta.(*Owner).name
-	repoName, idString, err := parseTwoPartID(d.Id(), "repository", "ID")
+	repoName, idString, err := parseID2(d.Id())
 	if err != nil {
 		return err
 	}

--- a/github/resource_github_repository_deploy_key_test.go
+++ b/github/resource_github_repository_deploy_key_test.go
@@ -98,7 +98,7 @@ func testAccCheckGithubRepositoryDeployKeyDestroy(s *terraform.State) error {
 		}
 
 		owner := meta.name
-		repoName, idString, err := parseTwoPartID(rs.Primary.ID, "repository", "ID")
+		repoName, idString, err := parseID2(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -136,7 +136,7 @@ func testAccCheckGithubRepositoryDeployKeyExists(ctx context.Context, n string) 
 		}
 		conn := meta.v3client
 		owner := meta.name
-		repoName, idString, err := parseTwoPartID(rs.Primary.ID, "repository", "ID")
+		repoName, idString, err := parseID2(rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/github/resource_github_repository_deployment_branch_policy.go
+++ b/github/resource_github_repository_deployment_branch_policy.go
@@ -168,7 +168,7 @@ func resourceGithubRepositoryDeploymentBranchPolicyDelete(d *schema.ResourceData
 }
 
 func resourceGithubRepositoryDeploymentBranchPolicyImport(d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	repoName, environmentName, id, err := parseThreePartID(d.Id(), "repository", "environment_name", "id")
+	repoName, environmentName, id, err := parseID3(d.Id())
 	if err != nil {
 		return nil, err
 	}

--- a/github/resource_github_repository_file_migration_test.go
+++ b/github/resource_github_repository_file_migration_test.go
@@ -142,7 +142,7 @@ package github
 // 			client.BaseURL = u
 // 			meta.v3client = client
 
-// 			got, err := resourceGithubRepositoryFileStateUpgradeV0(context.Background(), d.rawState, meta)
+// 			got, err := resourceGithubRepositoryFileStateUpgradeV0(t.Context(), d.rawState, meta)
 // 			if (err != nil) != d.shouldError {
 // 				t.Fatalf("unexpected error state: got error %v, shouldError %v", err, d.shouldError)
 // 			}

--- a/github/resource_github_repository_pull_request.go
+++ b/github/resource_github_repository_pull_request.go
@@ -328,7 +328,7 @@ func resourceGithubRepositoryPullRequestDelete(d *schema.ResourceData, meta any)
 func parsePullRequestID(d *schema.ResourceData) (owner, repository string, number int, err error) {
 	var strNumber string
 
-	if owner, repository, strNumber, err = parseThreePartID(d.Id(), "owner", "base_repository", "number"); err != nil {
+	if owner, repository, strNumber, err = parseID3(d.Id()); err != nil {
 		return owner, repository, number, err
 	}
 

--- a/github/resource_github_repository_ruleset.go
+++ b/github/resource_github_repository_ruleset.go
@@ -849,7 +849,7 @@ func resourceGithubRepositoryRulesetDelete(ctx context.Context, d *schema.Resour
 }
 
 func resourceGithubRepositoryRulesetImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-	repoName, rulesetIDStr, err := parseTwoPartID(d.Id(), "repository", "ruleset")
+	repoName, rulesetIDStr, err := parseID2(d.Id())
 	if err != nil {
 		return []*schema.ResourceData{d}, err
 	}

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -1066,7 +1066,7 @@ resource "github_repository" "test" {
 		`, testRepoName)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -1161,7 +1161,7 @@ resource "github_repository" "test" {
 		}
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
@@ -1230,7 +1230,7 @@ resource "github_repository" "test" {
 		`, testRepoName, testAccConf.testPublicTemplateRepositoryOwner, testAccConf.testPublicTemplateRepository)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise); skipIfEMUEnterprise(t) },
+			PreCheck:          func() { skipUnlessEnterprise(t); skipIfEMUEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{

--- a/github/resource_github_team_membership.go
+++ b/github/resource_github_team_membership.go
@@ -21,7 +21,7 @@ func resourceGithubTeamMembership() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, m any) ([]*schema.ResourceData, error) {
 				meta := m.(*Owner)
-				teamIdString, username, err := parseTwoPartID(d.Id(), "team_id", "username")
+				teamIdString, username, err := parseID2(d.Id())
 				if err != nil {
 					return nil, err
 				}
@@ -101,7 +101,7 @@ func resourceGithubTeamMembershipRead(ctx context.Context, d *schema.ResourceDat
 	client := meta.v3client
 	orgId := meta.id
 
-	teamIdString, username, err := parseTwoPartID(d.Id(), "team_id", "username")
+	teamIdString, username, err := parseID2(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/github/resource_github_team_membership_test.go
+++ b/github/resource_github_team_membership_test.go
@@ -97,7 +97,7 @@ func testAccCheckGithubTeamMembershipDestroy(s *terraform.State) error {
 			continue
 		}
 
-		teamIdString, username, err := parseTwoPartID(rs.Primary.ID, "team_id", "username")
+		teamIdString, username, err := parseID2(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -139,7 +139,7 @@ func testAccCheckGithubTeamMembershipExists(ctx context.Context, n string, membe
 		}
 		conn := meta.v3client
 		orgId := meta.id
-		teamIdString, username, err := parseTwoPartID(rs.Primary.ID, "team_id", "username")
+		teamIdString, username, err := parseID2(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -175,7 +175,7 @@ func testAccCheckGithubTeamMembershipRoleState(ctx context.Context, n, expected 
 		}
 		conn := meta.v3client
 		orgId := meta.id
-		teamIdString, username, err := parseTwoPartID(rs.Primary.ID, "team_id", "username")
+		teamIdString, username, err := parseID2(rs.Primary.ID)
 		if err != nil {
 			return err
 		}

--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -22,7 +22,7 @@ func resourceGithubTeamRepository() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, m any) ([]*schema.ResourceData, error) {
 				meta := m.(*Owner)
-				teamIdString, username, err := parseTwoPartID(d.Id(), "team_id", "username")
+				teamIdString, username, err := parseID2(d.Id())
 				if err != nil {
 					return nil, err
 				}
@@ -114,7 +114,7 @@ func resourceGithubTeamRepositoryRead(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	teamIdString, repoName, err := parseTwoPartID(d.Id(), "team_id", "repository")
+	teamIdString, repoName, err := parseID2(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -173,7 +173,7 @@ func resourceGithubTeamRepositoryUpdate(ctx context.Context, d *schema.ResourceD
 	client := meta.(*Owner).v3client
 	orgId := meta.(*Owner).id
 
-	teamIdString, repoName, err := parseTwoPartID(d.Id(), "team_id", "repository")
+	teamIdString, repoName, err := parseID2(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -211,7 +211,7 @@ func resourceGithubTeamRepositoryDelete(ctx context.Context, d *schema.ResourceD
 	client := meta.(*Owner).v3client
 	orgId := meta.(*Owner).id
 
-	teamIdString, repoName, err := parseTwoPartID(d.Id(), "team_id", "repository")
+	teamIdString, repoName, err := parseID2(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/github/resource_github_team_sync_group_mapping_test.go
+++ b/github/resource_github_team_sync_group_mapping_test.go
@@ -19,7 +19,7 @@ func TestAccGithubTeamSyncGroupMapping_basic(t *testing.T) {
 		rn := "github_team_sync_group_mapping.test_mapping"
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			CheckDestroy:      testAccCheckGithubTeamSyncGroupMappingDestroy,
 			Steps: []resource.TestStep{
@@ -51,7 +51,7 @@ func TestAccGithubTeamSyncGroupMapping_basic(t *testing.T) {
 		rn := "github_team_sync_group_mapping.test_mapping"
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			CheckDestroy:      testAccCheckGithubTeamSyncGroupMappingDestroy,
 			Steps: []resource.TestStep{
@@ -73,7 +73,7 @@ func TestAccGithubTeamSyncGroupMapping_basic(t *testing.T) {
 		rn := "github_team_sync_group_mapping.test_mapping"
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			CheckDestroy:      testAccCheckGithubTeamSyncGroupMappingDestroy,
 			Steps: []resource.TestStep{
@@ -117,7 +117,7 @@ func TestAccGithubTeamSyncGroupMapping_basic(t *testing.T) {
 		rn := "github_team_sync_group_mapping.test_mapping"
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, enterprise) },
+			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			CheckDestroy:      testAccCheckGithubTeamSyncGroupMappingDestroy,
 			Steps: []resource.TestStep{

--- a/github/transport_test.go
+++ b/github/transport_test.go
@@ -36,7 +36,7 @@ func TestEtagTransport(t *testing.T) {
 	u, _ := url.Parse(ts.URL + "/")
 	client.BaseURL = u
 
-	ctx := context.WithValue(context.Background(), ctxEtag, "something")
+	ctx := context.WithValue(t.Context(), ctxEtag, "something")
 	r, _, err := client.Repositories.Get(ctx, "test", "blah")
 	if err != nil {
 		t.Fatal(err)
@@ -149,7 +149,7 @@ func TestRateLimitTransport_abuseLimit_get(t *testing.T) {
 	u, _ := url.Parse(ts.URL + "/")
 	client.BaseURL = u
 
-	ctx := context.WithValue(context.Background(), ctxId, t.Name())
+	ctx := context.WithValue(t.Context(), ctxId, t.Name())
 	r, _, err := client.Repositories.Get(ctx, "test", "blah")
 	if err != nil {
 		t.Fatal(err)
@@ -230,7 +230,7 @@ func TestRateLimitTransport_abuseLimit_post(t *testing.T) {
 	u, _ := url.Parse(ts.URL + "/")
 	client.BaseURL = u
 
-	ctx := context.WithValue(context.Background(), ctxId, t.Name())
+	ctx := context.WithValue(t.Context(), ctxId, t.Name())
 	r, _, err := client.Repositories.Create(ctx, "tada", &github.Repository{
 		Name:        new("radek-example-48"),
 		Description: new(""),
@@ -290,7 +290,7 @@ func TestRateLimitTransport_abuseLimit_post_error(t *testing.T) {
 	u, _ := url.Parse(ts.URL + "/")
 	client.BaseURL = u
 
-	ctx := context.WithValue(context.Background(), ctxId, t.Name())
+	ctx := context.WithValue(t.Context(), ctxId, t.Name())
 	_, _, err := client.Repositories.Create(ctx, "tada", &github.Repository{
 		Name:        new("radek-example-48"),
 		Description: new(""),
@@ -423,7 +423,7 @@ func TestRetryTransport_retry_post_error(t *testing.T) {
 	u, _ := url.Parse(ts.URL + "/")
 	client.BaseURL = u
 
-	ctx := context.WithValue(context.Background(), ctxId, t.Name())
+	ctx := context.WithValue(t.Context(), ctxId, t.Name())
 	_, _, err := client.Repositories.Create(ctx, "tada", &github.Repository{
 		Name:        new("radek-example-48"),
 		Description: new(""),
@@ -486,7 +486,7 @@ func TestRetryTransport_retry_post_success(t *testing.T) {
 	u, _ := url.Parse(ts.URL + "/")
 	client.BaseURL = u
 
-	ctx := context.WithValue(context.Background(), ctxId, t.Name())
+	ctx := context.WithValue(t.Context(), ctxId, t.Name())
 	_, _, err := client.Repositories.Create(ctx, "tada", &github.Repository{
 		Name:        new("radek-example-48"),
 		Description: new(""),

--- a/github/util.go
+++ b/github/util.go
@@ -110,32 +110,15 @@ func caseInsensitive() schema.SchemaDiffSuppressFunc {
 	}
 }
 
-// wrapErrors is provided to easily turn errors into diag.Diagnostics
-// until we go through the provider and replace error usage.
-func wrapErrors(errs []error) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	for _, err := range errs {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  "Error",
-			Detail:   err.Error(),
-		})
-	}
-
-	return diags
-}
-
 func validateValueFunc(values []string) schema.SchemaValidateDiagFunc {
 	return func(v any, k cty.Path) diag.Diagnostics {
-		errs := make([]error, 0)
 		value := v.(string)
 		valid := slices.Contains(values, value)
 
 		if !valid {
-			errs = append(errs, fmt.Errorf("%s is an invalid value for argument %s", value, k))
+			return diag.Errorf("%s is an invalid value for argument %s", value, k)
 		}
-		return wrapErrors(errs)
+		return nil
 	}
 }
 
@@ -197,21 +180,31 @@ func (e *unconvertibleIdError) Error() string {
 var secretNameRegexp = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")
 
 func validateSecretNameFunc(v any, path cty.Path) diag.Diagnostics {
-	errs := make([]error, 0)
+	var diags diag.Diagnostics
 	name, ok := v.(string)
 	if !ok {
 		return diag.Errorf("expected type of %s to be string", path)
 	}
 
 	if !secretNameRegexp.MatchString(name) {
-		errs = append(errs, errors.New("secret names can only contain alphanumeric characters or underscores and must not start with a number"))
+		diags = append(diags, diag.Diagnostic{
+			Severity:      diag.Error,
+			Detail:        "secret names can only contain alphanumeric characters or underscores and must not start with a number",
+			Summary:       "Error",
+			AttributePath: path,
+		})
 	}
 
 	if strings.HasPrefix(strings.ToUpper(name), "GITHUB_") {
-		errs = append(errs, errors.New("secret names must not start with the GITHUB_ prefix"))
+		diags = append(diags, diag.Diagnostic{
+			Severity:      diag.Error,
+			Detail:        "secret names must not start with the GITHUB_ prefix",
+			Summary:       "Error",
+			AttributePath: path,
+		})
 	}
 
-	return wrapErrors(errs)
+	return diags
 }
 
 // deleteResourceOn404AndSwallow304OtherwiseReturnError will log and delete resource if error is 404 which indicates resource (or any of its ancestors)

--- a/github/util.go
+++ b/github/util.go
@@ -200,7 +200,7 @@ func validateSecretNameFunc(v any, path cty.Path) diag.Diagnostics {
 	errs := make([]error, 0)
 	name, ok := v.(string)
 	if !ok {
-		return wrapErrors([]error{fmt.Errorf("expected type of %s to be string", path)})
+		return diag.Errorf("expected type of %s to be string", path)
 	}
 
 	if !secretNameRegexp.MatchString(name) {

--- a/github/util.go
+++ b/github/util.go
@@ -139,16 +139,6 @@ func validateValueFunc(values []string) schema.SchemaValidateDiagFunc {
 	}
 }
 
-// return the pieces of id `left:right` as left, right.
-func parseTwoPartID(id, left, right string) (string, string, error) {
-	parts := strings.SplitN(id, ":", 2)
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("unexpected ID format (%q); expected %s:%s", id, left, right)
-	}
-
-	return parts[0], parts[1], nil
-}
-
 // format the strings into an id `a:b`.
 func buildTwoPartID(a, b string) string {
 	return fmt.Sprintf("%s:%s", a, b)

--- a/github/util.go
+++ b/github/util.go
@@ -144,16 +144,6 @@ func buildTwoPartID(a, b string) string {
 	return fmt.Sprintf("%s:%s", a, b)
 }
 
-// return the pieces of id `left:center:right` as left, center, right.
-func parseThreePartID(id, left, center, right string) (string, string, string, error) {
-	parts := strings.SplitN(id, ":", 3)
-	if len(parts) != 3 {
-		return "", "", "", fmt.Errorf("unexpected ID format (%q). Expected %s:%s:%s", id, left, center, right)
-	}
-
-	return parts[0], parts[1], parts[2], nil
-}
-
 // format the strings into an id `a:b:c`.
 func buildThreePartID(a, b, c string) string {
 	return fmt.Sprintf("%s:%s:%s", a, b, c)

--- a/github/util_test.go
+++ b/github/util_test.go
@@ -562,3 +562,36 @@ func TestGithubUtilValidateSecretName(t *testing.T) {
 		}
 	}
 }
+
+func TestGithubUtilValidateSecretName_invalid_input(t *testing.T) {
+	cases := []struct {
+		Name  any
+		Error bool
+	}{
+		{
+			Name:  1,
+			Error: true,
+		},
+		{
+			Name:  []string{"v"},
+			Error: true,
+		},
+		{
+			Name:  map[string]string{"_valid_underscore_": "valid_underscore"},
+			Error: true,
+		},
+	}
+
+	for _, tc := range cases {
+		name := tc.Name
+		diags := validateSecretNameFunc(name, cty.Path{cty.GetAttrStep{Name: ""}})
+
+		if tc.Error != (len(diags) != 0) {
+			if tc.Error {
+				t.Fatalf("expected error, got none (%s)", tc.Name)
+			} else {
+				t.Fatalf("unexpected error(s): %v (%s)", diags, tc.Name)
+			}
+		}
+	}
+}

--- a/github/util_test.go
+++ b/github/util_test.go
@@ -497,29 +497,6 @@ func TestGithubUtilRole_validation(t *testing.T) {
 	}
 }
 
-func TestGithubUtilTwoPartID(t *testing.T) {
-	partOne, partTwo := "foo", "bar"
-
-	id := buildTwoPartID(partOne, partTwo)
-
-	if id != "foo:bar" {
-		t.Fatalf("Expected two part id to be foo:bar, actual: %s", id)
-	}
-
-	parsedPartOne, parsedPartTwo, err := parseTwoPartID(id, "left", "right")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if parsedPartOne != "foo" {
-		t.Fatalf("Expected parsed part one foo, actual: %s", parsedPartOne)
-	}
-
-	if parsedPartTwo != "bar" {
-		t.Fatalf("Expected parsed part two bar, actual: %s", parsedPartTwo)
-	}
-}
-
 func flipUsernameCase(username string) string {
 	oc := []rune(username)
 


### PR DESCRIPTION
----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- Codebase had unwanted patterns and no automatic protection against them

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Configure `gofmt` to rewrite:
	- `skipUnlessMode(t, enterprise)` to `skipUnlessEnterprise(t)`
	- `parseTwoPartID` with `parseID2`
	- `parseThreePartID` with `parseID3`
	- usage of `wrapErrors` with single `fmt.Errorf` with `diag.Errorf`
	- unnecessary `diag.FromErr(fmt.Errof(` calls
	- usage of `wrapErrors` with single `err` element with `diag.FromErr`
- Replace usage of `wrapErrors` directly with `diag.Diagnostics`
- Fix `github_branch_protection` migration test to be unit tests
- Replace all unnecessary `context.Background()` in tests with  `t.Context()`

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
