### PR TITLE
fix: add plan-time validation to key_prefix in autolink reference resource (#3176)

### DIFF
--- a/github/resource_github_repository_autolink_reference.go
+++ b/github/resource_github_repository_autolink_reference.go
@@ -69,6 +69,10 @@ func resourceGithubRepositoryAutolinkReference() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 				Description: "This prefix appended by a number will generate a link any time it is found in an issue, pull request, or commit",
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringMatch(
+					regexp.MustCompile(`^[a-zA-Z0-9.=+:/#_-]*[a-zA-Z.=+:/#_-]$`),
+					"must only contain letters, numbers, or .-_+=:/# and must not end with a number",
+				)),
 			},
 			"target_url_template": {
 				Type:             schema.TypeString,

--- a/github/resource_github_repository_autolink_reference_test.go
+++ b/github/resource_github_repository_autolink_reference_test.go
@@ -296,4 +296,24 @@ func TestAccGithubRepositoryAutolinkReference(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("rejects key_prefix ending with a digit at plan time", func(t *testing.T) {
+		config := `
+			resource "github_repository_autolink_reference" "autolink_invalid" {
+				repository          = "some-repo"
+				key_prefix          = "PTFY25"
+				target_url_template = "https://example.com/<num>"
+			}
+		`
+
+		resource.UnitTest(t, resource.TestCase{
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:      config,
+					ExpectError: regexp.MustCompile(`must not end with a number`),
+				},
+			},
+		})
+	})
 }


### PR DESCRIPTION
## Summary

Fixes #3176

## Problem

`terraform plan` accepts any value for `key_prefix` in `github_repository_autolink_reference`, but `terraform apply` can fail with a 422 from the GitHub API if the value is invalid:

```
key_prefix must not end with a number
key_prefix must only contain letters, numbers, or .-_+=:/#
```

This creates a confusing plan/apply inconsistency where the plan shows a clean diff but apply fails.

## Fix

Added `ValidateDiagFunc` to the `key_prefix` schema field using a regexp that mirrors GitHub's API constraints:

- Allowed characters: letters, digits, and `.-_+=:/#`
- Must **not** end with a digit

```go
ValidateDiagFunc: validation.ToDiagFunc(validation.StringMatch(
    regexp.MustCompile(`^[a-zA-Z0-9.=+:/#_-]*[a-zA-Z.=+:/#_-]$`),
    "must only contain letters, numbers, or .-_+=:/# and must not end with a number",
)),
```

Both `regexp` and `validation` were already imported in this file (used by `target_url_template`). No new dependencies needed.

## Testing

Existing acceptance tests use `key_prefix` values like `TEST1-`, `TEST2-`, etc. which all pass the new validation. Invalid values like `PTFY25` (ends with digit) will now be caught at plan time.