### PR TITLE
feat: Support pre-signed JWT for GitHub App authentication

### DIFF
--- a/examples/app_authentication/README.md
+++ b/examples/app_authentication/README.md
@@ -4,13 +4,25 @@ This example demonstrates authenticating using a GitHub App.
 
 The example will create a repository in the specified organization.
 
-You may use variables passed via command line:
+## Using a PEM file
 
 ```console
 export GITHUB_OWNER=
 export GITHUB_APP_ID=
 export GITHUB_APP_INSTALLATION_ID=
 export GITHUB_APP_PEM_FILE=
+```
+
+## Using a pre-signed JWT
+
+If you sign the GitHub App JWT externally (e.g., using AWS KMS or HashiCorp Vault),
+you can pass the signed JWT directly instead of providing a PEM file.
+In this case, `GITHUB_APP_ID` is not required.
+
+```console
+export GITHUB_OWNER=
+export GITHUB_APP_INSTALLATION_ID=
+export GITHUB_APP_JWT=
 ```
 
 ```console

--- a/github/apps.go
+++ b/github/apps.go
@@ -15,6 +15,13 @@ import (
 	"github.com/go-jose/go-jose/v3/jwt"
 )
 
+// GenerateOAuthTokenFromJWT exchanges a pre-signed GitHub App JWT for an installation access token.
+// The JWT must be signed by the GitHub App's private key and contain the correct claims.
+// This allows signing to be handled externally (e.g., by a secrets manager or KMS).
+func GenerateOAuthTokenFromJWT(apiURL *url.URL, appInstallationID, appJWT string) (string, error) {
+	return getInstallationAccessToken(apiURL, appJWT, appInstallationID)
+}
+
 // GenerateOAuthTokenFromApp generates a GitHub OAuth access token from a set of valid GitHub App credentials.
 // The returned token can be used to interact with both GitHub's REST and GraphQL APIs.
 func GenerateOAuthTokenFromApp(apiURL *url.URL, appID, appInstallationID, pemData string) (string, error) {

--- a/github/apps.go
+++ b/github/apps.go
@@ -15,6 +15,13 @@ import (
 	"github.com/go-jose/go-jose/v4/jwt"
 )
 
+// GenerateOAuthTokenFromJWT exchanges a pre-signed GitHub App JWT for an installation access token.
+// The JWT must be signed by the GitHub App's private key and contain the correct claims.
+// This allows signing to be handled externally (e.g., by a secrets manager or KMS).
+func GenerateOAuthTokenFromJWT(apiURL *url.URL, appInstallationID, appJWT string) (string, error) {
+	return getInstallationAccessToken(apiURL, appJWT, appInstallationID)
+}
+
 // GenerateOAuthTokenFromApp generates a GitHub OAuth access token from a set of valid GitHub App credentials.
 // The returned token can be used to interact with both GitHub's REST and GraphQL APIs.
 func GenerateOAuthTokenFromApp(apiURL *url.URL, appID, appInstallationID, pemData string) (string, error) {

--- a/github/provider.go
+++ b/github/provider.go
@@ -103,7 +103,7 @@ func Provider() *schema.Provider {
 					Schema: map[string]*schema.Schema{
 						"id": {
 							Type:        schema.TypeString,
-							Required:    true,
+							Optional:    true,
 							DefaultFunc: schema.EnvDefaultFunc("GITHUB_APP_ID", nil),
 							Description: descriptions["app_auth.id"],
 						},
@@ -114,11 +114,20 @@ func Provider() *schema.Provider {
 							Description: descriptions["app_auth.installation_id"],
 						},
 						"pem_file": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Sensitive:   true,
-							DefaultFunc: schema.EnvDefaultFunc("GITHUB_APP_PEM_FILE", nil),
-							Description: descriptions["app_auth.pem_file"],
+							Type:         schema.TypeString,
+							Optional:     true,
+							Sensitive:    true,
+							DefaultFunc:  schema.EnvDefaultFunc("GITHUB_APP_PEM_FILE", nil),
+							Description:  descriptions["app_auth.pem_file"],
+							ExactlyOneOf: []string{"app_auth.0.pem_file", "app_auth.0.jwt"},
+						},
+						"jwt": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Sensitive:    true,
+							DefaultFunc:  schema.EnvDefaultFunc("GITHUB_APP_JWT", nil),
+							Description:  descriptions["app_auth.jwt"],
+							ExactlyOneOf: []string{"app_auth.0.pem_file", "app_auth.0.jwt"},
 						},
 					},
 				},
@@ -324,7 +333,8 @@ func init() {
 			"`token`. Anonymous mode is enabled if both `token` and `app_auth` are not set.",
 		"app_auth.id":              "The GitHub App ID.",
 		"app_auth.installation_id": "The GitHub App installation instance ID.",
-		"app_auth.pem_file":        "The GitHub App PEM file contents.",
+		"app_auth.pem_file":        "The GitHub App PEM file contents. Exactly one of `pem_file` or `jwt` must be set.",
+		"app_auth.jwt":             "A pre-signed GitHub App JWT. Exactly one of `pem_file` or `jwt` must be set.",
 		"write_delay_ms": "Amount of time in milliseconds to sleep in between writes to GitHub API. " +
 			"Defaults to 1000ms or 1s if not set.",
 		"read_delay_ms": "Amount of time in milliseconds to sleep in between non-write requests to GitHub API. " +
@@ -381,12 +391,10 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 		if appAuth, ok := d.Get("app_auth").([]any); ok && len(appAuth) > 0 && appAuth[0] != nil {
 			appAuthAttr := appAuth[0].(map[string]any)
 
-			var appID, appInstallationID, appPemFile string
+			var appID, appInstallationID string
 
 			if v, ok := appAuthAttr["id"].(string); ok && v != "" {
 				appID = v
-			} else {
-				return nil, wrapErrors([]error{fmt.Errorf("app_auth.id must be set and contain a non-empty value")})
 			}
 
 			if v, ok := appAuthAttr["installation_id"].(string); ok && v != "" {
@@ -395,7 +403,21 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 				return nil, wrapErrors([]error{fmt.Errorf("app_auth.installation_id must be set and contain a non-empty value")})
 			}
 
-			if v, ok := appAuthAttr["pem_file"].(string); ok && v != "" {
+			apiPath := ""
+			if isGHES {
+				apiPath = GHESRESTAPIPath
+			}
+			appAPIURL := baseURL.JoinPath(apiPath)
+
+			var appToken string
+			var err error
+
+			if v, ok := appAuthAttr["jwt"].(string); ok && v != "" {
+				appToken, err = GenerateOAuthTokenFromJWT(appAPIURL, appInstallationID, v)
+			} else if v, ok := appAuthAttr["pem_file"].(string); ok && v != "" {
+				if appID == "" {
+					return nil, wrapErrors([]error{fmt.Errorf("app_auth.id must be set when using pem_file")})
+				}
 				// The Go encoding/pem package only decodes PEM formatted blocks
 				// that contain new lines. Some platforms, like Terraform Cloud,
 				// do not support new lines within Environment Variables.
@@ -403,17 +425,12 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 				// (explicit value, or default value taken from
 				// GITHUB_APP_PEM_FILE Environment Variable) is replaced with an
 				// actual new line character before decoding.
-				appPemFile = strings.ReplaceAll(v, `\n`, "\n")
+				appPemFile := strings.ReplaceAll(v, `\n`, "\n")
+				appToken, err = GenerateOAuthTokenFromApp(appAPIURL, appID, appInstallationID, appPemFile)
 			} else {
-				return nil, wrapErrors([]error{fmt.Errorf("app_auth.pem_file must be set and contain a non-empty value")})
+				return nil, wrapErrors([]error{fmt.Errorf("exactly one of app_auth.pem_file or app_auth.jwt must be set")})
 			}
 
-			apiPath := ""
-			if isGHES {
-				apiPath = GHESRESTAPIPath
-			}
-
-			appToken, err := GenerateOAuthTokenFromApp(baseURL.JoinPath(apiPath), appID, appInstallationID, appPemFile)
 			if err != nil {
 				return nil, wrapErrors([]error{err})
 			}

--- a/github/provider.go
+++ b/github/provider.go
@@ -58,7 +58,7 @@ func NewProvider() func() *schema.Provider {
 						Schema: map[string]*schema.Schema{
 							"id": {
 								Type:        schema.TypeString,
-								Required:    true,
+								Optional:    true,
 								DefaultFunc: schema.EnvDefaultFunc("GITHUB_APP_ID", nil),
 								Description: "The GitHub App's identifier. This can also be set by the `GITHUB_APP_ID` environment variable.",
 							},
@@ -69,11 +69,20 @@ func NewProvider() func() *schema.Provider {
 								Description: "The GitHub App's installation identifier. This can also be set by the `GITHUB_APP_INSTALLATION_ID` environment variable.",
 							},
 							"pem_file": {
-								Type:        schema.TypeString,
-								Required:    true,
-								Sensitive:   true,
-								DefaultFunc: schema.EnvDefaultFunc("GITHUB_APP_PEM_FILE", nil),
-								Description: "The GitHub App's PEM file content; `\\n` can be used for newlines. This can also be set by the `GITHUB_APP_PEM_FILE` environment variable.",
+								Type:         schema.TypeString,
+								Optional:     true,
+								Sensitive:    true,
+								DefaultFunc:  schema.EnvDefaultFunc("GITHUB_APP_PEM_FILE", nil),
+								Description:  "The GitHub App's PEM file content; `\\n` can be used for newlines. Exactly one of `pem_file` or `jwt` must be set. This can also be set by the `GITHUB_APP_PEM_FILE` environment variable.",
+								ExactlyOneOf: []string{"app_auth.0.pem_file", "app_auth.0.jwt"},
+							},
+							"jwt": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								Sensitive:    true,
+								DefaultFunc:  schema.EnvDefaultFunc("GITHUB_APP_JWT", nil),
+								Description:  "A pre-signed GitHub App JWT. Exactly one of `pem_file` or `jwt` must be set. This can also be set by the `GITHUB_APP_JWT` environment variable.",
+								ExactlyOneOf: []string{"app_auth.0.pem_file", "app_auth.0.jwt"},
 							},
 						},
 					},
@@ -338,12 +347,10 @@ func configureProvider() func(context.Context, *schema.ResourceData) (any, diag.
 		if appAuth, ok := d.Get("app_auth").([]any); ok && len(appAuth) > 0 && appAuth[0] != nil {
 			appAuthAttr := appAuth[0].(map[string]any)
 
-			var appID, appInstallationID, appPemFile string
+			var appID, appInstallationID string
 
 			if v, ok := appAuthAttr["id"].(string); ok && v != "" {
 				appID = v
-			} else {
-				return nil, diag.Errorf("app_auth.id must be set and contain a non-empty value")
 			}
 
 			if v, ok := appAuthAttr["installation_id"].(string); ok && v != "" {
@@ -352,7 +359,21 @@ func configureProvider() func(context.Context, *schema.ResourceData) (any, diag.
 				return nil, diag.Errorf("app_auth.installation_id must be set and contain a non-empty value")
 			}
 
-			if v, ok := appAuthAttr["pem_file"].(string); ok && v != "" {
+			apiPath := ""
+			if isGHES {
+				apiPath = GHESRESTAPIPath
+			}
+			appAPIURL := baseURL.JoinPath(apiPath)
+
+			var appToken string
+			var appErr error
+
+			if v, ok := appAuthAttr["jwt"].(string); ok && v != "" {
+				appToken, appErr = GenerateOAuthTokenFromJWT(appAPIURL, appInstallationID, v)
+			} else if v, ok := appAuthAttr["pem_file"].(string); ok && v != "" {
+				if appID == "" {
+					return nil, diag.Errorf("app_auth.id must be set when using pem_file")
+				}
 				// The Go encoding/pem package only decodes PEM formatted blocks
 				// that contain new lines. Some platforms, like Terraform Cloud,
 				// do not support new lines within Environment Variables.
@@ -360,19 +381,14 @@ func configureProvider() func(context.Context, *schema.ResourceData) (any, diag.
 				// (explicit value, or default value taken from
 				// GITHUB_APP_PEM_FILE Environment Variable) is replaced with an
 				// actual new line character before decoding.
-				appPemFile = strings.ReplaceAll(v, `\n`, "\n")
+				appPemFile := strings.ReplaceAll(v, `\n`, "\n")
+				appToken, appErr = GenerateOAuthTokenFromApp(appAPIURL, appID, appInstallationID, appPemFile)
 			} else {
-				return nil, diag.Errorf("app_auth.pem_file must be set and contain a non-empty value")
+				return nil, diag.Errorf("exactly one of app_auth.pem_file or app_auth.jwt must be set")
 			}
 
-			apiPath := ""
-			if isGHES {
-				apiPath = GHESRESTAPIPath
-			}
-
-			appToken, err := GenerateOAuthTokenFromApp(baseURL.JoinPath(apiPath), appID, appInstallationID, appPemFile)
-			if err != nil {
-				return nil, diag.FromErr(err)
+			if appErr != nil {
+				return nil, diag.FromErr(appErr)
 			}
 
 			token = appToken


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #3317

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->
- GitHub App authentication required a PEM private key file (pem_file), meaning the
private key had to be stored in the CI/CD environment.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `app_auth` now accepts a `jwt` field as an alternative to `pem_file`.
- Users can generate and sign the GitHub App JWT externally and pass it directly to the provider.
- Exactly one of `pem_file` or `jwt` must be set (`ExactlyOneOf` validation).
- The `GITHUB_APP_JWT` environment variable can be used to supply the JWT.


### Pull request checklist

- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
