### PR TITLE
docs: Fix default permission value for team block in repository_collaborators

### DIFF
--- a/website/docs/r/repository_collaborators.html.markdown
+++ b/website/docs/r/repository_collaborators.html.markdown
@@ -82,8 +82,7 @@ The `team` block supports:
 
 - `team_id` - (Required) The GitHub team id or the GitHub team slug.
 - `permission` - (Optional) The permission of the outside collaborators for the repository.
-  Must be one of `pull`, `triage`, `push`, `maintain`, `admin` or the name of an existing [custom repository role](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-peoples-access-to-your-organization-with-roles/managing-custom-repository-roles-for-an-organization) within the organisation. Defaults to `pull`.
-  Must be `push` for personal repositories. Defaults to `push`.
+  Must be one of `pull`, `triage`, `push`, `maintain`, `admin` or the name of an existing [custom repository role](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-peoples-access-to-your-organization-with-roles/managing-custom-repository-roles-for-an-organization) within the organisation. Defaults to `push`.
 
 The `ignore_team` block supports:
 


### PR DESCRIPTION
### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- The `team` block's `permission` field documented "Defaults to `pull`" but the implementation uses `push` (`Default: "push"` in schema definition).
- "Must be `push` for personal repositories" was documented, but teams are only applicable to organization repositories.

https://github.com/integrations/terraform-provider-github/blob/256cdd84f92658f73f67fa10f9b8e41af27445fa/github/resource_github_repository_collaborators.go#L52-L62

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updated to "Defaults to `push`" to match the implementation.
- Removed "Must be `push` for personal repositories" since teams are only applicable to organization repositories.

### Pull request checklist

- ~~[ ] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))~~
- ~~[ ] Tests for the changes have been added (for bug fixes / features)~~
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No
