### PR TITLE
feat: add `display_name` filter to `github_external_groups` data source

### DIFF
--- a/docs/data-sources/external_groups.md
+++ b/docs/data-sources/external_groups.md
@@ -10,6 +10,8 @@ Use this data source to retrieve external groups belonging to an organization.
 
 ## Example Usage
 
+### All external groups
+
 ```terraform
 data "github_external_groups" "example_external_groups" {}
 
@@ -22,9 +24,25 @@ output "groups" {
 }
 ```
 
+### Filtered by display name
+
+```terraform
+data "github_external_groups" "example_external_groups_filtered" {
+  display_name = "my-group"
+}
+
+locals {
+  filtered_groups = data.github_external_groups.example_external_groups_filtered
+}
+
+output "groups" {
+  value = local.filtered_groups
+}
+```
+
 ## Argument Reference
 
-N/A. This resource will retrieve all the external groups belonging to an organization.
+- `display_name` - (Optional) Filter the list of external groups by display name. Only groups whose name contains this value will be returned.
 
 ## Attributes Reference
 

--- a/examples/data-sources/external_groups/example_2.tf
+++ b/examples/data-sources/external_groups/example_2.tf
@@ -1,0 +1,11 @@
+data "github_external_groups" "example_external_groups_filtered" {
+  display_name = "my-group"
+}
+
+locals {
+  filtered_groups = data.github_external_groups.example_external_groups_filtered
+}
+
+output "groups" {
+  value = local.filtered_groups
+}

--- a/github/data_source_github_external_groups.go
+++ b/github/data_source_github_external_groups.go
@@ -14,6 +14,10 @@ func dataSourceGithubExternalGroups() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceGithubExternalGroupsRead,
 		Schema: map[string]*schema.Schema{
+			"display_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"external_groups": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -48,6 +52,11 @@ func dataSourceGithubExternalGroupsRead(ctx context.Context, d *schema.ResourceD
 
 	opts := &github.ListExternalGroupsOptions{}
 
+	if v, ok := d.GetOk("display_name"); ok {
+		displayName := v.(string)
+		opts.DisplayName = &displayName
+	}
+
 	externalGroups := new(github.ExternalGroupList)
 
 	for {
@@ -80,6 +89,10 @@ func dataSourceGithubExternalGroupsRead(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	d.SetId(fmt.Sprintf("/orgs/%v/external-groups", orgName))
+	resourceID := fmt.Sprintf("/orgs/%v/external-groups", orgName)
+	if opts.DisplayName != nil {
+		resourceID = fmt.Sprintf("/orgs/%v/external-groups/%v", orgName, *opts.DisplayName)
+	}
+	d.SetId(resourceID)
 	return nil
 }

--- a/github/data_source_github_external_groups_test.go
+++ b/github/data_source_github_external_groups_test.go
@@ -1,0 +1,49 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccGithubExternalGroupsDataSource(t *testing.T) {
+	t.Run("queries_all", func(t *testing.T) {
+		config := `
+			data "github_external_groups" "all" {}
+		`
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessEMUEnterprise(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrSet("data.github_external_groups.all", "external_groups.#"),
+					),
+				},
+			},
+		})
+	})
+
+	t.Run("queries_with_display_name_filter", func(t *testing.T) {
+		config := `
+			data "github_external_groups" "filtered" {
+				display_name = "test"
+			}
+		`
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessEMUEnterprise(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrSet("data.github_external_groups.filtered", "external_groups.#"),
+					),
+				},
+			},
+		})
+	})
+}

--- a/templates/data-sources/external_groups.md.tmpl
+++ b/templates/data-sources/external_groups.md.tmpl
@@ -10,11 +10,17 @@ Use this data source to retrieve external groups belonging to an organization.
 
 ## Example Usage
 
+### All external groups
+
 {{ tffile "examples/data-sources/external_groups/example_1.tf" }}
+
+### Filtered by display name
+
+{{ tffile "examples/data-sources/external_groups/example_2.tf" }}
 
 ## Argument Reference
 
-N/A. This resource will retrieve all the external groups belonging to an organization.
+- `display_name` - (Optional) Filter the list of external groups by display name. Only groups whose name contains this value will be returned.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Summary

Adds an optional `display_name` argument to the `github_external_groups` data source. When provided, it filters external groups server-side using the GitHub API's `display_name` query parameter, reducing the amount of data returned and stored in state.

Closes #3409

## Changes

- **`github/data_source_github_external_groups.go`** — Added `display_name` optional string attribute to the schema; passes it to `ListExternalGroupsOptions.DisplayName` when set; includes `display_name` in the resource ID for uniqueness
- **`github/data_source_github_external_groups_test.go`** — New acceptance tests for both filtered and unfiltered queries (gated by `skipUnlessEMUEnterprise`)
- **`examples/data-sources/external_groups/example_2.tf`** — New example showing filtered usage
- **`templates/data-sources/external_groups.md.tmpl`** + **`docs/data-sources/external_groups.md`** — Updated documentation with new argument and example

## Usage

```hcl
# Fetch all external groups (existing behavior, unchanged)
data "github_external_groups" "all" {}

# Fetch external groups filtered by display name (new)
data "github_external_groups" "filtered" {
  display_name = "my-group"
}
```

## Notes

- The go-github SDK v85 `ListExternalGroupsOptions` already supports the `DisplayName` field — no SDK changes needed
- Fully backwards compatible — `display_name` is optional and defaults to no filter