### PR TITLE
fix(github_repository): wire code_security in security_and_analysis read/write

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -570,6 +570,11 @@ func calculateSecurityAndAnalysis(d *schema.ResourceData) *github.SecurityAndAna
 			Status: new(status),
 		}
 	}
+	if ok, status := tryGetSecurityAndAnalysisSettingStatus(lookup, "code_security"); ok {
+		securityAndAnalysis.CodeSecurity = &github.CodeSecurity{
+			Status: new(status),
+		}
+	}
 	if ok, status := tryGetSecurityAndAnalysisSettingStatus(lookup, "secret_scanning"); ok {
 		securityAndAnalysis.SecretScanning = &github.SecretScanning{
 			Status: new(status),
@@ -1198,6 +1203,13 @@ func flattenSecurityAndAnalysis(securityAndAnalysis *github.SecurityAndAnalysis)
 	if advancedSecurity != nil {
 		securityAndAnalysisMap["advanced_security"] = []any{map[string]any{
 			"status": advancedSecurity.GetStatus(),
+		}}
+	}
+
+	codeSecurity := securityAndAnalysis.GetCodeSecurity()
+	if codeSecurity != nil {
+		securityAndAnalysisMap["code_security"] = []any{map[string]any{
+			"status": codeSecurity.GetStatus(),
 		}}
 	}
 


### PR DESCRIPTION
PR #2935 added the `code_security` schema block. Neither read nor write paths were extended to handle it.

Effect:
- write: `code_security { status = ... }` in config is silently dropped
- read: `code_security` never populated in state on refresh -> permanent `+ code_security` diff on every plan

Fix mirrors existing `advanced_security` handling in both functions.

`TestAccGithubRepositorySecurity` (added in #2935) already asserts `code_security`. Was broken pre-fix. Passes post-fix.

Out of scope: `secret_scanning_ai_detection`, `secret_scanning_non_provider_patterns`. Schema exists from #2935 but go-github v86 lacks the types. Separate fix needed - go-github update first.
