### PR TITLE
feat: Expose secret_scanning_push_protection_custom_link on github_organization_settings

### DIFF
--- a/docs/data-sources/organization.md
+++ b/docs/data-sources/organization.md
@@ -56,3 +56,5 @@ data "github_organization" "example" {
 - `dependency_graph_enabled_for_new_repositories` - Whether dependency graph is automatically enabled for new repositories.
 - `secret_scanning_enabled_for_new_repositories` - Whether secret scanning is automatically enabled for new repositories.
 - `secret_scanning_push_protection_enabled_for_new_repositories` - Whether secret scanning push protection is automatically enabled for new repositories.
+- `secret_scanning_push_protection_custom_link_enabled` - Whether a custom link is shown to contributors blocked by secret scanning push protection.
+- `secret_scanning_push_protection_custom_link` - URL displayed to contributors blocked by secret scanning push protection.

--- a/docs/resources/organization_settings.md
+++ b/docs/resources/organization_settings.md
@@ -38,6 +38,8 @@ resource "github_organization_settings" "test" {
   dependency_graph_enabled_for_new_repositories                = false
   secret_scanning_enabled_for_new_repositories                 = false
   secret_scanning_push_protection_enabled_for_new_repositories = false
+  secret_scanning_push_protection_custom_link_enabled          = true
+  secret_scanning_push_protection_custom_link                  = "https://example.com/secret-scanning-help"
 }
 ```
 
@@ -71,6 +73,8 @@ The following arguments are supported:
 - `dependency_graph_enabled_for_new_repositories` - (Optional) Whether or not dependency graph is enabled for new repositories. Defaults to `false`.
 - `secret_scanning_enabled_for_new_repositories` - (Optional) Whether or not secret scanning is enabled for new repositories. Defaults to `false`.
 - `secret_scanning_push_protection_enabled_for_new_repositories` - (Optional) Whether or not secret scanning push protection is enabled for new repositories. Defaults to `false`.
+- `secret_scanning_push_protection_custom_link_enabled` - (Optional) Whether a custom link is shown to contributors blocked by secret scanning push protection. Setting this to `true` requires `secret_scanning_push_protection_custom_link` to be a non-empty URL. If managed at the enterprise level via `github_enterprise_security_analysis_settings`, this resource overrides that value for this organization.
+- `secret_scanning_push_protection_custom_link` - (Optional) URL displayed to contributors blocked by secret scanning push protection. Requires `secret_scanning_push_protection_custom_link_enabled` to be `true`.
 
 ## Attributes Reference
 

--- a/examples/resources/organization_settings/example_1.tf
+++ b/examples/resources/organization_settings/example_1.tf
@@ -25,4 +25,6 @@ resource "github_organization_settings" "test" {
   dependency_graph_enabled_for_new_repositories                = false
   secret_scanning_enabled_for_new_repositories                 = false
   secret_scanning_push_protection_enabled_for_new_repositories = false
+  secret_scanning_push_protection_custom_link_enabled          = true
+  secret_scanning_push_protection_custom_link                  = "https://example.com/secret-scanning-help"
 }

--- a/github/data_source_github_organization.go
+++ b/github/data_source_github_organization.go
@@ -141,6 +141,14 @@ func dataSourceGithubOrganization() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"secret_scanning_push_protection_custom_link_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"secret_scanning_push_protection_custom_link": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"summary_only": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -265,6 +273,8 @@ func dataSourceGithubOrganizationRead(ctx context.Context, d *schema.ResourceDat
 		_ = d.Set("dependency_graph_enabled_for_new_repositories", organization.GetDependencyGraphEnabledForNewRepos())
 		_ = d.Set("secret_scanning_enabled_for_new_repositories", organization.GetSecretScanningEnabledForNewRepos())
 		_ = d.Set("secret_scanning_push_protection_enabled_for_new_repositories", organization.GetSecretScanningPushProtectionEnabledForNewRepos())
+		_ = d.Set("secret_scanning_push_protection_custom_link_enabled", organization.GetSecretScanningPushProtectionCustomLinkEnabled())
+		_ = d.Set("secret_scanning_push_protection_custom_link", organization.GetSecretScanningPushProtectionCustomLink())
 	}
 
 	d.SetId(strconv.FormatInt(organization.GetID(), 10))

--- a/github/data_source_github_organization_test.go
+++ b/github/data_source_github_organization_test.go
@@ -41,6 +41,7 @@ func TestAccGithubOrganizationDataSource(t *testing.T) {
 			resource.TestCheckResourceAttrSet("data.github_organization.test", "dependency_graph_enabled_for_new_repositories"),
 			resource.TestCheckResourceAttrSet("data.github_organization.test", "secret_scanning_enabled_for_new_repositories"),
 			resource.TestCheckResourceAttrSet("data.github_organization.test", "secret_scanning_push_protection_enabled_for_new_repositories"),
+			resource.TestCheckResourceAttrSet("data.github_organization.test", "secret_scanning_push_protection_custom_link_enabled"),
 		)
 
 		resource.Test(t, resource.TestCase{
@@ -139,6 +140,8 @@ func TestAccGithubOrganizationDataSource(t *testing.T) {
 			resource.TestCheckNoResourceAttr("data.github_organization.test", "dependency_graph_enabled_for_new_repositories"),
 			resource.TestCheckNoResourceAttr("data.github_organization.test", "secret_scanning_enabled_for_new_repositories"),
 			resource.TestCheckNoResourceAttr("data.github_organization.test", "secret_scanning_push_protection_enabled_for_new_repositories"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "secret_scanning_push_protection_custom_link_enabled"),
+			resource.TestCheckNoResourceAttr("data.github_organization.test", "secret_scanning_push_protection_custom_link"),
 		)
 
 		resource.Test(t, resource.TestCase{

--- a/github/resource_github_organization_settings.go
+++ b/github/resource_github_organization_settings.go
@@ -169,6 +169,18 @@ func resourceGithubOrganizationSettings() *schema.Resource {
 				Default:     false,
 				Description: "Whether or not secret scanning push protection is enabled for new repositories.",
 			},
+			"secret_scanning_push_protection_custom_link_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Whether a custom link is shown to contributors who are blocked from pushing a secret by push protection. Setting this to `true` requires `secret_scanning_push_protection_custom_link` to be a non-empty URL. If managed at the enterprise level via `github_enterprise_security_analysis_settings`, this resource overrides that value for this organization.",
+			},
+			"secret_scanning_push_protection_custom_link": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "URL displayed to contributors who are blocked from pushing a secret by push protection. Requires `secret_scanning_push_protection_custom_link_enabled` to be `true`.",
+			},
 		},
 	}
 }
@@ -290,6 +302,14 @@ func buildOrganizationSettings(d *schema.ResourceData, isEnterprise bool) *githu
 	if shouldInclude("secret_scanning_push_protection_enabled_for_new_repositories") {
 		settings.SecretScanningPushProtectionEnabledForNewRepos = new(d.Get("secret_scanning_push_protection_enabled_for_new_repositories").(bool))
 	}
+	if shouldInclude("secret_scanning_push_protection_custom_link_enabled") {
+		settings.SecretScanningPushProtectionCustomLinkEnabled = new(d.Get("secret_scanning_push_protection_custom_link_enabled").(bool))
+	}
+	if shouldInclude("secret_scanning_push_protection_custom_link") {
+		if v, ok := d.GetOk("secret_scanning_push_protection_custom_link"); ok {
+			settings.SecretScanningPushProtectionCustomLink = new(v.(string))
+		}
+	}
 
 	// Enterprise-specific field
 	if isEnterprise {
@@ -398,6 +418,12 @@ func resourceGithubOrganizationSettingsCreateOrUpdate(d *schema.ResourceData, me
 	}
 	if settings.SecretScanningPushProtectionEnabledForNewRepos != nil {
 		log.Printf("[DEBUG]   SecretScanningPushProtectionEnabledForNewRepos: %v", *settings.SecretScanningPushProtectionEnabledForNewRepos)
+	}
+	if settings.SecretScanningPushProtectionCustomLinkEnabled != nil {
+		log.Printf("[DEBUG]   SecretScanningPushProtectionCustomLinkEnabled: %v", *settings.SecretScanningPushProtectionCustomLinkEnabled)
+	}
+	if settings.SecretScanningPushProtectionCustomLink != nil {
+		log.Printf("[DEBUG]   SecretScanningPushProtectionCustomLink: %s", *settings.SecretScanningPushProtectionCustomLink)
 	}
 
 	orgSettings, _, err := client.Organizations.Edit(ctx, org, settings)
@@ -511,6 +537,12 @@ func resourceGithubOrganizationSettingsRead(d *schema.ResourceData, meta any) er
 		return err
 	}
 	if err = d.Set("secret_scanning_push_protection_enabled_for_new_repositories", orgSettings.GetSecretScanningPushProtectionEnabledForNewRepos()); err != nil {
+		return err
+	}
+	if err = d.Set("secret_scanning_push_protection_custom_link_enabled", orgSettings.GetSecretScanningPushProtectionCustomLinkEnabled()); err != nil {
+		return err
+	}
+	if err = d.Set("secret_scanning_push_protection_custom_link", orgSettings.GetSecretScanningPushProtectionCustomLink()); err != nil {
 		return err
 	}
 	return nil

--- a/github/resource_github_organization_settings_test.go
+++ b/github/resource_github_organization_settings_test.go
@@ -39,6 +39,8 @@ func TestAccGithubOrganizationSettings(t *testing.T) {
 			dependency_graph_enabled_for_new_repositories = false
 			secret_scanning_enabled_for_new_repositories = false
 			secret_scanning_push_protection_enabled_for_new_repositories = false
+			secret_scanning_push_protection_custom_link_enabled = true
+			secret_scanning_push_protection_custom_link = "https://example.com/secret-scanning-help"
 		  }`
 
 		check := resource.ComposeTestCheckFunc(
@@ -159,6 +161,7 @@ func TestAccGithubOrganizationSettings(t *testing.T) {
 			dependency_graph_enabled_for_new_repositories = false
 			secret_scanning_enabled_for_new_repositories = false
 			secret_scanning_push_protection_enabled_for_new_repositories = false
+			secret_scanning_push_protection_custom_link_enabled = false
 		}`
 
 		check := resource.ComposeTestCheckFunc(
@@ -206,6 +209,10 @@ func TestAccGithubOrganizationSettings(t *testing.T) {
 				"github_organization_settings.test",
 				"secret_scanning_push_protection_enabled_for_new_repositories", "false",
 			),
+			resource.TestCheckResourceAttr(
+				"github_organization_settings.test",
+				"secret_scanning_push_protection_custom_link_enabled", "false",
+			),
 		)
 
 		resource.Test(t, resource.TestCase{
@@ -234,6 +241,8 @@ func TestAccGithubOrganizationSettings(t *testing.T) {
 			dependency_graph_enabled_for_new_repositories = true
 			secret_scanning_enabled_for_new_repositories = false
 			secret_scanning_push_protection_enabled_for_new_repositories = true
+			secret_scanning_push_protection_custom_link_enabled = true
+			secret_scanning_push_protection_custom_link = "https://example.com/secret-scanning-help"
 		}`
 
 		check := resource.ComposeTestCheckFunc(
@@ -280,6 +289,14 @@ func TestAccGithubOrganizationSettings(t *testing.T) {
 			resource.TestCheckResourceAttr(
 				"github_organization_settings.test",
 				"secret_scanning_push_protection_enabled_for_new_repositories", "true",
+			),
+			resource.TestCheckResourceAttr(
+				"github_organization_settings.test",
+				"secret_scanning_push_protection_custom_link_enabled", "true",
+			),
+			resource.TestCheckResourceAttr(
+				"github_organization_settings.test",
+				"secret_scanning_push_protection_custom_link", "https://example.com/secret-scanning-help",
 			),
 		)
 

--- a/templates/data-sources/organization.md.tmpl
+++ b/templates/data-sources/organization.md.tmpl
@@ -52,3 +52,5 @@ Use this data source to retrieve basic information about a GitHub Organization.
 - `dependency_graph_enabled_for_new_repositories` - Whether dependency graph is automatically enabled for new repositories.
 - `secret_scanning_enabled_for_new_repositories` - Whether secret scanning is automatically enabled for new repositories.
 - `secret_scanning_push_protection_enabled_for_new_repositories` - Whether secret scanning push protection is automatically enabled for new repositories.
+- `secret_scanning_push_protection_custom_link_enabled` - Whether a custom link is shown to contributors blocked by secret scanning push protection.
+- `secret_scanning_push_protection_custom_link` - URL displayed to contributors blocked by secret scanning push protection.

--- a/templates/resources/organization_settings.md.tmpl
+++ b/templates/resources/organization_settings.md.tmpl
@@ -42,6 +42,8 @@ The following arguments are supported:
 - `dependency_graph_enabled_for_new_repositories` - (Optional) Whether or not dependency graph is enabled for new repositories. Defaults to `false`.
 - `secret_scanning_enabled_for_new_repositories` - (Optional) Whether or not secret scanning is enabled for new repositories. Defaults to `false`.
 - `secret_scanning_push_protection_enabled_for_new_repositories` - (Optional) Whether or not secret scanning push protection is enabled for new repositories. Defaults to `false`.
+- `secret_scanning_push_protection_custom_link_enabled` - (Optional) Whether a custom link is shown to contributors blocked by secret scanning push protection. Setting this to `true` requires `secret_scanning_push_protection_custom_link` to be a non-empty URL. If managed at the enterprise level via `github_enterprise_security_analysis_settings`, this resource overrides that value for this organization.
+- `secret_scanning_push_protection_custom_link` - (Optional) URL displayed to contributors blocked by secret scanning push protection. Requires `secret_scanning_push_protection_custom_link_enabled` to be `true`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Summary

Adds two new fields to `github_organization_settings` (resource) and
`github_organization` (data source):

- `secret_scanning_push_protection_custom_link_enabled` (`bool`,
  `Optional + Computed`) — toggles whether a custom URL is shown to
  contributors who try to push a secret.
- `secret_scanning_push_protection_custom_link` (`string`,
  `Optional + Computed`) — the URL itself.

The diff follows the existing `members_can_fork_private_repositories`
pattern (schema, `buildOrganizationSettings`, debug log, read) plus
test cases, docs, templates, and example HCL.

## Upstream wiring

Both fields map to new properties on the `Organization` struct in
go-github v86, added in
[google/go-github#4188](https://github.com/google/go-github/pull/4188):

- `Organization.SecretScanningPushProtectionCustomLinkEnabled`
- `Organization.SecretScanningPushProtectionCustomLink`

This repo picked up v86 in #3413, so no dependency change is needed.

## API status — please read

These two fields are **not currently listed in the public REST docs**
for [Update an organization](https://docs.github.com/en/rest/orgs/orgs?apiVersion=2022-11-28#update-an-organization),
but they are returned by `GET /orgs/{org}` and accepted by
`PATCH /orgs/{org}` in production. The upstream go-github PR
explicitly notes "observed but undocumented" and was reviewed/merged
under that understanding.

Verified end-to-end against a real org (`aletheia-works`) while
testing the go-github PR — both GET and PATCH responses include both
fields.

I am opening this here so terraform users can manage the setting
they already see in the GitHub UI. Happy to hold the PR until the
REST docs catch up if maintainers prefer.

## Relationship to enterprise resource

There is already a `secret_scanning_push_protection_custom_link`
(string only, no `_enabled` toggle) on
`github_enterprise_security_analysis_settings`. The two settings
control different scopes:

- The **enterprise** value sets the default link inherited by orgs in
  the enterprise.
- The **organization** value (this PR) overrides that default for one
  org and adds an explicit `_enabled` toggle that the API surfaces
  separately.

If both resources manage the same org, the org-level value wins. This
is documented in the new `secret_scanning_push_protection_custom_link_enabled`
description.

## Schema choice

Both fields are `Optional + Computed` with no `Default`, matching the
conservative pattern used in #3389 and #3432: if the user does not
configure the field, the provider reads the org's current value and
does not silently write anything. Happy to switch to `Default: false`
for the bool if reviewers prefer.

## Intentionally not in this PR

- **Cross-field validation** (e.g. `CustomizeDiff` to reject
  `_enabled = true` with empty URL, or vice versa). The existing
  enterprise-level resource has no such validation; matching it for
  now. Can be added in a follow-up once API rejection behavior is
  characterized.
- **URL format validation** (`ValidateFunc`). Same rationale.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -run TestNeverMatch ./github/...` (compile-level check
      for the new test assertions; acceptance tests need `TF_ACC=1`
      + tokens and were not run locally)
- [x] CI acceptance tests

## Related

- #3432 (`deploy_keys_enabled_for_repositories`) — sibling field from
  the same upstream go-github PR. Independent scope, opened separately
  so it can land without being held up by the undocumented-API
  discussion here.
- #3389 — another open PR adding org-level fields
  (`default_repository_branch`, `secret_scanning_validity_checks_enabled`).
  Independent scope, not touched.