### PR TITLE
Clarify auto_init behavior in R repository docs

### DIFF
--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -116,7 +116,7 @@ The following arguments are supported:
 
 * `has_downloads` - (**DEPRECATED**) (Optional) Set to `true` to enable the (deprecated) downloads features on the repository. This attribute is no longer in use, but it hasn't been removed yet. It will be removed in a future version. See [this discussion](https://github.com/orgs/community/discussions/102145#discussioncomment-8351756).
 
-* `auto_init` - (Optional) Set to `true` to produce an initial commit in the repository.
+* `auto_init` - (Optional) Set to `true` to produce an initial commit in the repository. If a repository is created without activating this functionality, adding it afterwards will not be effective. You'll have to `terraform destroy` and `terraform apply` again for the repository to be initialized properly.
 
 * `gitignore_template` - (Optional) Use the [name of the template](https://github.com/github/gitignore) without the extension. For example, "Haskell".
 


### PR DESCRIPTION
Update repository docs to state that auto_init only applies at creation. Adding auto_init to an existing repository will not initialize it; users must run terraform destroy and terraform apply to have the repository initialized properly. This reduces confusion about post-creation changes to the resource.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

### Pull request checklist

- [x ] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x ] No

----
