### PR TITLE
fix: remove actions_repository_access_level from state if repo missing

### DIFF
--- a/github/resource_github_actions_repository_access_level.go
+++ b/github/resource_github_actions_repository_access_level.go
@@ -66,7 +66,7 @@ func resourceGithubActionsRepositoryAccessLevelRead(d *schema.ResourceData, meta
 
 	actionAccessLevel, _, err := client.Repositories.GetActionsAccessLevel(ctx, owner, repoName)
 	if err != nil {
-		return err
+		return deleteResourceOn404AndSwallow304OtherwiseReturnError(err, d, "repository (%s/%s) actions access level", owner, repoName)
 	}
 
 	_ = d.Set("access_level", actionAccessLevel.GetAccessLevel())


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #3379

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

Error is throw if resource is not found during read.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Resource is removed from state so it will be recreated.

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

I did not add tests, as I couldn't find any existing ones for this scenario (resource in state, but not present in GitHub).
