### PR TITLE
fix: guard nil invitation from AddCollaborator for org members

### DIFF
--- a/github/resource_github_repository_collaborators.go
+++ b/github/resource_github_repository_collaborators.go
@@ -691,8 +691,13 @@ func updateUserCollaboratorsAndInvites(ctx context.Context, client *github.Clien
 		if err != nil {
 			return nil, err
 		}
-		inUser.invitationID = inv.ID
-		ghInvites = append(ghInvites, inUser)
+		// AddCollaborator returns 204 No Content (inv == nil) when the invitee
+		// is an organization member gaining direct access without an
+		// invitation. In that case there is no invitation ID to record.
+		if inv != nil {
+			inUser.invitationID = inv.ID
+			ghInvites = append(ghInvites, inUser)
+		}
 	}
 
 	for _, l := range remove {


### PR DESCRIPTION
Resolves #3370

----

### Before the change?

- `github_repository_collaborators` panics with a nil pointer dereference when creating or updating a resource that lists an organization member who is not yet a direct collaborator on the target repository.
- GitHub returns `204 No Content` from `PUT /repos/{owner}/{repo}/collaborators/{username}` on that path (the user is promoted to direct collaborator immediately, no invitation is issued). `client.Repositories.AddCollaborator` therefore returns `inv == nil, err == nil`.
- Since #3233 the code at `github/resource_github_repository_collaborators.go:694` unconditionally dereferences `inv.ID`, producing `SIGSEGV` inside `updateUserCollaboratorsAndInvites`.

Stack trace (trimmed):

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xde9469]

goroutine 77 [running]:
github.com/integrations/terraform-provider-github/v6/github.updateUserCollaboratorsAndInvites(...)
	github/resource_github_repository_collaborators.go:694 +0xe09
github.com/integrations/terraform-provider-github/v6/github.resourceGithubRepositoryCollaboratorsCreate(...)
	github/resource_github_repository_collaborators.go:199 +0x3f1
```

### After the change?

- The invitation-tracking branch is guarded on `inv != nil`. On the 204 path we skip recording an invitation ID because none was issued; the user is already a direct collaborator and will be picked up on the next refresh via `listUserCollaborators`.
- Same code path that was already safe for permission updates at line 648 (which already discards the `AddCollaborator` return value) is now safe for the invite-new-user path too.

Documentation reference for the 204 return:
https://docs.github.com/rest/collaborators/collaborators#add-a-repository-collaborator

### Pull request checklist

- [ ] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

Notes on the checklist:

- No schema changes — purely a runtime nil guard.
- I have not added a regression test because the existing `resource_github_repository_collaborators_test.go` is acceptance-style against a real GitHub org and reliably reproducing the 204 path requires an org member fixture. Happy to add a test if you can point me at a preferred pattern, or if a unit-test rig with a fake `github.Client` would be acceptable.

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

cc @stevehipwell @robert-crandall @deiga — this is a straight follow-up to the #3233 refactor; flagging you since you shipped v6.12.0.
