### PR TITLE
fix: handle string-typed reviewer.id in ruleset API responses

### DIFF
--- a/github/resource_github_organization_ruleset.go
+++ b/github/resource_github_organization_ruleset.go
@@ -768,7 +768,7 @@ func resourceGithubOrganizationRulesetCreate(ctx context.Context, d *schema.Reso
 
 	rulesetReq := resourceGithubRulesetObject(d, owner)
 
-	ruleset, resp, err := client.Organizations.CreateRepositoryRuleset(ctx, owner, rulesetReq)
+	ruleset, resp, err := createOrgRuleset(ctx, client, owner, rulesetReq)
 	if err != nil {
 		tflog.Error(ctx, fmt.Sprintf("Failed to create organization ruleset: %s/%s", owner, name), map[string]any{
 			"owner": owner,
@@ -824,7 +824,7 @@ func resourceGithubOrganizationRulesetRead(ctx context.Context, d *schema.Resour
 		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
 	}
 
-	ruleset, resp, err := client.Organizations.GetRepositoryRuleset(ctx, owner, rulesetID)
+	ruleset, resp, err := getOrgRuleset(ctx, client, owner, rulesetID)
 	if err != nil {
 		var ghErr *github.ErrorResponse
 		if errors.As(err, &ghErr) {
@@ -912,7 +912,7 @@ func resourceGithubOrganizationRulesetUpdate(ctx context.Context, d *schema.Reso
 
 	rulesetReq := resourceGithubRulesetObject(d, owner)
 
-	ruleset, resp, err := client.Organizations.UpdateRepositoryRuleset(ctx, owner, rulesetID, rulesetReq)
+	ruleset, resp, err := updateOrgRuleset(ctx, client, owner, rulesetID, rulesetReq)
 	if err != nil {
 		tflog.Error(ctx, fmt.Sprintf("Failed to update organization ruleset: %s/%d", owner, rulesetID), map[string]any{
 			"owner":      owner,
@@ -1005,7 +1005,7 @@ func resourceGithubOrganizationRulesetImport(ctx context.Context, d *schema.Reso
 		"ruleset_id": rulesetID,
 	})
 
-	ruleset, _, err := client.Organizations.GetRepositoryRuleset(ctx, owner, rulesetID)
+	ruleset, _, err := getOrgRuleset(ctx, client, owner, rulesetID)
 	if ruleset == nil || err != nil {
 		tflog.Error(ctx, fmt.Sprintf("Failed to import organization ruleset: %s/%d", owner, rulesetID), map[string]any{
 			"owner":      owner,

--- a/github/resource_github_repository_ruleset.go
+++ b/github/resource_github_repository_ruleset.go
@@ -702,7 +702,7 @@ func resourceGithubRepositoryRulesetCreate(ctx context.Context, d *schema.Resour
 		return diag.Errorf("cannot create ruleset on archived repository %s/%s", owner, repoName)
 	}
 
-	ruleset, resp, err := client.Repositories.CreateRuleset(ctx, owner, repoName, rulesetReq)
+	ruleset, resp, err := createRepoRuleset(ctx, client, owner, repoName, rulesetReq)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -739,7 +739,7 @@ func resourceGithubRepositoryRulesetRead(ctx context.Context, d *schema.Resource
 		ctx = context.WithValue(ctx, ctxEtag, d.Get("etag").(string))
 	}
 
-	ruleset, resp, err := client.Repositories.GetRuleset(ctx, owner, repoName, rulesetID, false)
+	ruleset, resp, err := getRepoRuleset(ctx, client, owner, repoName, rulesetID, false)
 	if err != nil {
 		var ghErr *github.ErrorResponse
 		if errors.As(err, &ghErr) {
@@ -815,7 +815,7 @@ func resourceGithubRepositoryRulesetUpdate(ctx context.Context, d *schema.Resour
 		return nil
 	}
 
-	ruleset, resp, err := client.Repositories.UpdateRuleset(ctx, owner, repoName, rulesetID, rulesetReq)
+	ruleset, resp, err := updateRepoRuleset(ctx, client, owner, repoName, rulesetID, rulesetReq)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -874,7 +874,7 @@ func resourceGithubRepositoryRulesetImport(ctx context.Context, d *schema.Resour
 		return []*schema.ResourceData{d}, err
 	}
 
-	ruleset, _, err := client.Repositories.GetRuleset(ctx, owner, repository.GetName(), rulesetID, false)
+	ruleset, _, err := getRepoRuleset(ctx, client, owner, repository.GetName(), rulesetID, false)
 	if ruleset == nil || err != nil {
 		return []*schema.ResourceData{d}, err
 	}

--- a/github/util_rules.go
+++ b/github/util_rules.go
@@ -2,7 +2,12 @@ package github
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
 	"reflect"
+	"regexp"
 	"sort"
 
 	"github.com/google/go-github/v84/github"
@@ -878,6 +883,110 @@ func flattenRules(ctx context.Context, rules *github.RepositoryRulesetRules, org
 	}
 
 	return []any{rulesMap}
+}
+
+// reviewerStringIDPattern matches JSON "id" fields with quoted integer values.
+// The GitHub API returns reviewer.id as a JSON string (e.g., "id": "12345") but
+// go-github's RulesetReviewer.ID expects *int64, causing unmarshal failures.
+// See https://github.com/integrations/terraform-provider-github/issues/3340
+var reviewerStringIDPattern = regexp.MustCompile(`"id"\s*:\s*"(\d+)"`)
+
+// fixReviewerStringIDs converts quoted integer "id" fields in raw JSON to
+// unquoted integers so that go-github can unmarshal them into *int64 fields.
+func fixReviewerStringIDs(data []byte) []byte {
+	return reviewerStringIDPattern.ReplaceAll(data, []byte(`"id":$1`))
+}
+
+// doRulesetRequest executes an HTTP request against the GitHub API and
+// unmarshals the response into a RepositoryRuleset. It applies
+// fixReviewerStringIDs to the response body before unmarshaling to work around
+// the GitHub API returning reviewer.id as a string instead of a number.
+func doRulesetRequest(ctx context.Context, client *github.Client, req *http.Request) (*github.RepositoryRuleset, *github.Response, error) {
+	resp, err := client.BareDo(ctx, req)
+	if err != nil {
+		return nil, resp, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	body = fixReviewerStringIDs(body)
+
+	var rs *github.RepositoryRuleset
+	if err := json.Unmarshal(body, &rs); err != nil {
+		return nil, resp, err
+	}
+
+	return rs, resp, nil
+}
+
+// createRepoRuleset creates a repository ruleset, working around the
+// reviewer.id string marshaling bug in go-github.
+func createRepoRuleset(ctx context.Context, client *github.Client, owner, repo string, ruleset github.RepositoryRuleset) (*github.RepositoryRuleset, *github.Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/rulesets", owner, repo)
+	req, err := client.NewRequest("POST", u, ruleset)
+	if err != nil {
+		return nil, nil, err
+	}
+	return doRulesetRequest(ctx, client, req)
+}
+
+// getRepoRuleset gets a repository ruleset, working around the
+// reviewer.id string marshaling bug in go-github.
+func getRepoRuleset(ctx context.Context, client *github.Client, owner, repo string, rulesetID int64, includesParents bool) (*github.RepositoryRuleset, *github.Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/rulesets/%v?includes_parents=%v", owner, repo, rulesetID, includesParents)
+	req, err := client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	return doRulesetRequest(ctx, client, req)
+}
+
+// updateRepoRuleset updates a repository ruleset, working around the
+// reviewer.id string marshaling bug in go-github.
+func updateRepoRuleset(ctx context.Context, client *github.Client, owner, repo string, rulesetID int64, ruleset github.RepositoryRuleset) (*github.RepositoryRuleset, *github.Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/rulesets/%v", owner, repo, rulesetID)
+	req, err := client.NewRequest("PUT", u, ruleset)
+	if err != nil {
+		return nil, nil, err
+	}
+	return doRulesetRequest(ctx, client, req)
+}
+
+// createOrgRuleset creates an organization ruleset, working around the
+// reviewer.id string marshaling bug in go-github.
+func createOrgRuleset(ctx context.Context, client *github.Client, org string, ruleset github.RepositoryRuleset) (*github.RepositoryRuleset, *github.Response, error) {
+	u := fmt.Sprintf("orgs/%v/rulesets", org)
+	req, err := client.NewRequest("POST", u, ruleset)
+	if err != nil {
+		return nil, nil, err
+	}
+	return doRulesetRequest(ctx, client, req)
+}
+
+// getOrgRuleset gets an organization ruleset, working around the
+// reviewer.id string marshaling bug in go-github.
+func getOrgRuleset(ctx context.Context, client *github.Client, org string, rulesetID int64) (*github.RepositoryRuleset, *github.Response, error) {
+	u := fmt.Sprintf("orgs/%v/rulesets/%v", org, rulesetID)
+	req, err := client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	return doRulesetRequest(ctx, client, req)
+}
+
+// updateOrgRuleset updates an organization ruleset, working around the
+// reviewer.id string marshaling bug in go-github.
+func updateOrgRuleset(ctx context.Context, client *github.Client, org string, rulesetID int64, ruleset github.RepositoryRuleset) (*github.RepositoryRuleset, *github.Response, error) {
+	u := fmt.Sprintf("orgs/%v/rulesets/%v", org, rulesetID)
+	req, err := client.NewRequest("PUT", u, ruleset)
+	if err != nil {
+		return nil, nil, err
+	}
+	return doRulesetRequest(ctx, client, req)
 }
 
 func bypassActorsDiffSuppressFunc(k, o, n string, d *schema.ResourceData) bool {

--- a/github/util_rules_test.go
+++ b/github/util_rules_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/google/go-github/v84/github"
@@ -1297,5 +1298,128 @@ func TestFlattenRulesetRepositoryPropertyTargetParameters_NilPropertyValues(t *t
 		if valSlice, ok := values.([]string); ok && len(valSlice) != 0 {
 			t.Errorf("Expected property_values to be nil or empty, got %v", values)
 		}
+	}
+}
+
+func TestFixReviewerStringIDs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "converts quoted integer id to unquoted",
+			input:    `{"id": "12345", "type": "Team"}`,
+			expected: `{"id":12345, "type": "Team"}`,
+		},
+		{
+			name:     "leaves unquoted integer id unchanged",
+			input:    `{"id": 12345, "type": "Team"}`,
+			expected: `{"id": 12345, "type": "Team"}`,
+		},
+		{
+			name:     "converts id without spaces after colon",
+			input:    `{"id":"99999","type":"Team"}`,
+			expected: `{"id":99999,"type":"Team"}`,
+		},
+		{
+			name:     "handles multiple reviewer ids",
+			input:    `[{"id": "111"}, {"id": "222"}]`,
+			expected: `[{"id":111}, {"id":222}]`,
+		},
+		{
+			name:     "does not convert non-digit string ids",
+			input:    `{"id": "abc123", "type": "Team"}`,
+			expected: `{"id": "abc123", "type": "Team"}`,
+		},
+		{
+			name:     "does not convert empty string ids",
+			input:    `{"id": "", "type": "Team"}`,
+			expected: `{"id": "", "type": "Team"}`,
+		},
+		{
+			name:     "handles full ruleset response with nested reviewer",
+			input:    `{"id":1,"name":"test","rules":[{"type":"pull_request","parameters":{"required_reviewers":[{"reviewer":{"id":"12345","type":"Team"},"minimum_approvals":1}]}}]}`,
+			expected: `{"id":1,"name":"test","rules":[{"type":"pull_request","parameters":{"required_reviewers":[{"reviewer":{"id":12345,"type":"Team"},"minimum_approvals":1}]}}]}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := fixReviewerStringIDs([]byte(tc.input))
+			if string(result) != tc.expected {
+				t.Errorf("fixReviewerStringIDs(%q) = %q, want %q", tc.input, string(result), tc.expected)
+			}
+		})
+	}
+}
+
+func TestFixReviewerStringIDs_UnmarshalRoundTrip(t *testing.T) {
+	// Simulate the actual GitHub API response that causes the bug:
+	// reviewer.id is returned as a JSON string instead of a number.
+	apiResponse := `{
+		"id": 999,
+		"name": "test-ruleset",
+		"target": "branch",
+		"source_type": "Repository",
+		"source": "test-repo",
+		"enforcement": "active",
+		"rules": [
+			{
+				"type": "pull_request",
+				"parameters": {
+					"dismiss_stale_reviews_on_push": false,
+					"require_code_owner_review": false,
+					"require_last_push_approval": false,
+					"required_approving_review_count": 1,
+					"required_review_thread_resolution": false,
+					"required_reviewers": [
+						{
+							"reviewer": {
+								"id": "12345",
+								"type": "Team"
+							},
+							"file_patterns": ["*.go"],
+							"minimum_approvals": 1
+						}
+					]
+				}
+			}
+		]
+	}`
+
+	// Without the fix, this would fail with:
+	// json: cannot unmarshal string into Go struct field
+	// RulesetReviewer.id of type int64
+	fixed := fixReviewerStringIDs([]byte(apiResponse))
+
+	var rs github.RepositoryRuleset
+	if err := json.Unmarshal(fixed, &rs); err != nil {
+		t.Fatalf("Failed to unmarshal fixed response: %v", err)
+	}
+
+	if rs.GetID() != 999 {
+		t.Errorf("Expected ruleset ID 999, got %d", rs.GetID())
+	}
+
+	if rs.Rules == nil || rs.Rules.PullRequest == nil {
+		t.Fatal("Expected pull_request rule to be parsed")
+	}
+
+	reviewers := rs.Rules.PullRequest.RequiredReviewers
+	if len(reviewers) != 1 {
+		t.Fatalf("Expected 1 required reviewer, got %d", len(reviewers))
+	}
+
+	if reviewers[0].Reviewer == nil {
+		t.Fatal("Expected reviewer to be non-nil")
+	}
+
+	if reviewers[0].Reviewer.GetID() != 12345 {
+		t.Errorf("Expected reviewer ID 12345, got %d", reviewers[0].Reviewer.GetID())
+	}
+
+	if reviewers[0].Reviewer.GetType() == nil || *reviewers[0].Reviewer.GetType() != github.RulesetReviewerTypeTeam {
+		t.Errorf("Expected reviewer type Team, got %v", reviewers[0].Reviewer.GetType())
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #3340 and #3214

The GitHub API returns `required_reviewers.reviewer.id` as a JSON string (e.g., `"12345"`), but go-github's `RulesetReviewer.ID` field is `*int64`. Standard Go JSON unmarshaling rejects this with:

```
json: cannot unmarshal string into Go struct field RepositoryRuleset.rules.required_reviewers.reviewer.id of type int64
```

The POST/PUT succeeds (the ruleset is created/updated on GitHub), but the provider cannot parse the response — so the resource is never recorded in Terraform state, creating orphaned rulesets on every retry.

### Why existing tests didn't catch this

The acceptance test `TestAccGithubRepositoryRuleset_requiredReviewers` (added in #3073) only runs when a maintainer adds the `acctest` label, and the CI matrix (`anonymous`, `individual`, `organization`) requires an org-mode run to pass the `skipUnlessHasOrgs` precheck. The unit tests for `expandRequiredReviewers` / `flattenRequiredReviewers` only exercise in-memory Go struct round-trips — they never parse raw JSON from the API, so they never hit the string→int64 mismatch that lives inside go-github's `json.Unmarshal` path.

## Approach

Rather than patching go-github upstream, this adds thin wrapper functions around the ruleset CRUD API calls in `util_rules.go`. The wrappers use `client.BareDo()` to obtain the raw HTTP response body, apply a targeted regex (`"id"\s*:\s*"(\d+)"` → `"id":$1`) to convert quoted integer IDs to unquoted integers, then unmarshal into the standard go-github types.

This approach:
- Fixes both repository-level and organization-level rulesets
- Is safe because the only `"id"` field returned as a quoted integer in ruleset responses is `reviewer.id` (the top-level ruleset ID and other numeric fields are already returned as JSON numbers)
- Matches the URL construction and method signatures of the upstream go-github methods exactly
- Does not affect any other API calls

## Changes

- **`github/util_rules.go`**: Added `fixReviewerStringIDs()` regex helper, `doRulesetRequest()` for raw response handling, and 6 wrapper functions (`createRepoRuleset`, `getRepoRuleset`, `updateRepoRuleset`, `createOrgRuleset`, `getOrgRuleset`, `updateOrgRuleset`)
- **`github/resource_github_repository_ruleset.go`**: Replaced 4 direct go-github calls with wrapper functions
- **`github/resource_github_organization_ruleset.go`**: Replaced 4 direct go-github calls with wrapper functions
- **`github/util_rules_test.go`**: Added unit tests for `fixReviewerStringIDs` (7 cases) and an end-to-end unmarshal round-trip test that simulates the actual buggy API response

## Test plan

- [x] Unit tests for `fixReviewerStringIDs` covering: quoted integer conversion, unquoted passthrough, no-space formatting, multiple IDs, non-digit strings, empty strings, full nested response
- [x] End-to-end unmarshal test simulating the actual GitHub API response with string reviewer IDs — verifies the fix at the JSON layer where the bug actually occurs
- [x] Existing `TestExpandRequiredReviewers`, `TestFlattenRequiredReviewers`, `TestRoundTripRequiredReviewers` still pass
- [x] `go vet ./...` clean
- [x] Full build succeeds
- [ ] Acceptance test `TestAccGithubRepositoryRuleset_requiredReviewers` — requires `acctest` label + org-mode CI run to exercise the real API round-trip