### PR TITLE
feat: Expose default_repository_branch and secret_scanning_validity_checks_enabled

### DIFF
--- a/docs/data-sources/organization.md
+++ b/docs/data-sources/organization.md
@@ -56,3 +56,5 @@ data "github_organization" "example" {
 - `dependency_graph_enabled_for_new_repositories` - Whether dependency graph is automatically enabled for new repositories.
 - `secret_scanning_enabled_for_new_repositories` - Whether secret scanning is automatically enabled for new repositories.
 - `secret_scanning_push_protection_enabled_for_new_repositories` - Whether secret scanning push protection is automatically enabled for new repositories.
+- `secret_scanning_validity_checks_enabled` - Whether secret scanning automatic validity checks on supported partner tokens are enabled for the organization.
+- `default_repository_branch` - The default branch name applied to new repositories created in the organization.

--- a/docs/resources/organization_settings.md
+++ b/docs/resources/organization_settings.md
@@ -38,6 +38,8 @@ resource "github_organization_settings" "test" {
   dependency_graph_enabled_for_new_repositories                = false
   secret_scanning_enabled_for_new_repositories                 = false
   secret_scanning_push_protection_enabled_for_new_repositories = false
+  secret_scanning_validity_checks_enabled                      = false
+  default_repository_branch                                    = "main"
 }
 ```
 
@@ -71,6 +73,8 @@ The following arguments are supported:
 - `dependency_graph_enabled_for_new_repositories` - (Optional) Whether or not dependency graph is enabled for new repositories. Defaults to `false`.
 - `secret_scanning_enabled_for_new_repositories` - (Optional) Whether or not secret scanning is enabled for new repositories. Defaults to `false`.
 - `secret_scanning_push_protection_enabled_for_new_repositories` - (Optional) Whether or not secret scanning push protection is enabled for new repositories. Defaults to `false`.
+- `secret_scanning_validity_checks_enabled` - (Optional) Whether or not secret scanning automatic validity checks on supported partner tokens are enabled for the organization. The current value is read from the API when not set.
+- `default_repository_branch` - (Optional) The default branch name applied to new repositories created in the organization (for example, `main`). The current value is read from the API when not set.
 
 ## Attributes Reference
 

--- a/examples/resources/organization_settings/example_1.tf
+++ b/examples/resources/organization_settings/example_1.tf
@@ -25,4 +25,6 @@ resource "github_organization_settings" "test" {
   dependency_graph_enabled_for_new_repositories                = false
   secret_scanning_enabled_for_new_repositories                 = false
   secret_scanning_push_protection_enabled_for_new_repositories = false
+  secret_scanning_validity_checks_enabled                      = false
+  default_repository_branch                                    = "main"
 }

--- a/github/data_source_github_organization.go
+++ b/github/data_source_github_organization.go
@@ -141,6 +141,14 @@ func dataSourceGithubOrganization() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"secret_scanning_validity_checks_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"default_repository_branch": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"summary_only": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -265,6 +273,8 @@ func dataSourceGithubOrganizationRead(ctx context.Context, d *schema.ResourceDat
 		_ = d.Set("dependency_graph_enabled_for_new_repositories", organization.GetDependencyGraphEnabledForNewRepos())
 		_ = d.Set("secret_scanning_enabled_for_new_repositories", organization.GetSecretScanningEnabledForNewRepos())
 		_ = d.Set("secret_scanning_push_protection_enabled_for_new_repositories", organization.GetSecretScanningPushProtectionEnabledForNewRepos())
+		_ = d.Set("secret_scanning_validity_checks_enabled", organization.GetSecretScanningValidityChecksEnabled())
+		_ = d.Set("default_repository_branch", organization.GetDefaultRepositoryBranch())
 	}
 
 	d.SetId(strconv.FormatInt(organization.GetID(), 10))

--- a/github/data_source_github_organization_test.go
+++ b/github/data_source_github_organization_test.go
@@ -41,6 +41,8 @@ func TestAccGithubOrganizationDataSource(t *testing.T) {
 			resource.TestCheckResourceAttrSet("data.github_organization.test", "dependency_graph_enabled_for_new_repositories"),
 			resource.TestCheckResourceAttrSet("data.github_organization.test", "secret_scanning_enabled_for_new_repositories"),
 			resource.TestCheckResourceAttrSet("data.github_organization.test", "secret_scanning_push_protection_enabled_for_new_repositories"),
+			resource.TestCheckResourceAttrSet("data.github_organization.test", "secret_scanning_validity_checks_enabled"),
+			resource.TestCheckResourceAttrSet("data.github_organization.test", "default_repository_branch"),
 		)
 
 		resource.Test(t, resource.TestCase{
@@ -139,6 +141,8 @@ func TestAccGithubOrganizationDataSource(t *testing.T) {
 			resource.TestCheckNoResourceAttr("data.github_organization.test", "dependency_graph_enabled_for_new_repositories"),
 			resource.TestCheckNoResourceAttr("data.github_organization.test", "secret_scanning_enabled_for_new_repositories"),
 			resource.TestCheckNoResourceAttr("data.github_organization.test", "secret_scanning_push_protection_enabled_for_new_repositories"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "secret_scanning_validity_checks_enabled"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "default_repository_branch"),
 		)
 
 		resource.Test(t, resource.TestCase{

--- a/github/resource_github_organization_settings.go
+++ b/github/resource_github_organization_settings.go
@@ -169,6 +169,18 @@ func resourceGithubOrganizationSettings() *schema.Resource {
 				Default:     false,
 				Description: "Whether or not secret scanning push protection is enabled for new repositories.",
 			},
+			"secret_scanning_validity_checks_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Whether or not secret scanning automatic validity checks on supported partner tokens are enabled for the organization.",
+			},
+			"default_repository_branch": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The default branch name applied to new repositories created in the organization (for example, 'main').",
+			},
 		},
 	}
 }
@@ -290,6 +302,14 @@ func buildOrganizationSettings(d *schema.ResourceData, isEnterprise bool) *githu
 	if shouldInclude("secret_scanning_push_protection_enabled_for_new_repositories") {
 		settings.SecretScanningPushProtectionEnabledForNewRepos = new(d.Get("secret_scanning_push_protection_enabled_for_new_repositories").(bool))
 	}
+	if shouldInclude("secret_scanning_validity_checks_enabled") {
+		settings.SecretScanningValidityChecksEnabled = new(d.Get("secret_scanning_validity_checks_enabled").(bool))
+	}
+	if shouldInclude("default_repository_branch") {
+		if v, ok := d.GetOk("default_repository_branch"); ok {
+			settings.DefaultRepositoryBranch = new(v.(string))
+		}
+	}
 
 	// Enterprise-specific field
 	if isEnterprise {
@@ -398,6 +418,12 @@ func resourceGithubOrganizationSettingsCreateOrUpdate(d *schema.ResourceData, me
 	}
 	if settings.SecretScanningPushProtectionEnabledForNewRepos != nil {
 		log.Printf("[DEBUG]   SecretScanningPushProtectionEnabledForNewRepos: %v", *settings.SecretScanningPushProtectionEnabledForNewRepos)
+	}
+	if settings.SecretScanningValidityChecksEnabled != nil {
+		log.Printf("[DEBUG]   SecretScanningValidityChecksEnabled: %v", *settings.SecretScanningValidityChecksEnabled)
+	}
+	if settings.DefaultRepositoryBranch != nil {
+		log.Printf("[DEBUG]   DefaultRepositoryBranch: %s", *settings.DefaultRepositoryBranch)
 	}
 
 	orgSettings, _, err := client.Organizations.Edit(ctx, org, settings)
@@ -511,6 +537,12 @@ func resourceGithubOrganizationSettingsRead(d *schema.ResourceData, meta any) er
 		return err
 	}
 	if err = d.Set("secret_scanning_push_protection_enabled_for_new_repositories", orgSettings.GetSecretScanningPushProtectionEnabledForNewRepos()); err != nil {
+		return err
+	}
+	if err = d.Set("secret_scanning_validity_checks_enabled", orgSettings.GetSecretScanningValidityChecksEnabled()); err != nil {
+		return err
+	}
+	if err = d.Set("default_repository_branch", orgSettings.GetDefaultRepositoryBranch()); err != nil {
 		return err
 	}
 	return nil

--- a/github/resource_github_organization_settings_test.go
+++ b/github/resource_github_organization_settings_test.go
@@ -586,6 +586,32 @@ func TestAccGithubOrganizationSettings(t *testing.T) {
 			})
 		})
 
+		t.Run("test default_repository_branch and secret_scanning_validity_checks_enabled", func(t *testing.T) {
+			config := `
+			resource "github_organization_settings" "test" {
+				billing_email = "test@example.com"
+				default_repository_branch = "main"
+				secret_scanning_validity_checks_enabled = false
+			}`
+
+			check := resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr("github_organization_settings.test", "billing_email", "test@example.com"),
+				resource.TestCheckResourceAttr("github_organization_settings.test", "default_repository_branch", "main"),
+				resource.TestCheckResourceAttr("github_organization_settings.test", "secret_scanning_validity_checks_enabled", "false"),
+			)
+
+			resource.Test(t, resource.TestCase{
+				PreCheck:          func() { skipUnlessHasOrgs(t) },
+				ProviderFactories: providerFactories,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check:  check,
+					},
+				},
+			})
+		})
+
 		t.Run("test enum field variations", func(t *testing.T) {
 			config := `
 			resource "github_organization_settings" "test" {

--- a/templates/data-sources/organization.md.tmpl
+++ b/templates/data-sources/organization.md.tmpl
@@ -52,3 +52,5 @@ Use this data source to retrieve basic information about a GitHub Organization.
 - `dependency_graph_enabled_for_new_repositories` - Whether dependency graph is automatically enabled for new repositories.
 - `secret_scanning_enabled_for_new_repositories` - Whether secret scanning is automatically enabled for new repositories.
 - `secret_scanning_push_protection_enabled_for_new_repositories` - Whether secret scanning push protection is automatically enabled for new repositories.
+- `secret_scanning_validity_checks_enabled` - Whether secret scanning automatic validity checks on supported partner tokens are enabled for the organization.
+- `default_repository_branch` - The default branch name applied to new repositories created in the organization.

--- a/templates/resources/organization_settings.md.tmpl
+++ b/templates/resources/organization_settings.md.tmpl
@@ -42,6 +42,8 @@ The following arguments are supported:
 - `dependency_graph_enabled_for_new_repositories` - (Optional) Whether or not dependency graph is enabled for new repositories. Defaults to `false`.
 - `secret_scanning_enabled_for_new_repositories` - (Optional) Whether or not secret scanning is enabled for new repositories. Defaults to `false`.
 - `secret_scanning_push_protection_enabled_for_new_repositories` - (Optional) Whether or not secret scanning push protection is enabled for new repositories. Defaults to `false`.
+- `secret_scanning_validity_checks_enabled` - (Optional) Whether or not secret scanning automatic validity checks on supported partner tokens are enabled for the organization. The current value is read from the API when not set.
+- `default_repository_branch` - (Optional) The default branch name applied to new repositories created in the organization (for example, `main`). The current value is read from the API when not set.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Resolves #3390

----

### Before the change?

- The `github_organization_settings` resource and `github_organization` data source did not surface two attributes that are already modeled on go-github v85's `Organization` struct and returned by `GET`/`PATCH /orgs/{org}` responses.

### After the change?

- Adds two attributes to `github_organization_settings`:
  - `default_repository_branch` — the default branch name applied to new repositories (e.g. `main`). Backed by `Organization.DefaultRepositoryBranch`.
  - `secret_scanning_validity_checks_enabled` — automatic validity checks on supported partner tokens for the organization. Backed by `Organization.SecretScanningValidityChecksEnabled`.
- Mirrors both onto the `github_organization` data source for symmetry, matching the pattern from #1850.
- These fields are already part of the `Organization` struct in the upstream `go-github` library, so this PR simply surfaces them in the Terraform provider, in the same shape as #3147 / #3389.
- All new attributes use `Optional + Computed` so existing configurations that omit them continue to track the live API value without producing phantom diffs (per the pattern recommended in #3385).

This PR is independent of #3389 and can be reviewed/merged in either order.

### Pull request checklist

- [x] Schema migrations have been created if needed (n/a — additive only)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

----