### PR TITLE
fix: use correct getter for members_can_fork_private_repositories in org data source

### DIFF
--- a/github/data_source_github_organization.go
+++ b/github/data_source_github_organization.go
@@ -254,7 +254,7 @@ func dataSourceGithubOrganizationRead(ctx context.Context, d *schema.ResourceDat
 		_ = d.Set("members_can_create_public_repositories", organization.GetMembersCanCreatePublicRepos())
 		_ = d.Set("members_can_create_private_repositories", organization.GetMembersCanCreatePrivateRepos())
 		_ = d.Set("members_can_create_internal_repositories", organization.GetMembersCanCreateInternalRepos())
-		_ = d.Set("members_can_fork_private_repositories", organization.GetMembersCanCreatePrivateRepos())
+		_ = d.Set("members_can_fork_private_repositories", organization.GetMembersCanForkPrivateRepos())
 		_ = d.Set("web_commit_signoff_required", organization.GetWebCommitSignoffRequired())
 		_ = d.Set("members_can_create_pages", organization.GetMembersCanCreatePages())
 		_ = d.Set("members_can_create_public_pages", organization.GetMembersCanCreatePublicPages())


### PR DESCRIPTION
Resolves #3362

----

### Before the change?

- `data_source_github_organization.go:257` calls `organization.GetMembersCanCreatePrivateRepos()` to populate `members_can_fork_private_repositories`, returning the value of `members_can_create_private_repositories` instead.

### After the change?

- Uses the correct getter `organization.GetMembersCanForkPrivateRepos()`, returning the actual fork permission value.

### Pull request checklist

- [x] Schema migrations have been created if needed
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No