### PR TITLE
feat: use provider owner as default for `github_organization` data source

### DIFF
--- a/github/data_source_github_organization.go
+++ b/github/data_source_github_organization.go
@@ -17,7 +17,8 @@ func dataSourceGithubOrganization() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 			},
 			"ignore_archived_repos": {
 				Type:     schema.TypeBool,
@@ -151,7 +152,10 @@ func dataSourceGithubOrganization() *schema.Resource {
 }
 
 func dataSourceGithubOrganizationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	name := d.Get("name").(string)
+	name := meta.(*Owner).name
+	if v, ok := d.GetOk("name"); ok {
+		name = v.(string)
+	}
 
 	client4 := meta.(*Owner).v4client
 	client3 := meta.(*Owner).v3client

--- a/github/data_source_github_organization_test.go
+++ b/github/data_source_github_organization_test.go
@@ -6,9 +6,32 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestAccGithubOrganizationDataSource(t *testing.T) {
+	t.Run("uses provider owner when name is not set", func(t *testing.T) {
+		config := `data "github_organization" "test" {}`
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessHasOrgs(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("data.github_organization.test", tfjsonpath.New("login"), knownvalue.StringExact(testAccConf.owner)),
+						statecheck.ExpectKnownValue("data.github_organization.test", tfjsonpath.New("orgname"), knownvalue.StringExact(testAccConf.owner)),
+						statecheck.ExpectKnownValue("data.github_organization.test", tfjsonpath.New("node_id"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_organization.test", tfjsonpath.New("plan"), knownvalue.NotNull()),
+					},
+				},
+			},
+		})
+	})
+
 	t.Run("queries for an organization without error", func(t *testing.T) {
 		config := fmt.Sprintf(`
 			data "github_organization" "test" {

--- a/website/docs/d/organization.html.markdown
+++ b/website/docs/d/organization.html.markdown
@@ -17,9 +17,15 @@ data "github_organization" "example" {
 }
 ```
 
+If `name` is omitted, the provider's configured `owner` is used:
+
+```hcl
+data "github_organization" "example" {}
+```
+
 ## Argument Reference
 
-* `name` - (Required) The name of the organization.
+* `name` - (Optional) The name of the organization. Defaults to the provider's configured `owner`.
 * `ignore_archived_repos` - (Optional) Whether or not to include archived repos in the `repositories` list. Defaults to `false`.
 * `summary_only` - (Optional) Exclude the repos, members and other attributes from the returned result. Defaults to `false`.
 


### PR DESCRIPTION
## Summary

When no `name` is provided to the `github_organization` data source, it now falls back to the provider's configured `owner` (or the authenticated user if no owner is set). This makes `name` optional.

## Motivation

Users who already configure an `owner` in the provider block shouldn't need to repeat it in every `github_organization` data source. This is consistent with how other data sources in this provider handle the owner fallback.

## Changes

- `github/data_source_github_organization.go`: changed `name` from `Required` to `Optional`+`Computed`, and fall back to `meta.(*Owner).name` when not supplied
- `github/data_source_github_organization_test.go`: added acceptance test verifying the fallback behaviour
- `website/docs/d/organization.html.markdown`: updated docs to reflect `name` is now optional, with a second example showing omitted `name`

## Example

Before (name was required):
```hcl
data "github_organization" "example" {
  name = "my-org"
}
```

After (name is  falls back to provider `owner`):optional 
```hcl
provider "github" {
  owner = "my-org"
}

data "github_organization" "example" {}
```

## Testing

All acceptance tests pass:
-  `uses_provider_owner_when_name_is_not_set` (new)
-  `queries_for_an_organization_without_error`
-  `queries_for_an_organization_with_archived_repos`
-  `queries_for_an_organization_summary_only_without_error`