### PR TITLE
docs: add inline link for github_branch_default deprecation note

### DIFF
--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -122,7 +122,7 @@ The following arguments are supported:
 
 * `license_template` - (Optional) Use the [name of the template](https://github.com/github/choosealicense.com/tree/gh-pages/_licenses) without the extension. For example, "mit" or "mpl-2.0".
 
-* `default_branch` - (Optional) (Deprecated: Use `github_branch_default` resource instead) The name of the default branch of the repository. **NOTE:** This can only be set after a repository has already been created,
+* `default_branch` - (Optional) (Deprecated: Use [`github_branch_default`](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_default) resource instead) The name of the default branch of the repository. **NOTE:** This can only be set after a repository has already been created,
 and after a correct reference has been created for the target branch inside the repository. This means a user will have to omit this parameter from the
 initial repository creation and create the target branch inside of the repository prior to setting this attribute.
 


### PR DESCRIPTION
## Summary
- add an inline link to the `github_branch_default` resource in the deprecated `default_branch` docs
- make the deprecation note point directly to the replacement resource page

Fixes #2716