### PR TITLE
fix: add DatabaseID to parent team GraphQL query to eliminate N+1 REST calls

### DIFF
--- a/github/data_source_github_organization_teams.go
+++ b/github/data_source_github_organization_teams.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/google/go-github/v85/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -98,7 +97,6 @@ func dataSourceGithubOrganizationTeamsRead(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 
-	clientv3 := meta.(*Owner).v3client
 	client := meta.(*Owner).v4client
 	orgName := meta.(*Owner).name
 	rootTeamsOnly := d.Get("root_teams_only").(bool)
@@ -122,7 +120,7 @@ func dataSourceGithubOrganizationTeamsRead(ctx context.Context, d *schema.Resour
 			return diag.FromErr(err)
 		}
 
-		additionalTeams, err := flattenGitHubTeams(clientv3, meta.(*Owner).StopContext, orgName, query)
++		additionalTeams, err := flattenGitHubTeams(query)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -143,7 +141,7 @@ func dataSourceGithubOrganizationTeamsRead(ctx context.Context, d *schema.Resour
 	return nil
 }
 
-func flattenGitHubTeams(client *github.Client, ctx context.Context, org string, tq TeamsQuery) ([]any, error) {
+func flattenGitHubTeams(tq TeamsQuery) ([]any, error) {
 	teams := tq.Organization.Teams.Nodes
 
 	if len(teams) == 0 {
@@ -171,21 +169,17 @@ func flattenGitHubTeams(client *github.Client, ctx context.Context, org string, 
 		t["members"] = flatMembers
 
 		var parentTeamId string
-		if len(team.Parent.Slug) != 0 {
-			parentTeam, _, err := client.Teams.GetTeamBySlug(ctx, org, string(team.Parent.Slug))
-			if err != nil {
-				return nil, err
-			}
-			parentTeamId = strconv.FormatInt(parentTeam.GetID(), 10)
-		}
-
-		t["parent_team_id"] = parentTeamId
-		t["parent_team_slug"] = team.Parent.Slug
 
 		parentTeam := make(map[string]any)
+		if team.Parent.DatabaseID != 0 {
+			parentTeamId = strconv.FormatInt(int64(team.Parent.DatabaseID), 10)
+		}
 		parentTeam["id"] = team.Parent.ID
 		parentTeam["slug"] = team.Parent.Slug
 		parentTeam["name"] = team.Parent.Name
+
+		t["parent_team_id"] = parentTeamId
+		t["parent_team_slug"] = team.Parent.Slug
 		t["parent"] = parentTeam
 
 		repositories := team.Repositories.Nodes

--- a/github/util_v4_teams.go
+++ b/github/util_v4_teams.go
@@ -14,9 +14,10 @@ type TeamsQuery struct {
 				Description githubv4.String
 				Privacy     githubv4.String
 				Parent      struct {
-					ID   githubv4.String
-					Slug githubv4.String
-					Name githubv4.String
+					ID         githubv4.String
+					DatabaseID githubv4.Int
+					Slug       githubv4.String
+					Name       githubv4.String
 				} `graphql:"parentTeam"`
 				Members struct {
 					Nodes []struct {


### PR DESCRIPTION
PR #1452 added the parent object to the teams data source, but `parent.id` was populated from the GraphQL node ID instead of the numeric database ID, causing issue #2491.

PR #2507 worked around this by adding `parent_team_id` and `parent_team_slug`, using a REST `GetTeamBySlug` call per parent team.

This commit fixes the root cause by adding `DatabaseID` to the parent team GraphQL query and using it for `parent.id`. This makes the per-team REST call unnecessary and removes the N+1 pattern.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2491

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- `parent.id` was populated from the GraphQL node ID instead of the numeric database ID.
- The data source used a REST `GetTeamBySlug` call per parent team to obtain the numeric parent team ID.
- This introduced an N+1 API call pattern when listing organization teams with parent teams.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `DatabaseID` is included in the parent team GraphQL query.
- `parent.id` is populated from the numeric database ID.
- The per-parent-team REST `GetTeamBySlug` call is no longer needed.
- Organization team flattening now avoids the N+1 REST API pattern for parent team IDs.

### Pull request checklist

- [x] Schema migrations have been created if needed (not needed)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (not needed)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No