### PR TITLE
[BUG] Fix drift with external collaborators invite

### DIFF
--- a/github/resource_github_repository_collaborators.go
+++ b/github/resource_github_repository_collaborators.go
@@ -255,10 +255,6 @@ func resourceGithubRepositoryCollaboratorsRead(ctx context.Context, d *schema.Re
 		return diag.FromErr(err)
 	}
 
-	if err := d.Set("user", ghUsers.flatten()); err != nil {
-		return diag.FromErr(err)
-	}
-
 	if isOrg {
 		ghTeams, err := listTeamCollaborators(ctx, client, owner, repoName, inTeams, inIgnoreTeams)
 		if err != nil {
@@ -277,6 +273,11 @@ func resourceGithubRepositoryCollaboratorsRead(ctx context.Context, d *schema.Re
 
 	ghInvitations, err := listInvitations(ctx, client, owner, repoName)
 	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	combinedUsersAndInvitations := slices.Concat(ghUsers, ghInvitations)
+	if err := d.Set("user", combinedUsersAndInvitations.flatten()); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/github/resource_github_repository_collaborators.go
+++ b/github/resource_github_repository_collaborators.go
@@ -117,6 +117,7 @@ func resourceGithubRepositoryCollaborators() *schema.Resource {
 }
 
 func resourceGithubRepositoryCollaboratorsDiff(ctx context.Context, d *schema.ResourceDiff, m any) error {
+	tflog.Debug(ctx, "Diffing user collaborators")
 	if d.HasChange("user") {
 		users := d.Get("user").(*schema.Set).List()
 		seen := make(map[string]any)
@@ -181,6 +182,11 @@ func resourceGithubRepositoryCollaboratorsCreate(ctx context.Context, d *schema.
 	teams := d.Get("team").(*schema.Set).List()
 	ignoreTeams := d.Get("ignore_team").(*schema.Set).List()
 
+	tflog.Debug(ctx, "Creating repository collaborators", map[string]any{
+		"users":       users,
+		"teams":       teams,
+		"ignoreTeams": ignoreTeams,
+	})
 	inUsers, err := getUserCollaborators(users)
 	if err != nil {
 		return diag.FromErr(err)
@@ -226,6 +232,7 @@ func resourceGithubRepositoryCollaboratorsCreate(ctx context.Context, d *schema.
 }
 
 func resourceGithubRepositoryCollaboratorsRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	tflog.Debug(ctx, "Reading repository collaborators")
 	meta, _ := m.(*Owner)
 	client := meta.v3client
 	owner := meta.name
@@ -289,6 +296,7 @@ func resourceGithubRepositoryCollaboratorsRead(ctx context.Context, d *schema.Re
 }
 
 func resourceGithubRepositoryCollaboratorsUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	tflog.Debug(ctx, "Updating repository collaborators")
 	meta, _ := m.(*Owner)
 	client := meta.v3client
 	owner := meta.name
@@ -334,6 +342,7 @@ func resourceGithubRepositoryCollaboratorsUpdate(ctx context.Context, d *schema.
 }
 
 func resourceGithubRepositoryCollaboratorsDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	tflog.Debug(ctx, "Deleting repository collaborators")
 	meta, _ := m.(*Owner)
 	client := meta.v3client
 	owner := meta.name
@@ -365,6 +374,7 @@ func resourceGithubRepositoryCollaboratorsDelete(ctx context.Context, d *schema.
 }
 
 func resourceGithubRepositoryCollaboratorsImport(ctx context.Context, d *schema.ResourceData, m any) ([]*schema.ResourceData, error) {
+	tflog.Debug(ctx, "Importing repository collaborators")
 	meta := m.(*Owner)
 	client := meta.v3client
 	owner := meta.name
@@ -497,7 +507,10 @@ func getTeamIdentity(d any) (teamIdentity, error) {
 
 func listUserCollaborators(ctx context.Context, client *github.Client, owner, repoName string) (userCollaborators, error) {
 	col := make([]userCollaborator, 0)
-
+	tflog.Debug(ctx, "Listing user collaborators", map[string]any{
+		"owner":    owner,
+		"repoName": repoName,
+	})
 	affiliations := []string{"direct", "outside"}
 	for _, affiliation := range affiliations {
 		opt := &github.ListCollaboratorsOptions{
@@ -633,6 +646,14 @@ func updateUserCollaboratorsAndInvites(ctx context.Context, client *github.Clien
 	for _, inUser := range inUsers {
 		lookup[inUser.login] = inUser
 	}
+
+	tflog.Debug(ctx, "Updating user collaborators and invitations", map[string]any{
+		"repoName": repoName,
+		"inUsers":  inUsers,
+		"lookup":   lookup,
+		"seen":     seen,
+		"remove":   remove,
+	})
 
 	ghUsers, err := listUserCollaborators(ctx, client, owner, repoName)
 	if err != nil {

--- a/github/resource_github_repository_collaborators_test.go
+++ b/github/resource_github_repository_collaborators_test.go
@@ -57,7 +57,7 @@ resource "github_repository_collaborators" "test" {
 }
 `, repoName, teamName0, teamName1, collaboratorUser)
 
-		resource.ParallelTest(t, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
@@ -118,7 +118,7 @@ resource "github_repository_collaborators" "test" {
 }
 `, repoName, testAccConf.testExternalUser)
 
-		resource.ParallelTest(t, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnauthenticated(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
@@ -196,7 +196,7 @@ resource "github_repository_collaborators" "test" {
 }
 `, configPre)
 
-		resource.ParallelTest(t, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
@@ -270,7 +270,7 @@ resource "github_repository_collaborators" "test" {
 }
 `, configPre)
 
-		resource.ParallelTest(t, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnauthenticated(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
@@ -336,7 +336,7 @@ resource "github_repository_collaborators" "test" {
 }
 `, configPre)
 
-		resource.ParallelTest(t, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
@@ -397,7 +397,7 @@ resource "github_repository_collaborators" "test" {
 }
 `, configPre)
 
-		resource.ParallelTest(t, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
@@ -451,7 +451,7 @@ resource "github_repository_collaborators" "test" {
 }
 `, repoName, teamName)
 
-		resource.ParallelTest(t, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{

--- a/github/resource_github_repository_collaborators_test.go
+++ b/github/resource_github_repository_collaborators_test.go
@@ -57,7 +57,7 @@ resource "github_repository_collaborators" "test" {
 }
 `, repoName, teamName0, teamName1, collaboratorUser)
 
-		resource.Test(t, resource.TestCase{
+		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
@@ -118,14 +118,14 @@ resource "github_repository_collaborators" "test" {
 }
 `, repoName, testAccConf.testExternalUser)
 
-		resource.Test(t, resource.TestCase{
+		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:          func() { skipUnauthenticated(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
 					Config: config,
 					ConfigStateChecks: []statecheck.StateCheck{
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("user"), knownvalue.SetSizeExact(0)),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("user"), knownvalue.SetSizeExact(1)),
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("team"), knownvalue.SetSizeExact(0)),
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(1)),
 					},
@@ -196,7 +196,7 @@ resource "github_repository_collaborators" "test" {
 }
 `, configPre)
 
-		resource.Test(t, resource.TestCase{
+		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
@@ -270,7 +270,7 @@ resource "github_repository_collaborators" "test" {
 }
 `, configPre)
 
-		resource.Test(t, resource.TestCase{
+		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:          func() { skipUnauthenticated(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
@@ -336,7 +336,7 @@ resource "github_repository_collaborators" "test" {
 }
 `, configPre)
 
-		resource.Test(t, resource.TestCase{
+		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
@@ -397,7 +397,7 @@ resource "github_repository_collaborators" "test" {
 }
 `, configPre)
 
-		resource.Test(t, resource.TestCase{
+		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
@@ -451,7 +451,7 @@ resource "github_repository_collaborators" "test" {
 }
 `, repoName, teamName)
 
-		resource.Test(t, resource.TestCase{
+		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{

--- a/github/util_user.go
+++ b/github/util_user.go
@@ -21,10 +21,6 @@ func (u userCollaborator) flatten() any {
 		"permission": u.permission,
 	}
 
-	if u.invitationID != nil {
-		m["invitation_id"] = *u.invitationID
-	}
-
 	return m
 }
 


### PR DESCRIPTION
----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- Adding an external collaborator would cause constant drift for as long as the invite would not have been accepted

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adding an external collaborator no longer causes drift in the `user` state

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
