### PR TITLE
feat: add light and dark README images for GitHub markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # Terraform Provider GitHub
 
-<p align="left">
 <picture>
 	<source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/b741c63a-76eb-4a40-af73-6509291d5b01">
 	<source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/48ba06ce-d885-45df-8600-279af9fe6887">
-	<img src="https://github.com/user-attachments/assets/48ba06ce-d885-45df-8600-279af9fe6887" width="72" alt="GitHub Octocat logo">
+	<img src="https://github.com/user-attachments/assets/48ba06ce-d885-45df-8600-279af9fe6887" width="72" align="left" alt="GitHub Octocat logo">
 </picture>
-</p>
 
 <picture>
 	<source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/f169cecd-2681-4479-8cb2-e798d8e3161c">

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Terraform Provider GitHub
 
+<p align="left">
 <picture>
 	<source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/b741c63a-76eb-4a40-af73-6509291d5b01">
 	<source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/48ba06ce-d885-45df-8600-279af9fe6887">
 	<img src="https://github.com/user-attachments/assets/48ba06ce-d885-45df-8600-279af9fe6887" width="72" alt="GitHub Octocat logo">
 </picture>
+</p>
 
 <picture>
 	<source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/f169cecd-2681-4479-8cb2-e798d8e3161c">

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
-Terraform Provider GitHub
-=========================
+# Terraform Provider GitHub
 
 <img src="https://cloud.githubusercontent.com/assets/98681/24211275/c4ebd04e-0ee8-11e7-8606-061d656a42df.png" width="72" height="">
 
-<img src="https://raw.githubusercontent.com/hashicorp/terraform-website/d841a1e5fca574416b5ca24306f85a0f4f41b36d/content/source/assets/images/logo-terraform-main.svg" width="300px">
+<picture>
+	<source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/f169cecd-2681-4479-8cb2-e798d8e3161c">
+	<source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/63998a27-2efd-47a1-b957-63a78b97f683">
+	<img src="https://github.com/user-attachments/assets/63998a27-2efd-47a1-b957-63a78b97f683" width="300px" alt="HashiCorp Terraform logo">
+</picture>
 
 This project is used to manipulate GitHub resources (repositories, teams, files, etc.) using Terraform. Its Terraform Registry page can be found [here](https://registry.terraform.io/providers/integrations/github/).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Terraform Provider GitHub
+# Terraform GitHub Provider
 
 <picture>
 	<source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/b741c63a-76eb-4a40-af73-6509291d5b01">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Terraform Provider GitHub
 
-<img src="https://cloud.githubusercontent.com/assets/98681/24211275/c4ebd04e-0ee8-11e7-8606-061d656a42df.png" width="72" height="">
+<picture>
+	<source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/b741c63a-76eb-4a40-af73-6509291d5b01">
+	<source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/48ba06ce-d885-45df-8600-279af9fe6887">
+	<img src="https://github.com/user-attachments/assets/48ba06ce-d885-45df-8600-279af9fe6887" width="72" alt="GitHub Octocat logo">
+</picture>
 
 <picture>
 	<source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/f169cecd-2681-4479-8cb2-e798d8e3161c">


### PR DESCRIPTION
## Summary
- replace the static Terraform logo image in README with a theme-aware picture block
- use dedicated light and dark GitHub-hosted image assets
- preserve a light-mode fallback image for default rendering

## Testing
- not run (README-only change)

<img width="1467" height="490" alt="image" src="https://github.com/user-attachments/assets/6943c123-b5de-427f-8394-abd8b2fd7c73" />

<img width="1441" height="497" alt="image" src="https://github.com/user-attachments/assets/0dc5cb07-bae3-46b9-9735-770ecbabdf21" />
