### PR TITLE
feat: add github_enterprise_private_repository_forking_setting resource

### DIFF
--- a/github/provider.go
+++ b/github/provider.go
@@ -219,6 +219,7 @@ func Provider() *schema.Provider {
 			"github_enterprise_ip_allow_list_entry":                                 resourceGithubEnterpriseIpAllowListEntry(),
 			"github_enterprise_actions_workflow_permissions":                        resourceGithubEnterpriseActionsWorkflowPermissions(),
 			"github_actions_organization_workflow_permissions":                      resourceGithubActionsOrganizationWorkflowPermissions(),
+			"github_enterprise_private_repository_forking_setting":                  resourceGithubEnterprisePrivateRepositoryForkingSetting(),
 			"github_enterprise_security_analysis_settings":                          resourceGithubEnterpriseSecurityAnalysisSettings(),
 			"github_workflow_repository_permissions":                                resourceGithubWorkflowRepositoryPermissions(),
 		},

--- a/github/resource_github_enterprise_private_repository_forking_setting.go
+++ b/github/resource_github_enterprise_private_repository_forking_setting.go
@@ -22,14 +22,14 @@ func resourceGithubEnterprisePrivateRepositoryForkingSetting() *schema.Resource 
 		},
 
 		CustomizeDiff: func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
-			settingValue := diff.Get("setting_value").(string)
-			policyValue := diff.Get("policy_value").(string)
+			settingValue := diff.Get("setting").(string)
+			policyValue := diff.Get("policy").(string)
 
 			if settingValue == "ENABLED" && policyValue == "" {
-				return fmt.Errorf("policy_value is required when setting_value is ENABLED")
+				return fmt.Errorf("policy is required when setting is ENABLED")
 			}
 			if settingValue != "ENABLED" && policyValue != "" {
-				return fmt.Errorf("policy_value must not be set when setting_value is %s", settingValue)
+				return fmt.Errorf("policy must not be set when setting is %s", settingValue)
 			}
 			return nil
 		},
@@ -41,7 +41,7 @@ func resourceGithubEnterprisePrivateRepositoryForkingSetting() *schema.Resource 
 				ForceNew:    true,
 				Description: "The slug of the enterprise.",
 			},
-			"setting_value": {
+			"setting": {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
@@ -51,7 +51,7 @@ func resourceGithubEnterprisePrivateRepositoryForkingSetting() *schema.Resource 
 				}, false)),
 				Description: "Whether private repository forking is enabled for the enterprise. Must be one of: ENABLED, DISABLED, NO_POLICY.",
 			},
-			"policy_value": {
+			"policy": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
@@ -62,7 +62,7 @@ func resourceGithubEnterprisePrivateRepositoryForkingSetting() *schema.Resource 
 					"USER_ACCOUNTS",
 					"EVERYWHERE",
 				}, false)),
-				Description: "Where members can fork private repositories. Required when setting_value is ENABLED. Must be one of: ENTERPRISE_ORGANIZATIONS, SAME_ORGANIZATION, SAME_ORGANIZATION_USER_ACCOUNTS, ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS, USER_ACCOUNTS, EVERYWHERE.",
+				Description: "Where members can fork private repositories. Required when setting is ENABLED. Must be one of: ENTERPRISE_ORGANIZATIONS, SAME_ORGANIZATION, SAME_ORGANIZATION_USER_ACCOUNTS, ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS, USER_ACCOUNTS, EVERYWHERE.",
 			},
 		},
 	}
@@ -79,14 +79,14 @@ func resourceGithubEnterprisePrivateRepositoryForkingSettingCreateOrUpdate(d *sc
 		return fmt.Errorf("error resolving enterprise ID for slug %q: %w", enterpriseSlug, err)
 	}
 
-	settingValue := githubv4.EnterpriseEnabledDisabledSettingValue(d.Get("setting_value").(string))
+	settingValue := githubv4.EnterpriseEnabledDisabledSettingValue(d.Get("setting").(string))
 
 	input := githubv4.UpdateEnterpriseAllowPrivateRepositoryForkingSettingInput{
 		EnterpriseID: enterpriseID,
 		SettingValue: settingValue,
 	}
 
-	if v, ok := d.GetOk("policy_value"); ok {
+	if v, ok := d.GetOk("policy"); ok {
 		pv := githubv4.EnterpriseAllowPrivateRepositoryForkingPolicyValue(v.(string))
 		input.PolicyValue = &pv
 	}
@@ -141,16 +141,16 @@ func resourceGithubEnterprisePrivateRepositoryForkingSettingRead(d *schema.Resou
 	}
 
 	settingValue := string(query.Enterprise.OwnerInfo.AllowPrivateRepositoryForkingSetting)
-	if err := d.Set("setting_value", settingValue); err != nil {
+	if err := d.Set("setting", settingValue); err != nil {
 		return err
 	}
 
 	if settingValue == "ENABLED" {
-		if err := d.Set("policy_value", string(query.Enterprise.OwnerInfo.AllowPrivateRepositoryForkingSettingPolicyValue)); err != nil {
+		if err := d.Set("policy", string(query.Enterprise.OwnerInfo.AllowPrivateRepositoryForkingSettingPolicyValue)); err != nil {
 			return err
 		}
 	} else {
-		if err := d.Set("policy_value", ""); err != nil {
+		if err := d.Set("policy", ""); err != nil {
 			return err
 		}
 	}

--- a/github/resource_github_enterprise_private_repository_forking_setting.go
+++ b/github/resource_github_enterprise_private_repository_forking_setting.go
@@ -1,0 +1,192 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/shurcooL/githubv4"
+)
+
+func resourceGithubEnterprisePrivateRepositoryForkingSetting() *schema.Resource {
+	return &schema.Resource{
+		Description: "Manages the private repository forking policy for a GitHub Enterprise.",
+		Create:      resourceGithubEnterprisePrivateRepositoryForkingSettingCreateOrUpdate,
+		Read:        resourceGithubEnterprisePrivateRepositoryForkingSettingRead,
+		Update:      resourceGithubEnterprisePrivateRepositoryForkingSettingCreateOrUpdate,
+		Delete:      resourceGithubEnterprisePrivateRepositoryForkingSettingDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
+			settingValue := diff.Get("setting_value").(string)
+			policyValue := diff.Get("policy_value").(string)
+
+			if settingValue == "ENABLED" && policyValue == "" {
+				return fmt.Errorf("policy_value is required when setting_value is ENABLED")
+			}
+			if settingValue != "ENABLED" && policyValue != "" {
+				return fmt.Errorf("policy_value must not be set when setting_value is %s", settingValue)
+			}
+			return nil
+		},
+
+		Schema: map[string]*schema.Schema{
+			"enterprise_slug": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The slug of the enterprise.",
+			},
+			"setting_value": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
+					"ENABLED",
+					"DISABLED",
+					"NO_POLICY",
+				}, false)),
+				Description: "Whether private repository forking is enabled for the enterprise. Must be one of: ENABLED, DISABLED, NO_POLICY.",
+			},
+			"policy_value": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
+					"ENTERPRISE_ORGANIZATIONS",
+					"SAME_ORGANIZATION",
+					"SAME_ORGANIZATION_USER_ACCOUNTS",
+					"ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS",
+					"USER_ACCOUNTS",
+					"EVERYWHERE",
+				}, false)),
+				Description: "Where members can fork private repositories. Required when setting_value is ENABLED. Must be one of: ENTERPRISE_ORGANIZATIONS, SAME_ORGANIZATION, SAME_ORGANIZATION_USER_ACCOUNTS, ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS, USER_ACCOUNTS, EVERYWHERE.",
+			},
+		},
+	}
+}
+
+func resourceGithubEnterprisePrivateRepositoryForkingSettingCreateOrUpdate(d *schema.ResourceData, meta any) error {
+	client := meta.(*Owner).v4client
+	ctx := context.Background()
+
+	enterpriseSlug := d.Get("enterprise_slug").(string)
+
+	enterpriseID, err := getEnterpriseID(ctx, client, enterpriseSlug)
+	if err != nil {
+		return fmt.Errorf("error resolving enterprise ID for slug %q: %w", enterpriseSlug, err)
+	}
+
+	settingValue := githubv4.EnterpriseEnabledDisabledSettingValue(d.Get("setting_value").(string))
+
+	input := githubv4.UpdateEnterpriseAllowPrivateRepositoryForkingSettingInput{
+		EnterpriseID: enterpriseID,
+		SettingValue: settingValue,
+	}
+
+	if v, ok := d.GetOk("policy_value"); ok {
+		pv := githubv4.EnterpriseAllowPrivateRepositoryForkingPolicyValue(v.(string))
+		input.PolicyValue = &pv
+	}
+
+	var mutate struct {
+		UpdateEnterpriseAllowPrivateRepositoryForkingSetting struct {
+			Enterprise struct {
+				ID githubv4.ID
+			}
+			Message githubv4.String
+		} `graphql:"updateEnterpriseAllowPrivateRepositoryForkingSetting(input: $input)"`
+	}
+
+	log.Printf("[DEBUG] Updating private repository forking setting for enterprise: %s", enterpriseSlug)
+	err = client.Mutate(ctx, &mutate, input, nil)
+	if err != nil {
+		return fmt.Errorf("error updating private repository forking setting for enterprise %q: %w", enterpriseSlug, err)
+	}
+
+	d.SetId(enterpriseSlug)
+
+	return resourceGithubEnterprisePrivateRepositoryForkingSettingRead(d, meta)
+}
+
+func resourceGithubEnterprisePrivateRepositoryForkingSettingRead(d *schema.ResourceData, meta any) error {
+	client := meta.(*Owner).v4client
+	ctx := context.Background()
+
+	enterpriseSlug := d.Id()
+
+	var query struct {
+		Enterprise struct {
+			OwnerInfo struct {
+				AllowPrivateRepositoryForkingSetting            githubv4.EnterpriseEnabledDisabledSettingValue
+				AllowPrivateRepositoryForkingSettingPolicyValue githubv4.EnterpriseAllowPrivateRepositoryForkingPolicyValue
+			}
+		} `graphql:"enterprise(slug: $slug)"`
+	}
+
+	variables := map[string]any{
+		"slug": githubv4.String(enterpriseSlug),
+	}
+
+	log.Printf("[DEBUG] Reading private repository forking setting for enterprise: %s", enterpriseSlug)
+	err := client.Query(ctx, &query, variables)
+	if err != nil {
+		return fmt.Errorf("error reading private repository forking setting for enterprise %q: %w", enterpriseSlug, err)
+	}
+
+	if err := d.Set("enterprise_slug", enterpriseSlug); err != nil {
+		return err
+	}
+
+	settingValue := string(query.Enterprise.OwnerInfo.AllowPrivateRepositoryForkingSetting)
+	if err := d.Set("setting_value", settingValue); err != nil {
+		return err
+	}
+
+	if settingValue == "ENABLED" {
+		if err := d.Set("policy_value", string(query.Enterprise.OwnerInfo.AllowPrivateRepositoryForkingSettingPolicyValue)); err != nil {
+			return err
+		}
+	} else {
+		if err := d.Set("policy_value", ""); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func resourceGithubEnterprisePrivateRepositoryForkingSettingDelete(d *schema.ResourceData, meta any) error {
+	client := meta.(*Owner).v4client
+	ctx := context.Background()
+
+	enterpriseSlug := d.Id()
+
+	enterpriseID, err := getEnterpriseID(ctx, client, enterpriseSlug)
+	if err != nil {
+		return fmt.Errorf("error resolving enterprise ID for slug %q: %w", enterpriseSlug, err)
+	}
+
+	input := githubv4.UpdateEnterpriseAllowPrivateRepositoryForkingSettingInput{
+		EnterpriseID: enterpriseID,
+		SettingValue: githubv4.EnterpriseEnabledDisabledSettingValueNoPolicy,
+	}
+
+	var mutate struct {
+		UpdateEnterpriseAllowPrivateRepositoryForkingSetting struct {
+			Enterprise struct {
+				ID githubv4.ID
+			}
+		} `graphql:"updateEnterpriseAllowPrivateRepositoryForkingSetting(input: $input)"`
+	}
+
+	log.Printf("[DEBUG] Resetting private repository forking setting to NO_POLICY for enterprise: %s", enterpriseSlug)
+	err = client.Mutate(ctx, &mutate, input, nil)
+	if err != nil {
+		return fmt.Errorf("error resetting private repository forking setting for enterprise %q: %w", enterpriseSlug, err)
+	}
+
+	return nil
+}

--- a/github/resource_github_enterprise_private_repository_forking_setting_test.go
+++ b/github/resource_github_enterprise_private_repository_forking_setting_test.go
@@ -8,192 +8,115 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAccGithubEnterprisePrivateRepositoryForkingSetting(t *testing.T) {
-	t.Run("enables private repository forking with policy", func(t *testing.T) {
-		config := fmt.Sprintf(`
+const testAccEnterpriseForkingSettingResource = "github_enterprise_private_repository_forking_setting.test"
+
+func testAccEnterpriseForkingSettingConfig(settingValue, policyValue string) string {
+	if policyValue != "" {
+		return fmt.Sprintf(`
 		resource "github_enterprise_private_repository_forking_setting" "test" {
 			enterprise_slug = "%s"
-			setting_value   = "ENABLED"
-			policy_value    = "SAME_ORGANIZATION"
+			setting_value   = "%s"
+			policy_value    = "%s"
 		}
-		`, testAccConf.enterpriseSlug)
+		`, testAccConf.enterpriseSlug, settingValue, policyValue)
+	}
+	return fmt.Sprintf(`
+	resource "github_enterprise_private_repository_forking_setting" "test" {
+		enterprise_slug = "%s"
+		setting_value   = "%s"
+	}
+	`, testAccConf.enterpriseSlug, settingValue)
+}
 
-		check := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "enterprise_slug", testAccConf.enterpriseSlug),
-			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "setting_value", "ENABLED"),
-			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "policy_value", "SAME_ORGANIZATION"),
-		)
+func testAccEnterpriseForkingSettingCheck(settingValue, policyValue string) resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr(testAccEnterpriseForkingSettingResource, "enterprise_slug", testAccConf.enterpriseSlug),
+		resource.TestCheckResourceAttr(testAccEnterpriseForkingSettingResource, "setting_value", settingValue),
+		resource.TestCheckResourceAttr(testAccEnterpriseForkingSettingResource, "policy_value", policyValue),
+	)
+}
 
+func TestAccGithubEnterprisePrivateRepositoryForkingSetting(t *testing.T) {
+	t.Run("enables private repository forking with policy", func(t *testing.T) {
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
-					Config: config,
-					Check:  check,
+					Config: testAccEnterpriseForkingSettingConfig("ENABLED", "SAME_ORGANIZATION"),
+					Check:  testAccEnterpriseForkingSettingCheck("ENABLED", "SAME_ORGANIZATION"),
 				},
 			},
 		})
 	})
 
 	t.Run("updates policy value", func(t *testing.T) {
-		configs := map[string]string{
-			"before": fmt.Sprintf(`
-			resource "github_enterprise_private_repository_forking_setting" "test" {
-				enterprise_slug = "%s"
-				setting_value   = "ENABLED"
-				policy_value    = "SAME_ORGANIZATION"
-			}
-			`, testAccConf.enterpriseSlug),
-
-			"after": fmt.Sprintf(`
-			resource "github_enterprise_private_repository_forking_setting" "test" {
-				enterprise_slug = "%s"
-				setting_value   = "ENABLED"
-				policy_value    = "ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS"
-			}
-			`, testAccConf.enterpriseSlug),
-		}
-
-		checks := map[string]resource.TestCheckFunc{
-			"before": resource.ComposeTestCheckFunc(
-				resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "setting_value", "ENABLED"),
-				resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "policy_value", "SAME_ORGANIZATION"),
-			),
-			"after": resource.ComposeTestCheckFunc(
-				resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "setting_value", "ENABLED"),
-				resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "policy_value", "ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS"),
-			),
-		}
-
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
-					Config: configs["before"],
-					Check:  checks["before"],
+					Config: testAccEnterpriseForkingSettingConfig("ENABLED", "SAME_ORGANIZATION"),
+					Check:  testAccEnterpriseForkingSettingCheck("ENABLED", "SAME_ORGANIZATION"),
 				},
 				{
-					Config: configs["after"],
-					Check:  checks["after"],
+					Config: testAccEnterpriseForkingSettingConfig("ENABLED", "ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS"),
+					Check:  testAccEnterpriseForkingSettingCheck("ENABLED", "ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS"),
 				},
 			},
 		})
 	})
 
 	t.Run("disables private repository forking", func(t *testing.T) {
-		config := fmt.Sprintf(`
-		resource "github_enterprise_private_repository_forking_setting" "test" {
-			enterprise_slug = "%s"
-			setting_value   = "DISABLED"
-		}
-		`, testAccConf.enterpriseSlug)
-
-		check := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "enterprise_slug", testAccConf.enterpriseSlug),
-			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "setting_value", "DISABLED"),
-			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "policy_value", ""),
-		)
-
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
-					Config: config,
-					Check:  check,
+					Config: testAccEnterpriseForkingSettingConfig("DISABLED", ""),
+					Check:  testAccEnterpriseForkingSettingCheck("DISABLED", ""),
 				},
 			},
 		})
 	})
 
 	t.Run("sets no policy", func(t *testing.T) {
-		config := fmt.Sprintf(`
-		resource "github_enterprise_private_repository_forking_setting" "test" {
-			enterprise_slug = "%s"
-			setting_value   = "NO_POLICY"
-		}
-		`, testAccConf.enterpriseSlug)
-
-		check := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "enterprise_slug", testAccConf.enterpriseSlug),
-			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "setting_value", "NO_POLICY"),
-			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "policy_value", ""),
-		)
-
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
-					Config: config,
-					Check:  check,
+					Config: testAccEnterpriseForkingSettingConfig("NO_POLICY", ""),
+					Check:  testAccEnterpriseForkingSettingCheck("NO_POLICY", ""),
 				},
 			},
 		})
 	})
 
 	t.Run("transitions from enabled to disabled", func(t *testing.T) {
-		configs := map[string]string{
-			"enabled": fmt.Sprintf(`
-			resource "github_enterprise_private_repository_forking_setting" "test" {
-				enterprise_slug = "%s"
-				setting_value   = "ENABLED"
-				policy_value    = "SAME_ORGANIZATION"
-			}
-			`, testAccConf.enterpriseSlug),
-
-			"disabled": fmt.Sprintf(`
-			resource "github_enterprise_private_repository_forking_setting" "test" {
-				enterprise_slug = "%s"
-				setting_value   = "DISABLED"
-			}
-			`, testAccConf.enterpriseSlug),
-		}
-
-		checks := map[string]resource.TestCheckFunc{
-			"enabled": resource.ComposeTestCheckFunc(
-				resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "setting_value", "ENABLED"),
-				resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "policy_value", "SAME_ORGANIZATION"),
-			),
-			"disabled": resource.ComposeTestCheckFunc(
-				resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "setting_value", "DISABLED"),
-				resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "policy_value", ""),
-			),
-		}
-
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
-					Config: configs["enabled"],
-					Check:  checks["enabled"],
+					Config: testAccEnterpriseForkingSettingConfig("ENABLED", "SAME_ORGANIZATION"),
+					Check:  testAccEnterpriseForkingSettingCheck("ENABLED", "SAME_ORGANIZATION"),
 				},
 				{
-					Config: configs["disabled"],
-					Check:  checks["disabled"],
+					Config: testAccEnterpriseForkingSettingConfig("DISABLED", ""),
+					Check:  testAccEnterpriseForkingSettingCheck("DISABLED", ""),
 				},
 			},
 		})
 	})
 
 	t.Run("rejects policy_value when disabled", func(t *testing.T) {
-		config := fmt.Sprintf(`
-		resource "github_enterprise_private_repository_forking_setting" "test" {
-			enterprise_slug = "%s"
-			setting_value   = "DISABLED"
-			policy_value    = "SAME_ORGANIZATION"
-		}
-		`, testAccConf.enterpriseSlug)
-
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
-					Config:      config,
+					Config:      testAccEnterpriseForkingSettingConfig("DISABLED", "SAME_ORGANIZATION"),
 					ExpectError: regexp.MustCompile(`policy_value must not be set when setting_value is DISABLED`),
 				},
 			},
@@ -201,19 +124,12 @@ func TestAccGithubEnterprisePrivateRepositoryForkingSetting(t *testing.T) {
 	})
 
 	t.Run("requires policy_value when enabled", func(t *testing.T) {
-		config := fmt.Sprintf(`
-		resource "github_enterprise_private_repository_forking_setting" "test" {
-			enterprise_slug = "%s"
-			setting_value   = "ENABLED"
-		}
-		`, testAccConf.enterpriseSlug)
-
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
-					Config:      config,
+					Config:      testAccEnterpriseForkingSettingConfig("ENABLED", ""),
 					ExpectError: regexp.MustCompile(`policy_value is required when setting_value is ENABLED`),
 				},
 			},
@@ -221,30 +137,16 @@ func TestAccGithubEnterprisePrivateRepositoryForkingSetting(t *testing.T) {
 	})
 
 	t.Run("imports without error", func(t *testing.T) {
-		config := fmt.Sprintf(`
-		resource "github_enterprise_private_repository_forking_setting" "test" {
-			enterprise_slug = "%s"
-			setting_value   = "ENABLED"
-			policy_value    = "ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS"
-		}
-		`, testAccConf.enterpriseSlug)
-
-		check := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "enterprise_slug", testAccConf.enterpriseSlug),
-			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "setting_value", "ENABLED"),
-			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "policy_value", "ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS"),
-		)
-
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
-					Config: config,
-					Check:  check,
+					Config: testAccEnterpriseForkingSettingConfig("ENABLED", "ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS"),
+					Check:  testAccEnterpriseForkingSettingCheck("ENABLED", "ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS"),
 				},
 				{
-					ResourceName:      "github_enterprise_private_repository_forking_setting.test",
+					ResourceName:      testAccEnterpriseForkingSettingResource,
 					ImportState:       true,
 					ImportStateVerify: true,
 				},

--- a/github/resource_github_enterprise_private_repository_forking_setting_test.go
+++ b/github/resource_github_enterprise_private_repository_forking_setting_test.go
@@ -1,0 +1,254 @@
+package github
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccGithubEnterprisePrivateRepositoryForkingSetting(t *testing.T) {
+	t.Run("enables private repository forking with policy", func(t *testing.T) {
+		config := fmt.Sprintf(`
+		resource "github_enterprise_private_repository_forking_setting" "test" {
+			enterprise_slug = "%s"
+			setting_value   = "ENABLED"
+			policy_value    = "SAME_ORGANIZATION"
+		}
+		`, testAccConf.enterpriseSlug)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "enterprise_slug", testAccConf.enterpriseSlug),
+			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "setting_value", "ENABLED"),
+			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "policy_value", "SAME_ORGANIZATION"),
+		)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessEnterprise(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check:  check,
+				},
+			},
+		})
+	})
+
+	t.Run("updates policy value", func(t *testing.T) {
+		configs := map[string]string{
+			"before": fmt.Sprintf(`
+			resource "github_enterprise_private_repository_forking_setting" "test" {
+				enterprise_slug = "%s"
+				setting_value   = "ENABLED"
+				policy_value    = "SAME_ORGANIZATION"
+			}
+			`, testAccConf.enterpriseSlug),
+
+			"after": fmt.Sprintf(`
+			resource "github_enterprise_private_repository_forking_setting" "test" {
+				enterprise_slug = "%s"
+				setting_value   = "ENABLED"
+				policy_value    = "ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS"
+			}
+			`, testAccConf.enterpriseSlug),
+		}
+
+		checks := map[string]resource.TestCheckFunc{
+			"before": resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "setting_value", "ENABLED"),
+				resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "policy_value", "SAME_ORGANIZATION"),
+			),
+			"after": resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "setting_value", "ENABLED"),
+				resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "policy_value", "ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS"),
+			),
+		}
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessEnterprise(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: configs["before"],
+					Check:  checks["before"],
+				},
+				{
+					Config: configs["after"],
+					Check:  checks["after"],
+				},
+			},
+		})
+	})
+
+	t.Run("disables private repository forking", func(t *testing.T) {
+		config := fmt.Sprintf(`
+		resource "github_enterprise_private_repository_forking_setting" "test" {
+			enterprise_slug = "%s"
+			setting_value   = "DISABLED"
+		}
+		`, testAccConf.enterpriseSlug)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "enterprise_slug", testAccConf.enterpriseSlug),
+			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "setting_value", "DISABLED"),
+			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "policy_value", ""),
+		)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessEnterprise(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check:  check,
+				},
+			},
+		})
+	})
+
+	t.Run("sets no policy", func(t *testing.T) {
+		config := fmt.Sprintf(`
+		resource "github_enterprise_private_repository_forking_setting" "test" {
+			enterprise_slug = "%s"
+			setting_value   = "NO_POLICY"
+		}
+		`, testAccConf.enterpriseSlug)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "enterprise_slug", testAccConf.enterpriseSlug),
+			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "setting_value", "NO_POLICY"),
+			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "policy_value", ""),
+		)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessEnterprise(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check:  check,
+				},
+			},
+		})
+	})
+
+	t.Run("transitions from enabled to disabled", func(t *testing.T) {
+		configs := map[string]string{
+			"enabled": fmt.Sprintf(`
+			resource "github_enterprise_private_repository_forking_setting" "test" {
+				enterprise_slug = "%s"
+				setting_value   = "ENABLED"
+				policy_value    = "SAME_ORGANIZATION"
+			}
+			`, testAccConf.enterpriseSlug),
+
+			"disabled": fmt.Sprintf(`
+			resource "github_enterprise_private_repository_forking_setting" "test" {
+				enterprise_slug = "%s"
+				setting_value   = "DISABLED"
+			}
+			`, testAccConf.enterpriseSlug),
+		}
+
+		checks := map[string]resource.TestCheckFunc{
+			"enabled": resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "setting_value", "ENABLED"),
+				resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "policy_value", "SAME_ORGANIZATION"),
+			),
+			"disabled": resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "setting_value", "DISABLED"),
+				resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "policy_value", ""),
+			),
+		}
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessEnterprise(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: configs["enabled"],
+					Check:  checks["enabled"],
+				},
+				{
+					Config: configs["disabled"],
+					Check:  checks["disabled"],
+				},
+			},
+		})
+	})
+
+	t.Run("rejects policy_value when disabled", func(t *testing.T) {
+		config := fmt.Sprintf(`
+		resource "github_enterprise_private_repository_forking_setting" "test" {
+			enterprise_slug = "%s"
+			setting_value   = "DISABLED"
+			policy_value    = "SAME_ORGANIZATION"
+		}
+		`, testAccConf.enterpriseSlug)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessEnterprise(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:      config,
+					ExpectError: regexp.MustCompile(`policy_value must not be set when setting_value is DISABLED`),
+				},
+			},
+		})
+	})
+
+	t.Run("requires policy_value when enabled", func(t *testing.T) {
+		config := fmt.Sprintf(`
+		resource "github_enterprise_private_repository_forking_setting" "test" {
+			enterprise_slug = "%s"
+			setting_value   = "ENABLED"
+		}
+		`, testAccConf.enterpriseSlug)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessEnterprise(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:      config,
+					ExpectError: regexp.MustCompile(`policy_value is required when setting_value is ENABLED`),
+				},
+			},
+		})
+	})
+
+	t.Run("imports without error", func(t *testing.T) {
+		config := fmt.Sprintf(`
+		resource "github_enterprise_private_repository_forking_setting" "test" {
+			enterprise_slug = "%s"
+			setting_value   = "ENABLED"
+			policy_value    = "ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS"
+		}
+		`, testAccConf.enterpriseSlug)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "enterprise_slug", testAccConf.enterpriseSlug),
+			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "setting_value", "ENABLED"),
+			resource.TestCheckResourceAttr("github_enterprise_private_repository_forking_setting.test", "policy_value", "ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS"),
+		)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessEnterprise(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check:  check,
+				},
+				{
+					ResourceName:      "github_enterprise_private_repository_forking_setting.test",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	})
+}

--- a/github/resource_github_enterprise_private_repository_forking_setting_test.go
+++ b/github/resource_github_enterprise_private_repository_forking_setting_test.go
@@ -15,15 +15,15 @@ func testAccEnterpriseForkingSettingConfig(settingValue, policyValue string) str
 		return fmt.Sprintf(`
 		resource "github_enterprise_private_repository_forking_setting" "test" {
 			enterprise_slug = "%s"
-			setting_value   = "%s"
-			policy_value    = "%s"
+			setting   = "%s"
+			policy    = "%s"
 		}
 		`, testAccConf.enterpriseSlug, settingValue, policyValue)
 	}
 	return fmt.Sprintf(`
 	resource "github_enterprise_private_repository_forking_setting" "test" {
 		enterprise_slug = "%s"
-		setting_value   = "%s"
+		setting   = "%s"
 	}
 	`, testAccConf.enterpriseSlug, settingValue)
 }
@@ -31,8 +31,8 @@ func testAccEnterpriseForkingSettingConfig(settingValue, policyValue string) str
 func testAccEnterpriseForkingSettingCheck(settingValue, policyValue string) resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr(testAccEnterpriseForkingSettingResource, "enterprise_slug", testAccConf.enterpriseSlug),
-		resource.TestCheckResourceAttr(testAccEnterpriseForkingSettingResource, "setting_value", settingValue),
-		resource.TestCheckResourceAttr(testAccEnterpriseForkingSettingResource, "policy_value", policyValue),
+		resource.TestCheckResourceAttr(testAccEnterpriseForkingSettingResource, "setting", settingValue),
+		resource.TestCheckResourceAttr(testAccEnterpriseForkingSettingResource, "policy", policyValue),
 	)
 }
 
@@ -110,27 +110,27 @@ func TestAccGithubEnterprisePrivateRepositoryForkingSetting(t *testing.T) {
 		})
 	})
 
-	t.Run("rejects policy_value when disabled", func(t *testing.T) {
+	t.Run("rejects policy when disabled", func(t *testing.T) {
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
 					Config:      testAccEnterpriseForkingSettingConfig("DISABLED", "SAME_ORGANIZATION"),
-					ExpectError: regexp.MustCompile(`policy_value must not be set when setting_value is DISABLED`),
+					ExpectError: regexp.MustCompile(`policy must not be set when setting is DISABLED`),
 				},
 			},
 		})
 	})
 
-	t.Run("requires policy_value when enabled", func(t *testing.T) {
+	t.Run("requires policy when enabled", func(t *testing.T) {
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessEnterprise(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
 					Config:      testAccEnterpriseForkingSettingConfig("ENABLED", ""),
-					ExpectError: regexp.MustCompile(`policy_value is required when setting_value is ENABLED`),
+					ExpectError: regexp.MustCompile(`policy is required when setting is ENABLED`),
 				},
 			},
 		})

--- a/website/docs/r/enterprise_private_repository_forking_setting.html.markdown
+++ b/website/docs/r/enterprise_private_repository_forking_setting.html.markdown
@@ -1,0 +1,82 @@
+---
+layout: "github"
+page_title: "GitHub: github_enterprise_private_repository_forking_setting"
+description: |-
+  Manages the private repository forking policy for a GitHub Enterprise.
+---
+
+# github_enterprise_private_repository_forking_setting
+
+This resource manages the enterprise-level policy that controls whether and where
+members can fork private and internal repositories within a GitHub Enterprise.
+
+When `setting_value` is `ENABLED`, the `policy_value` attribute controls where forks
+can be created. When `DISABLED`, forking of private repositories is not allowed.
+When `NO_POLICY`, individual organizations within the enterprise control their own
+forking settings.
+
+~> **Note:** You must have enterprise admin access to use this resource.
+
+## Example Usage
+
+### Restrict forking to same organization only
+
+```hcl
+resource "github_enterprise_private_repository_forking_setting" "example" {
+  enterprise_slug = "my-enterprise"
+  setting_value   = "ENABLED"
+  policy_value    = "SAME_ORGANIZATION"
+}
+```
+
+### Allow forking to enterprise-managed user accounts or enterprise organizations
+
+```hcl
+resource "github_enterprise_private_repository_forking_setting" "example" {
+  enterprise_slug = "my-enterprise"
+  setting_value   = "ENABLED"
+  policy_value    = "ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS"
+}
+```
+
+### Disable private repository forking entirely
+
+```hcl
+resource "github_enterprise_private_repository_forking_setting" "example" {
+  enterprise_slug = "my-enterprise"
+  setting_value   = "DISABLED"
+}
+```
+
+### Allow organizations to set their own policy
+
+```hcl
+resource "github_enterprise_private_repository_forking_setting" "example" {
+  enterprise_slug = "my-enterprise"
+  setting_value   = "NO_POLICY"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `enterprise_slug` - (Required) The slug of the enterprise.
+* `setting_value` - (Required) Whether private repository forking is enabled for the enterprise. Must be one of `ENABLED`, `DISABLED`, or `NO_POLICY`.
+* `policy_value` - (Optional) Where members can fork private repositories. Required when `setting_value` is `ENABLED`. Must be one of:
+  * `ENTERPRISE_ORGANIZATIONS` - Members can fork to an organization within this enterprise.
+  * `SAME_ORGANIZATION` - Members can fork only within the same organization (intra-org).
+  * `SAME_ORGANIZATION_USER_ACCOUNTS` - Members can fork to their user account or within the same organization.
+  * `ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS` - Members can fork to their enterprise-managed user account or an organization inside this enterprise.
+  * `USER_ACCOUNTS` - Members can fork to their user account.
+  * `EVERYWHERE` - Members can fork to their user account or an organization, either inside or outside of this enterprise.
+
+~> **Note:** Destroying this resource sets the enterprise policy to `NO_POLICY`, which allows individual organizations to control their own forking settings. It does not set the policy to `DISABLED`.
+
+## Import
+
+Enterprise private repository forking settings can be imported using the enterprise slug:
+
+```
+$ terraform import github_enterprise_private_repository_forking_setting.example my-enterprise
+```

--- a/website/docs/r/enterprise_private_repository_forking_setting.html.markdown
+++ b/website/docs/r/enterprise_private_repository_forking_setting.html.markdown
@@ -10,7 +10,7 @@ description: |-
 This resource allows you to create and manage the private repository forking policy for a GitHub Enterprise.
 You must have enterprise admin access to use this resource.
 
-When `setting_value` is `ENABLED`, the `policy_value` attribute controls where forks
+When `setting` is `ENABLED`, the `policy` attribute controls where forks
 can be created. When `DISABLED`, forking of private repositories is not allowed.
 When `NO_POLICY`, individual organizations within the enterprise control their own
 forking settings.
@@ -22,8 +22,8 @@ forking settings.
 ```hcl
 resource "github_enterprise_private_repository_forking_setting" "example" {
   enterprise_slug = "my-enterprise"
-  setting_value   = "ENABLED"
-  policy_value    = "SAME_ORGANIZATION"
+  setting   = "ENABLED"
+  policy    = "SAME_ORGANIZATION"
 }
 ```
 
@@ -32,8 +32,8 @@ resource "github_enterprise_private_repository_forking_setting" "example" {
 ```hcl
 resource "github_enterprise_private_repository_forking_setting" "example" {
   enterprise_slug = "my-enterprise"
-  setting_value   = "ENABLED"
-  policy_value    = "ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS"
+  setting   = "ENABLED"
+  policy    = "ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS"
 }
 ```
 
@@ -42,7 +42,7 @@ resource "github_enterprise_private_repository_forking_setting" "example" {
 ```hcl
 resource "github_enterprise_private_repository_forking_setting" "example" {
   enterprise_slug = "my-enterprise"
-  setting_value   = "DISABLED"
+  setting   = "DISABLED"
 }
 ```
 
@@ -51,7 +51,7 @@ resource "github_enterprise_private_repository_forking_setting" "example" {
 ```hcl
 resource "github_enterprise_private_repository_forking_setting" "example" {
   enterprise_slug = "my-enterprise"
-  setting_value   = "NO_POLICY"
+  setting   = "NO_POLICY"
 }
 ```
 
@@ -60,8 +60,8 @@ resource "github_enterprise_private_repository_forking_setting" "example" {
 The following arguments are supported:
 
 * `enterprise_slug` - (Required) The slug of the enterprise.
-* `setting_value` - (Required) Whether private repository forking is enabled for the enterprise. Must be one of `ENABLED`, `DISABLED`, or `NO_POLICY`.
-* `policy_value` - (Optional) Where members can fork private repositories. Required when `setting_value` is `ENABLED`. Must be one of:
+* `setting` - (Required) Whether private repository forking is enabled for the enterprise. Must be one of `ENABLED`, `DISABLED`, or `NO_POLICY`.
+* `policy` - (Optional) Where members can fork private repositories. Required when `setting` is `ENABLED`. Must be one of:
   * `ENTERPRISE_ORGANIZATIONS` - Members can fork to an organization within this enterprise.
   * `SAME_ORGANIZATION` - Members can fork only within the same organization (intra-org).
   * `SAME_ORGANIZATION_USER_ACCOUNTS` - Members can fork to their user account or within the same organization.

--- a/website/docs/r/enterprise_private_repository_forking_setting.html.markdown
+++ b/website/docs/r/enterprise_private_repository_forking_setting.html.markdown
@@ -2,20 +2,18 @@
 layout: "github"
 page_title: "GitHub: github_enterprise_private_repository_forking_setting"
 description: |-
-  Manages the private repository forking policy for a GitHub Enterprise.
+  Creates and manages the private repository forking policy for a GitHub Enterprise.
 ---
 
 # github_enterprise_private_repository_forking_setting
 
-This resource manages the enterprise-level policy that controls whether and where
-members can fork private and internal repositories within a GitHub Enterprise.
+This resource allows you to create and manage the private repository forking policy for a GitHub Enterprise.
+You must have enterprise admin access to use this resource.
 
 When `setting_value` is `ENABLED`, the `policy_value` attribute controls where forks
 can be created. When `DISABLED`, forking of private repositories is not allowed.
 When `NO_POLICY`, individual organizations within the enterprise control their own
 forking settings.
-
-~> **Note:** You must have enterprise admin access to use this resource.
 
 ## Example Usage
 
@@ -71,7 +69,11 @@ The following arguments are supported:
   * `USER_ACCOUNTS` - Members can fork to their user account.
   * `EVERYWHERE` - Members can fork to their user account or an organization, either inside or outside of this enterprise.
 
-~> **Note:** Destroying this resource sets the enterprise policy to `NO_POLICY`, which allows individual organizations to control their own forking settings. It does not set the policy to `DISABLED`.
+**Note:** Destroying this resource sets the enterprise policy to `NO_POLICY`, which allows individual organizations to control their own forking settings. It does not set the policy to `DISABLED`.
+
+## Attributes Reference
+
+No additional attributes are exported.
 
 ## Import
 


### PR DESCRIPTION
Resolves #3363
Relates to #2851, #1844

----

### Before the change?

- No way to manage the enterprise-level private repository forking policy via Terraform.
- The forking destination policy (where members can fork to) is only configurable through the GitHub UI or raw GraphQL mutations.

### After the change?

- New resource `github_enterprise_private_repository_forking_setting` that manages the enterprise-wide fork policy via the `updateEnterpriseAllowPrivateRepositoryForkingSetting` GraphQL mutation.
- Supports `setting` (`ENABLED`, `DISABLED`, `NO_POLICY`) and `policy` (6 destination options including `ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS` for EMU environments).
- Includes `CustomizeDiff` validation, import support, and full acceptance test suite (8 tests all passing).
- Destroying the resource resets to `NO_POLICY`, returning control to individual organizations.

#### Example usage

```hcl
resource "github_enterprise_private_repository_forking_setting" "example" {
  enterprise_slug = "my-enterprise"
  setting         = "ENABLED"
  policy          = "ENTERPRISE_ORGANIZATIONS_USER_ACCOUNTS"
}
```

### Pull request checklist

- [x] Schema migrations have been created if needed
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No