### PR TITLE
[MAINT]: Introduce stricter linter rules for new code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,7 @@ jobs:
   lint-new:
     name: Strict linting of new code
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: latest
-      - run: make build -o lintcheck # Stop running `make lintcheck` before build. Linting is handled by a separate job
+      - run: make build -o lintcheck # Stop running `make lintcheck` before build. Linting is handled separately
       - run: make test
 
   lint-new:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,26 +33,12 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - run: make build -o lintcheck # Stop running `make lintcheck` before build. Linting is handled by a separate job
-      - run: make test
-
-  lint:
-    name: Lint code
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Set-up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          cache: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: latest
+      - run: make build -o lintcheck # Stop running `make lintcheck` before build. Linting is handled by a separate job
+      - run: make test
 
   lint-new:
     name: Strict linting of new code
@@ -110,7 +96,6 @@ jobs:
     needs:
       - ci
       - docs
-      - lint
       - lint-new
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,8 +34,26 @@ jobs:
           go-version-file: go.mod
           cache: true
       - run: make tools
-      - run: make build
+      - run: make build -o lintcheck # Stop running `make lintcheck` before build. Linting is handled by a separate job
       - run: make test
+
+  lint:
+    name: Lint code
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set-up Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: latest
 
   docs:
     name: Documentation
@@ -70,6 +88,7 @@ jobs:
     needs:
       - ci
       - docs
+      - lint
     if: always()
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,29 @@ jobs:
         with:
           version: latest
 
+  lint-new:
+    name: Strict linting of new code
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set-up Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: make .golangci.new.yml
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          only-new-issues: true
+          args: --config=.golangci.new.yml
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest
@@ -89,6 +112,7 @@ jobs:
       - ci
       - docs
       - lint
+      - lint-new
     if: always()
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,6 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - run: make tools
       - run: make build -o lintcheck # Stop running `make lintcheck` before build. Linting is handled by a separate job
       - run: make test
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set-up Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -64,7 +64,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set-up Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ testdata/
 website/vendor
 terraform-provider-github
 
+# Generated temporary files
+.golangci.new.yml
+
 # Test exclusions
 !command/test-fixtures/**/*.tfstate
 !command/test-fixtures/**/.terraform/

--- a/.golangci.strict.yml
+++ b/.golangci.strict.yml
@@ -1,0 +1,9 @@
+# These rules are enabled for any new code, but not for the whole codebase yet.
+# This file is for linting rules we want to start enforcing, but can't enable for the whole codebase yet.
+# Always add new rules to .golangci.yml first. If they cause too many issues to fix reasonably, add them here instead.
+# Once a rule in here has been fixed across the codebase, remove it from here and add it to .golangci.yml.
+version: "2"
+
+linters:
+  enable:
+    - forcetypeassert

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -38,6 +38,12 @@ fmt:
 	@echo "==> Fixing source code formatting..."
 	golangci-lint fmt ./...
 
+# Merges the rules in .golangci.yml and .golangci.strict.yml into a new file .golangci.new.yml, which is used for checking only new code. 
+# This allows us to start enforcing new linting rules on new code without having to fix all existing issues in the codebase at once.
+# Only executes if either of the source files has changed, to avoid unnecessary work.
+.golangci.new.yml: .golangci.yml .golangci.strict.yml
+	@yq eval-all 'select(fileIndex == 0) *+ select(fileIndex == 1)' .golangci.yml .golangci.strict.yml > .golangci.new.yml 
+
 lint:
 	@echo "==> Checking source code against linters and fixing..."
 	golangci-lint run --fix ./...
@@ -45,6 +51,11 @@ lint:
 lintcheck:
 	@echo "==> Checking source code against linters..."
 	golangci-lint run ./...
+
+lintcheck-new: .golangci.new.yml
+	@branch=$$(git rev-parse --abbrev-ref HEAD); \
+	printf "==> Checking changed source code against linters on branch: \033[1m%s\033[0m...\n" "🌿 $$branch 🌿"
+	golangci-lint run ./... --new-from-merge-base main --config .golangci.new.yml
 
 test:
 	@branch=$$(git rev-parse --abbrev-ref HEAD); \
@@ -94,4 +105,4 @@ mdfmt:
 mdlint:
 	@rumdl check $(RUMDL_ARGS) .
 
-.PHONY: build test testacc fmt lint lintcheck tools sweep generatedocs validatedocs fmtdocs lintdocs checkdocs yamlfmt mdfmt mdlint
+.PHONY: build test testacc fmt lint lintcheck lintcheck-new tools sweep generatedocs validatedocs fmtdocs lintdocs checkdocs yamlfmt mdfmt mdlint

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -38,7 +38,7 @@ fmt:
 	@echo "==> Fixing source code formatting..."
 	golangci-lint fmt ./...
 
-# Merges the rules in .golangci.yml and .golangci.strict.yml into a new file .golangci.new.yml, which is used for checking only new code. 
+# Merges the rules in .golangci.yml and .golangci.strict.yml into a new file .golangci.new.yml, which is used for checking only new code.
 # This allows us to start enforcing new linting rules on new code without having to fix all existing issues in the codebase at once.
 # Only executes if either of the source files has changed, to avoid unnecessary work.
 .golangci.new.yml: .golangci.yml .golangci.strict.yml

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -52,6 +52,12 @@ lintcheck:
 	@echo "==> Checking source code against linters..."
 	golangci-lint run ./...
 
+# Checks all code against the strict rules. This is expected to fail until all issues have been fixed, but it allows us to track progress on fixing the issues and ensures that no new issues are introduced.
+lintcheck-strict: .golangci.new.yml
+	@branch=$$(git rev-parse --abbrev-ref HEAD); \
+	printf "==> Checking source code against strict linters on branch: \033[1m%s\033[0m...\n" "🌿 $$branch 🌿"
+	golangci-lint run ./... --config .golangci.new.yml
+
 lintcheck-new: .golangci.new.yml
 	@branch=$$(git rev-parse --abbrev-ref HEAD); \
 	printf "==> Checking changed source code against linters on branch: \033[1m%s\033[0m...\n" "🌿 $$branch 🌿"
@@ -105,4 +111,4 @@ mdfmt:
 mdlint:
 	@rumdl check $(RUMDL_ARGS) .
 
-.PHONY: build test testacc fmt lint lintcheck lintcheck-new tools sweep generatedocs validatedocs fmtdocs lintdocs checkdocs yamlfmt mdfmt mdlint
+.PHONY: build test testacc fmt lint lintcheck lintcheck-strict lintcheck-new tools sweep generatedocs validatedocs fmtdocs lintdocs checkdocs yamlfmt mdfmt mdlint


### PR DESCRIPTION
### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- New code and existing code forced to use same linter rules

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Enables holding new code to a stricter standard
- Adds `make lintcheck-new` to run stricter linters on only code since HEAD of `main`
- Adds `make lintcheck-strict` to run stricter linters on whole codebase
	- Useful to see if some strict linters can be moved to default config 
- Refactor `ci.yaml` workflow, to run linters in parallel using `golangci-lint-action`
	- This enables inline linter complaints in PRs

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

