### PR TITLE
refactor: migrate data_source_github_branch logging to tflog

### DIFF
--- a/github/data_source_github_branch.go
+++ b/github/data_source_github_branch.go
@@ -3,10 +3,11 @@ package github
 import (
 	"context"
 	"errors"
-	"log"
+	"fmt"
 	"net/http"
 
 	"github.com/google/go-github/v84/github"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -54,7 +55,11 @@ func dataSourceGithubBranchRead(ctx context.Context, d *schema.ResourceData, met
 		var ghErr *github.ErrorResponse
 		if errors.As(err, &ghErr) {
 			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[DEBUG] Missing GitHub branch %s/%s (%s)", orgName, repoName, branchRefName)
+				tflog.Debug(ctx, fmt.Sprintf("Missing GitHub branch %s/%s (%s)", orgName, repoName, branchRefName), map[string]any{
+					"org":    orgName,
+					"repo":   repoName,
+					"branch": branchRefName,
+				})
 				d.SetId("")
 				return nil
 			}


### PR DESCRIPTION
Migrates `data_source_github_branch.go` from the stdlib `log` package to `tflog`, part of the work tracked in #3070.

The one debug log statement (404 branch-not-found path) gets structured key-value fields attached alongside the formatted message, matching the pattern from the already-migrated files (`resource_github_membership.go`, `resource_github_actions_environment_secret.go`).

**Changes:**
- Swap `"log"` import for `"fmt"` + `"github.com/hashicorp/terraform-plugin-log/tflog"`
- Convert `log.Printf("[DEBUG] ...")` ? `tflog.Debug(ctx, fmt.Sprintf(...), map[string]any{...})`

Tested: the function already uses `ReadContext`, so `ctx` is in scope. Import path verified against existing migrated files.