### PR TITLE
docs: correct format of import for github_membership

### DIFF
--- a/website/docs/r/membership.html.markdown
+++ b/website/docs/r/membership.html.markdown
@@ -39,8 +39,8 @@ The following arguments are supported:
 
 ## Import
 
-GitHub Membership can be imported using an ID made up of `organization:username`, e.g.
+GitHub Membership can be imported using an ID made up of `team-id:username`, e.g.
 
 ```
-$ terraform import github_membership.member hashicorp:someuser
+$ terraform import github_membership.member team:someuser
 ```


### PR DESCRIPTION
### Before the change?
Following the documented format, received errors:

```
github_team_membership.members["GideonPARANOID"]: Importing from ID "getndazn:GideonPARANOID"...
╷
│ Error: strconv.ParseInt: parsing "getndazn": invalid syntaxGET https://api.github.com/orgs/getndazn/teams/getndazn: 404 Not Found []
```

### After the change?

Following updated format description:

```
github_team_membership.members["GideonPARANOID"]: Importing from ID "codx:GideonPARANOID"...
github_team_membership.members["GideonPARANOID"]: Import prepared!
  Prepared github_team_membership for import
github_team_membership.members["GideonPARANOID"]: Refreshing state... [id=7498018:GideonPARANOID]

Import successful!
```


### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
