### PR TITLE
refactor: migrate data_source_github_ref logging to tflog

### DIFF
--- a/github/data_source_github_ref.go
+++ b/github/data_source_github_ref.go
@@ -3,10 +3,11 @@ package github
 import (
 	"context"
 	"errors"
-	"log"
+	"fmt"
 	"net/http"
 
 	"github.com/google/go-github/v84/github"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -56,7 +57,11 @@ func dataSourceGithubRefRead(ctx context.Context, d *schema.ResourceData, meta a
 		var ghErr *github.ErrorResponse
 		if errors.As(err, &ghErr) {
 			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[DEBUG] Missing GitHub ref %s/%s (%s)", owner, repoName, ref)
+				tflog.Debug(ctx, fmt.Sprintf("Missing GitHub ref %s/%s (%s)", owner, repoName, ref), map[string]any{
+					"owner": owner,
+					"repo":  repoName,
+					"ref":   ref,
+				})
 				d.SetId("")
 				return nil
 			}


### PR DESCRIPTION
Part of the ongoing tflog migration effort tracked in #3070.

Replaces the single `log.Printf("[DEBUG] ...")` call in `data_source_github_ref.go` with `tflog.Debug`, bringing this data source inline with the structured, context-aware logging approach the rest of the codebase is moving towards.

Changes:
- Drop stdlib `log` import
- Add `fmt` and `github.com/hashicorp/terraform-plugin-log/tflog`
- Convert `log.Printf` to `tflog.Debug` with structured key/value fields (`owner`, `repo`, `ref`)

No behavior change — pure logging refactor.