### PR TITLE
fix: support in-place updates for repository custom property values

### DIFF
--- a/github/resource_github_repository_custom_property.go
+++ b/github/resource_github_repository_custom_property.go
@@ -13,6 +13,7 @@ func resourceGithubRepositoryCustomProperty() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceGithubRepositoryCustomPropertyCreate,
 		Read:   resourceGithubRepositoryCustomPropertyRead,
+		Update: resourceGithubRepositoryCustomPropertyUpdate,
 		Delete: resourceGithubRepositoryCustomPropertyDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -46,7 +47,6 @@ func resourceGithubRepositoryCustomProperty() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				ForceNew: true,
 			},
 		},
 	}
@@ -83,6 +83,13 @@ func resourceGithubRepositoryCustomPropertyCreate(d *schema.ResourceData, meta a
 
 	d.SetId(buildThreePartID(owner, repoName, propertyName))
 
+	return resourceGithubRepositoryCustomPropertyRead(d, meta)
+}
+
+func resourceGithubRepositoryCustomPropertyUpdate(d *schema.ResourceData, meta any) error {
+	if err := resourceGithubRepositoryCustomPropertyCreate(d, meta); err != nil {
+		return err
+	}
 	return resourceGithubRepositoryCustomPropertyRead(d, meta)
 }
 

--- a/github/resource_github_repository_custom_property_test.go
+++ b/github/resource_github_repository_custom_property_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccGithubRepositoryCustomProperty(t *testing.T) {
@@ -130,6 +131,79 @@ func TestAccGithubRepositoryCustomProperty(t *testing.T) {
 				{
 					Config: config,
 					Check:  checkWithOwner,
+				},
+			},
+		})
+	})
+
+	t.Run("updates custom property value in place without replacement", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%srepo-custom-prop-%s", testResourcePrefix, randomID)
+		propertyName := fmt.Sprintf("tf-acc-test-property-%s", randomID)
+
+		configTemplate := `
+			resource "github_organization_custom_properties" "test" {
+				allowed_values = ["alpha", "beta"]
+				description    = "Test Description"
+				property_name  = "%s"
+				value_type     = "single_select"
+			}
+			resource "github_repository" "test" {
+				name = "%s"
+				auto_init = true
+			}
+			resource "github_repository_custom_property" "test" {
+				repository    = github_repository.test.name
+				property_name = github_organization_custom_properties.test.property_name
+				property_type = github_organization_custom_properties.test.value_type
+				property_value = ["%s"]
+			}
+		`
+
+		configAlpha := fmt.Sprintf(configTemplate, propertyName, repoName, "alpha")
+		configBeta := fmt.Sprintf(configTemplate, propertyName, repoName, "beta")
+
+		var firstID string
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessHasOrgs(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: configAlpha,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("github_repository_custom_property.test", "property_value.#", "1"),
+						resource.TestCheckResourceAttr("github_repository_custom_property.test", "property_value.0", "alpha"),
+						func(s *terraform.State) error {
+							rs, ok := s.RootModule().Resources["github_repository_custom_property.test"]
+							if !ok {
+								return fmt.Errorf("resource not found in state")
+							}
+							firstID = rs.Primary.ID
+							return nil
+						},
+					),
+				},
+				{
+					Config: configBeta,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("github_repository_custom_property.test", "property_value.#", "1"),
+						resource.TestCheckResourceAttr("github_repository_custom_property.test", "property_value.0", "beta"),
+						func(s *terraform.State) error {
+							rs, ok := s.RootModule().Resources["github_repository_custom_property.test"]
+							if !ok {
+								return fmt.Errorf("resource not found in state")
+							}
+							if rs.Primary.ID != firstID {
+								return fmt.Errorf("resource ID changed across update: %q -> %q (expected in-place update)", firstID, rs.Primary.ID)
+							}
+							return nil
+						},
+					),
+				},
+				{
+					Config:   configBeta,
+					PlanOnly: true,
 				},
 			},
 		})


### PR DESCRIPTION
Resolves #3377

----

### Before the change?

- Changing `property_value` on `github_repository_custom_property` produces a `-/+ destroy and then create replacement` plan, because `property_value` is declared `ForceNew: true` and the resource has no `Update` function (only `Create`, `Read`, `Delete`).
- On apply, the destroy step calls `client.Repositories.CreateOrUpdateCustomProperties` with `Value: nil`, which per the [GitHub REST docs](https://docs.github.com/en/rest/repos/custom-properties#create-or-update-custom-property-values-for-a-repository) "removes or 'unsets' the property value". The subsequent create step re-sets it, leaving a window where the property is unset (or reverts to the org-level default) which is breaking downstream systems that depend on the property being continuously set.
- The underlying API (`PATCH /repos/{owner}/{repo}/properties/values`) is documented as upsert, and `Create` already calls it. The sibling resource `github_organization_custom_property` is wired with `Create + Read + Update + Delete` for the analogous org-level API; the repo-level resource is the outlier.

### After the change?

- Wire an `Update` function that delegates to `Create`, mirroring the [pattern used by `github_organization_custom_properties`](https://github.com/integrations/terraform-provider-github/blob/main/github/resource_github_organization_custom_properties.go#L139-L144).
- Remove `ForceNew: true` from the `property_value` schema entry. Identity fields (`repository`, `property_name`, `property_type`) remain `ForceNew` — those are immutable on the GitHub API side.
- Add an acceptance subtest (`updates custom property value in place without replacement`) that applies an initial value, updates it, asserts the resource ID is unchanged across the two steps (proving no replacement), and asserts an empty follow-up plan.
- A value change now plans as `~ update in-place` and issues a single upsert, with no intermediate unset window.

### Pull request checklist

- [ ] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

> No schema migration is required: removing `ForceNew` from a field does not change how the value is stored in state, so existing state files remain compatible. The website docs already describe `property_value` as a mutable input and never claimed forced replacement, so no doc update is needed.

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

> Removing `ForceNew` is a non-breaking schema relaxation: configurations that previously planned as replacements will now plan as in-place updates. Configurations with unchanged `property_value` continue to plan as no-ops. No state migration is required.