### PR TITLE
migrate github_user_gpg_key to context-aware CRUD functions

### DIFF
--- a/github/resource_github_user_gpg_key.go
+++ b/github/resource_github_user_gpg_key.go
@@ -8,14 +8,15 @@ import (
 	"strconv"
 
 	"github.com/google/go-github/v84/github"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceGithubUserGpgKey() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceGithubUserGpgKeyCreate,
-		Read:   resourceGithubUserGpgKeyRead,
-		Delete: resourceGithubUserGpgKeyDelete,
+		CreateContext: resourceGithubUserGpgKeyCreate,
+		ReadContext:   resourceGithubUserGpgKeyRead,
+		DeleteContext: resourceGithubUserGpgKeyDelete,
 
 		Schema: map[string]*schema.Schema{
 			"armored_public_key": {
@@ -37,32 +38,27 @@ func resourceGithubUserGpgKey() *schema.Resource {
 	}
 }
 
-func resourceGithubUserGpgKeyCreate(d *schema.ResourceData, meta any) error {
+func resourceGithubUserGpgKeyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*Owner).v3client
 
 	pubKey := d.Get("armored_public_key").(string)
-	ctx := context.Background()
 
 	key, _, err := client.Users.CreateGPGKey(ctx, pubKey)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(strconv.FormatInt(key.GetID(), 10))
 
-	return resourceGithubUserGpgKeyRead(d, meta)
+	return resourceGithubUserGpgKeyRead(ctx, d, meta)
 }
 
-func resourceGithubUserGpgKeyRead(d *schema.ResourceData, meta any) error {
+func resourceGithubUserGpgKeyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*Owner).v3client
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return unconvertibleIdErr(d.Id(), err)
-	}
-	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	if !d.IsNewResource() {
-		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
+		return diag.FromErr(unconvertibleIdErr(d.Id(), err))
 	}
 
 	key, _, err := client.Users.GetGPGKey(ctx, id)
@@ -79,26 +75,25 @@ func resourceGithubUserGpgKeyRead(d *schema.ResourceData, meta any) error {
 				return nil
 			}
 		}
-		return err
+		return diag.FromErr(err)
 	}
 
 	if err = d.Set("key_id", key.GetKeyID()); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	return nil
 }
 
-func resourceGithubUserGpgKeyDelete(d *schema.ResourceData, meta any) error {
+func resourceGithubUserGpgKeyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*Owner).v3client
 
 	id, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
-		return unconvertibleIdErr(d.Id(), err)
+		return diag.FromErr(unconvertibleIdErr(d.Id(), err))
 	}
-	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
 	_, err = client.Users.DeleteGPGKey(ctx, id)
 
-	return err
+	return diag.FromErr(err)
 }


### PR DESCRIPTION
Closes #2996

Migrates `resource_github_user_gpg_key` from the deprecated non-context-aware SDK signatures to `CreateContext`/`ReadContext`/`DeleteContext`, updating return types from `error` to `diag.Diagnostics` throughout.

Changes:
- `Create`/`Read`/`Delete` ? `CreateContext`/`ReadContext`/`DeleteContext` in the resource struct
- All CRUD function signatures updated to accept `ctx context.Context` and return `diag.Diagnostics`
- Removed inline `context.Background()` and `context.WithValue()` calls (ctx now flows in from the SDK)
- All `return err` ? `return diag.FromErr(err)`

Built and `go vet ./...` clean.