### PR TITLE
maint: migrate various data sources to tflog structured logging

### DIFF
--- a/github/data_source_github_ref.go
+++ b/github/data_source_github_ref.go
@@ -3,10 +3,10 @@ package github
 import (
 	"context"
 	"errors"
-	"log"
 	"net/http"
 
 	"github.com/google/go-github/v84/github"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -56,7 +56,11 @@ func dataSourceGithubRefRead(ctx context.Context, d *schema.ResourceData, meta a
 		var ghErr *github.ErrorResponse
 		if errors.As(err, &ghErr) {
 			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[DEBUG] Missing GitHub ref %s/%s (%s)", owner, repoName, ref)
+				tflog.Debug(ctx, "Missing GitHub ref", map[string]any{
+					"owner":    owner,
+					"repoName": repoName,
+					"ref":      ref,
+				})
 				d.SetId("")
 				return nil
 			}

--- a/github/data_source_github_ref.go
+++ b/github/data_source_github_ref.go
@@ -3,10 +3,10 @@ package github
 import (
 	"context"
 	"errors"
-	"log"
 	"net/http"
 
 	"github.com/google/go-github/v88/github"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -56,7 +56,7 @@ func dataSourceGithubRefRead(ctx context.Context, d *schema.ResourceData, meta a
 		var ghErr *github.ErrorResponse
 		if errors.As(err, &ghErr) {
 			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[DEBUG] Missing GitHub ref %s/%s (%s)", owner, repoName, ref)
+				tflog.Debug(ctx, "Missing GitHub ref", map[string]any{"owner": owner, "repoName": repoName, "ref": ref})
 				d.SetId("")
 				return nil
 			}

--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 
 	"github.com/google/go-github/v84/github"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -370,7 +370,10 @@ func dataSourceGithubRepositoryRead(ctx context.Context, d *schema.ResourceData,
 		var ghErr *github.ErrorResponse
 		if errors.As(err, &ghErr) {
 			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[DEBUG] Missing GitHub repository %s/%s", owner, repoName)
+				tflog.Debug(ctx, "Missing GitHub repository", map[string]any{
+					"owner": owner,
+					"repo":  repoName,
+				})
 				d.SetId("")
 				return nil
 			}

--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 
 	"github.com/google/go-github/v88/github"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -371,7 +371,7 @@ func dataSourceGithubRepositoryRead(ctx context.Context, d *schema.ResourceData,
 		var ghErr *github.ErrorResponse
 		if errors.As(err, &ghErr) {
 			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[DEBUG] Missing GitHub repository %s/%s", owner, repoName)
+				tflog.Debug(ctx, "Missing GitHub repository", map[string]any{"owner": owner, "repo": repoName})
 				d.SetId("")
 				return nil
 			}

--- a/github/data_source_github_repository_file.go
+++ b/github/data_source_github_repository_file.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/google/go-github/v84/github"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -83,11 +83,16 @@ func dataSourceGithubRepositoryFileRead(ctx context.Context, d *schema.ResourceD
 	// split and replace owner and repo
 	parts := strings.Split(repo, "/")
 	if len(parts) == 2 {
-		log.Printf("[DEBUG] repo has a slash, extracting owner from: %s", repo)
+		tflog.Debug(ctx, "repo has a slash, extracting owner from", map[string]any{
+			"repo": repo,
+		})
 		owner = parts[0]
 		repo = parts[1]
 
-		log.Printf("[DEBUG] owner: %s repo:%s", owner, repo)
+		tflog.Debug(ctx, "owner and repo", map[string]any{
+			"owner": owner,
+			"repo":  repo,
+		})
 	}
 
 	file := d.Get("file").(string)
@@ -102,7 +107,11 @@ func dataSourceGithubRepositoryFileRead(ctx context.Context, d *schema.ResourceD
 		var ghErr *github.ErrorResponse
 		if errors.As(err, &ghErr) {
 			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[DEBUG] Missing GitHub repository file %s/%s/%s", owner, repo, file)
+				tflog.Debug(ctx, "Missing GitHub repository file", map[string]any{
+					"owner": owner,
+					"repo":  repo,
+					"file":  file,
+				})
 				d.SetId("")
 				return nil
 			}
@@ -145,12 +154,21 @@ func dataSourceGithubRepositoryFileRead(ctx context.Context, d *schema.ResourceD
 		})
 	}
 
-	log.Printf("[DEBUG] Data Source fetching commit info for repository file: %s/%s/%s", owner, repo, file)
+	tflog.Debug(ctx, "Data Source fetching commit info for repository file", map[string]any{
+		"owner": owner,
+		"repo":  repo,
+		"file":  file,
+	})
 	commit, err := getFileCommit(ctx, client, owner, repo, file, ref)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	log.Printf("[DEBUG] Found file: %s/%s/%s, in commit SHA: %s ", owner, repo, file, commit.GetSHA())
+	tflog.Debug(ctx, "Found file, in commit SHA", map[string]any{
+		"owner": owner,
+		"repo":  repo,
+		"file":  file,
+		"sha":   commit.GetSHA(),
+	})
 
 	if err = d.Set("commit_sha", commit.GetSHA()); err != nil {
 		return diag.FromErr(err)

--- a/github/data_source_github_repository_file.go
+++ b/github/data_source_github_repository_file.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/google/go-github/v88/github"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -83,11 +83,11 @@ func dataSourceGithubRepositoryFileRead(ctx context.Context, d *schema.ResourceD
 	// split and replace owner and repo
 	parts := strings.Split(repo, "/")
 	if len(parts) == 2 {
-		log.Printf("[DEBUG] repo has a slash, extracting owner from: %s", repo)
+		tflog.Debug(ctx, "repo has a slash, extracting owner from", map[string]any{"repo": repo})
 		owner = parts[0]
 		repo = parts[1]
 
-		log.Printf("[DEBUG] owner: %s repo:%s", owner, repo)
+		tflog.Debug(ctx, "owner and repo", map[string]any{"owner": owner, "repo": repo})
 	}
 
 	file := d.Get("file").(string)
@@ -102,7 +102,7 @@ func dataSourceGithubRepositoryFileRead(ctx context.Context, d *schema.ResourceD
 		var ghErr *github.ErrorResponse
 		if errors.As(err, &ghErr) {
 			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[DEBUG] Missing GitHub repository file %s/%s/%s", owner, repo, file)
+				tflog.Debug(ctx, "Missing GitHub repository file", map[string]any{"owner": owner, "repo": repo, "file": file})
 				d.SetId("")
 				return nil
 			}
@@ -145,12 +145,12 @@ func dataSourceGithubRepositoryFileRead(ctx context.Context, d *schema.ResourceD
 		})
 	}
 
-	log.Printf("[DEBUG] Data Source fetching commit info for repository file: %s/%s/%s", owner, repo, file)
+	tflog.Debug(ctx, "Data Source fetching commit info for repository file", map[string]any{"owner": owner, "repo": repo, "file": file})
 	commit, err := getFileCommit(ctx, client, owner, repo, file, ref)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	log.Printf("[DEBUG] Found file: %s/%s/%s, in commit SHA: %s ", owner, repo, file, commit.GetSHA())
+	tflog.Debug(ctx, "Found file, in commit SHA", map[string]any{"owner": owner, "repo": repo, "file": file, "sha": commit.GetSHA()})
 
 	if err = d.Set("commit_sha", commit.GetSHA()); err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

Addresses parts of #3070
----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->
"Logging was using the standard Go log package, which outputs unstructured text to stdout."
- 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
"Migrated selected data sources to use tflog for structured logging. This allows for better log filtering and follows the Terraform Plugin SDK v2 best practices."
- 

### Pull request checklist

- [ ] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
