### PR TITLE
[FEAT] Add User as repository ruleset bypass actor

### DIFF
--- a/docs/resources/repository_ruleset.md
+++ b/docs/resources/repository_ruleset.md
@@ -296,7 +296,7 @@ The `rules` block supports the following:
 
 #### bypass_actors
 
-- `actor_id` - (Optional) (Number) The ID of the actor that can bypass a ruleset. If `actor_type` is `Integration`, `actor_id` is a GitHub App ID. App ID can be obtained by following instructions from the [Get an App API docs](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-app). If `actor_type` is `User`, `actor_id` is the numeric GitHub user ID. Some actor types such as `DeployKey` do not have an ID.
+- `actor_id` - (Optional) (Number) The ID of the actor that can bypass a ruleset. If `actor_type` is `Integration`, `actor_id` is a GitHub App ID. App ID can be obtained by following instructions from the [Get an App API docs](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-app). If `actor_type` is `User`, `actor_id` is the numeric GitHub user ID. Some actor types such as `DeployKey` and `OrganizationAdmin` do not have an ID.
 
 - `actor_type` (String) The type of actor that can bypass a ruleset. Can be one of: `RepositoryRole`, `Team`, `Integration`, `OrganizationAdmin`, `DeployKey`, `User`.
 
@@ -304,7 +304,6 @@ The `rules` block supports the following:
 
 ~> Note: at the time of writing this, the following actor types correspond to the following actor IDs:
 
-- `OrganizationAdmin` -> `1`
 - `RepositoryRole` (This is the actor type, the following are the base repository roles and their associated IDs.)
   - `maintain` -> `2`
   - `write` -> `4`

--- a/docs/resources/repository_ruleset.md
+++ b/docs/resources/repository_ruleset.md
@@ -296,9 +296,9 @@ The `rules` block supports the following:
 
 #### bypass_actors
 
-- `actor_id` - (Optional) (Number) The ID of the actor that can bypass a ruleset. If `actor_type` is `Integration`, `actor_id` is a GitHub App ID. App ID can be obtained by following instructions from the [Get an App API docs](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-app). Some actor types such as `DeployKey` do not have an ID.
+- `actor_id` - (Optional) (Number) The ID of the actor that can bypass a ruleset. If `actor_type` is `Integration`, `actor_id` is a GitHub App ID. App ID can be obtained by following instructions from the [Get an App API docs](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-app). If `actor_type` is `User`, `actor_id` is the numeric GitHub user ID. Some actor types such as `DeployKey` do not have an ID.
 
-- `actor_type` (String) The type of actor that can bypass a ruleset. Can be one of: `RepositoryRole`, `Team`, `Integration`, `OrganizationAdmin`, `DeployKey`.
+- `actor_type` (String) The type of actor that can bypass a ruleset. Can be one of: `RepositoryRole`, `Team`, `Integration`, `OrganizationAdmin`, `DeployKey`, `User`.
 
 - `bypass_mode` - (Optional) (String) When the specified actor can bypass the ruleset. pull_request means that an actor can only bypass rules on pull requests. Can be one of: `always`, `pull_request`, `exempt`.
 
@@ -309,6 +309,7 @@ The `rules` block supports the following:
   - `maintain` -> `2`
   - `write` -> `4`
   - `admin` -> `5`
+- `User` -> the numeric GitHub user ID
 
 #### conditions
 

--- a/github/resource_github_repository_ruleset.go
+++ b/github/resource_github_repository_ruleset.go
@@ -68,13 +68,13 @@ func resourceGithubRepositoryRuleset() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Default:     nil,
-							Description: "The ID of the actor that can bypass a ruleset. When `actor_type` is `OrganizationAdmin`, this should be set to `1`. Some resources such as DeployKey do not have an ID and this should be omitted.",
+							Description: "The ID of the actor that can bypass a ruleset. When `actor_type` is `OrganizationAdmin`, this should be set to `1`. When `actor_type` is `User`, this should be set to the numeric GitHub user ID. Some resources such as DeployKey do not have an ID and this should be omitted.",
 						},
 						"actor_type": {
 							Type:             schema.TypeString,
 							Required:         true,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"RepositoryRole", "Team", "Integration", "OrganizationAdmin", "DeployKey"}, false)),
-							Description:      "The type of actor that can bypass a ruleset. See https://docs.github.com/en/rest/repos/rules for more information.",
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"RepositoryRole", "Team", "Integration", "OrganizationAdmin", "DeployKey", "User"}, false)),
+							Description:      "The type of actor that can bypass a ruleset. Can be one of: `RepositoryRole`, `Team`, `Integration`, `OrganizationAdmin`, `DeployKey`, or `User`. See https://docs.github.com/en/rest/repos/rules for more information.",
 						},
 						"bypass_mode": {
 							Type:             schema.TypeString,

--- a/github/resource_github_repository_ruleset.go
+++ b/github/resource_github_repository_ruleset.go
@@ -68,7 +68,7 @@ func resourceGithubRepositoryRuleset() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Default:     nil,
-							Description: "The ID of the actor that can bypass a ruleset. When `actor_type` is `OrganizationAdmin`, this should be set to `1`. When `actor_type` is `User`, this should be set to the numeric GitHub user ID. Some resources such as DeployKey do not have an ID and this should be omitted.",
+							Description: "The ID of the actor that can bypass a ruleset. When `actor_type` is `OrganizationAdmin`, this should be set to `1`. When `actor_type` is `User`, this should be set to the numeric GitHub user ID. Some actor types such as `DeployKey` do not have an ID and this should be omitted.",
 						},
 						"actor_type": {
 							Type:             schema.TypeString,

--- a/github/resource_github_repository_ruleset.go
+++ b/github/resource_github_repository_ruleset.go
@@ -68,7 +68,7 @@ func resourceGithubRepositoryRuleset() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Default:     nil,
-							Description: "The ID of the actor that can bypass a ruleset. When `actor_type` is `OrganizationAdmin`, this should be set to `1`. When `actor_type` is `User`, this should be set to the numeric GitHub user ID. Some actor types such as `DeployKey` do not have an ID and this should be omitted.",
+							Description: "The ID of the actor that can bypass a ruleset. When `actor_type` is `User`, this should be set to the numeric GitHub user ID. Some actor types such as `DeployKey` and `OrganizationAdmin` do not have an ID and this should be omitted.",
 						},
 						"actor_type": {
 							Type:             schema.TypeString,

--- a/github/resource_github_repository_ruleset_test.go
+++ b/github/resource_github_repository_ruleset_test.go
@@ -29,6 +29,10 @@ resource "github_repository_environment" "example" {
 	repository   = github_repository.test.name
 }
 
+data "github_user" "current" {
+	username = "%[3]s"
+}
+
 resource "github_repository_ruleset" "test" {
 	name        = "test"
 	repository  = github_repository.test.id
@@ -43,6 +47,12 @@ resource "github_repository_ruleset" "test" {
 	bypass_actors {
 		actor_id    = 5
 		actor_type  = "RepositoryRole"
+		bypass_mode = "always"
+	}
+
+	bypass_actors {
+		actor_id    = tonumber(data.github_user.current.id)
+		actor_type  = "User"
 		bypass_mode = "always"
 	}
 
@@ -113,7 +123,7 @@ resource "github_repository_ruleset" "test" {
 		non_fast_forward = true
 	}
 }
-`, repoName, testAccConf.testRepositoryVisibility)
+`, repoName, testAccConf.testRepositoryVisibility, testAccConf.username)
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnauthenticated(t) },
@@ -125,12 +135,15 @@ resource "github_repository_ruleset" "test" {
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "name", "test"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "target", "branch"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "enforcement", "active"),
-						resource.TestCheckResourceAttr("github_repository_ruleset.test", "bypass_actors.#", "2"),
+						resource.TestCheckResourceAttr("github_repository_ruleset.test", "bypass_actors.#", "3"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "bypass_actors.0.actor_type", "DeployKey"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "bypass_actors.0.bypass_mode", "always"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "bypass_actors.1.actor_id", "5"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "bypass_actors.1.actor_type", "RepositoryRole"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "bypass_actors.1.bypass_mode", "always"),
+						resource.TestCheckResourceAttrPair("github_repository_ruleset.test", "bypass_actors.2.actor_id", "data.github_user.current", "id"),
+						resource.TestCheckResourceAttr("github_repository_ruleset.test", "bypass_actors.2.actor_type", "User"),
+						resource.TestCheckResourceAttr("github_repository_ruleset.test", "bypass_actors.2.bypass_mode", "always"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "rules.0.pull_request.0.allowed_merge_methods.#", "2"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "rules.0.required_code_scanning.0.required_code_scanning_tool.0.alerts_threshold", "errors"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "rules.0.required_code_scanning.0.required_code_scanning_tool.0.security_alerts_threshold", "high_or_higher"),

--- a/github/resource_github_repository_ruleset_test.go
+++ b/github/resource_github_repository_ruleset_test.go
@@ -8,7 +8,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestAccGithubRepositoryRuleset(t *testing.T) {
@@ -29,10 +32,6 @@ resource "github_repository_environment" "example" {
 	repository   = github_repository.test.name
 }
 
-data "github_user" "current" {
-	username = "%[3]s"
-}
-
 resource "github_repository_ruleset" "test" {
 	name        = "test"
 	repository  = github_repository.test.id
@@ -47,12 +46,6 @@ resource "github_repository_ruleset" "test" {
 	bypass_actors {
 		actor_id    = 5
 		actor_type  = "RepositoryRole"
-		bypass_mode = "always"
-	}
-
-	bypass_actors {
-		actor_id    = tonumber(data.github_user.current.id)
-		actor_type  = "User"
 		bypass_mode = "always"
 	}
 
@@ -123,7 +116,7 @@ resource "github_repository_ruleset" "test" {
 		non_fast_forward = true
 	}
 }
-`, repoName, testAccConf.testRepositoryVisibility, testAccConf.username)
+`, repoName, testAccConf.testRepositoryVisibility)
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnauthenticated(t) },
@@ -135,15 +128,12 @@ resource "github_repository_ruleset" "test" {
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "name", "test"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "target", "branch"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "enforcement", "active"),
-						resource.TestCheckResourceAttr("github_repository_ruleset.test", "bypass_actors.#", "3"),
+						resource.TestCheckResourceAttr("github_repository_ruleset.test", "bypass_actors.#", "2"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "bypass_actors.0.actor_type", "DeployKey"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "bypass_actors.0.bypass_mode", "always"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "bypass_actors.1.actor_id", "5"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "bypass_actors.1.actor_type", "RepositoryRole"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "bypass_actors.1.bypass_mode", "always"),
-						resource.TestCheckResourceAttrPair("github_repository_ruleset.test", "bypass_actors.2.actor_id", "data.github_user.current", "id"),
-						resource.TestCheckResourceAttr("github_repository_ruleset.test", "bypass_actors.2.actor_type", "User"),
-						resource.TestCheckResourceAttr("github_repository_ruleset.test", "bypass_actors.2.bypass_mode", "always"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "rules.0.pull_request.0.allowed_merge_methods.#", "2"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "rules.0.required_code_scanning.0.required_code_scanning_tool.0.alerts_threshold", "errors"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "rules.0.required_code_scanning.0.required_code_scanning_tool.0.security_alerts_threshold", "high_or_higher"),
@@ -151,6 +141,63 @@ resource "github_repository_ruleset" "test" {
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "rules.0.copilot_code_review.0.review_on_push", "true"),
 						resource.TestCheckResourceAttr("github_repository_ruleset.test", "rules.0.copilot_code_review.0.review_draft_pull_requests", "false"),
 					),
+				},
+			},
+		})
+	})
+
+	t.Run("create_branch_ruleset_with_user_bypass_actor", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%srepo-ruleset-user-bypass-%s", testResourcePrefix, randomID)
+
+		config := fmt.Sprintf(`
+resource "github_repository" "test" {
+	name = "%s"
+	auto_init = true
+	vulnerability_alerts = true
+	visibility = "%s"
+}
+
+data "github_user" "current" {
+	username = "%[3]s"
+}
+
+resource "github_repository_ruleset" "test" {
+	name        = "test-user-bypass"
+	repository  = github_repository.test.id
+	target      = "branch"
+	enforcement = "active"
+
+	bypass_actors {
+		actor_id    = tonumber(data.github_user.current.id)
+		actor_type  = "User"
+		bypass_mode = "always"
+	}
+
+	conditions {
+		ref_name {
+			include = ["~ALL"]
+			exclude = []
+		}
+	}
+
+	rules {
+		creation = true
+	}
+}
+`, repoName, testAccConf.testRepositoryVisibility, testAccConf.username)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_ruleset.test", tfjsonpath.New("bypass_actors").AtSliceIndex(0).AtMapKey("actor_type"), knownvalue.StringExact("User")),
+						statecheck.ExpectKnownValue("github_repository_ruleset.test", tfjsonpath.New("bypass_actors").AtSliceIndex(0).AtMapKey("bypass_mode"), knownvalue.StringExact("always")),
+						statecheck.ExpectKnownValue("github_repository_ruleset.test", tfjsonpath.New("bypass_actors").AtSliceIndex(0).AtMapKey("actor_id"), knownvalue.NotNull()),
+					},
 				},
 			},
 		})

--- a/templates/resources/repository_ruleset.md.tmpl
+++ b/templates/resources/repository_ruleset.md.tmpl
@@ -225,9 +225,9 @@ The `rules` block supports the following:
 
 #### bypass_actors
 
-- `actor_id` - (Optional) (Number) The ID of the actor that can bypass a ruleset. If `actor_type` is `Integration`, `actor_id` is a GitHub App ID. App ID can be obtained by following instructions from the [Get an App API docs](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-app). Some actor types such as `DeployKey` do not have an ID.
+- `actor_id` - (Optional) (Number) The ID of the actor that can bypass a ruleset. If `actor_type` is `Integration`, `actor_id` is a GitHub App ID. App ID can be obtained by following instructions from the [Get an App API docs](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-app). If `actor_type` is `User`, `actor_id` is the numeric GitHub user ID. Some actor types such as `DeployKey` do not have an ID.
 
-- `actor_type` (String) The type of actor that can bypass a ruleset. Can be one of: `RepositoryRole`, `Team`, `Integration`, `OrganizationAdmin`, `DeployKey`.
+- `actor_type` (String) The type of actor that can bypass a ruleset. Can be one of: `RepositoryRole`, `Team`, `Integration`, `OrganizationAdmin`, `DeployKey`, `User`.
 
 - `bypass_mode` - (Optional) (String) When the specified actor can bypass the ruleset. pull_request means that an actor can only bypass rules on pull requests. Can be one of: `always`, `pull_request`, `exempt`.
 
@@ -238,6 +238,7 @@ The `rules` block supports the following:
   - `maintain` -> `2`
   - `write` -> `4`
   - `admin` -> `5`
+- `User` -> the numeric GitHub user ID
 
 #### conditions
 

--- a/templates/resources/repository_ruleset.md.tmpl
+++ b/templates/resources/repository_ruleset.md.tmpl
@@ -225,7 +225,7 @@ The `rules` block supports the following:
 
 #### bypass_actors
 
-- `actor_id` - (Optional) (Number) The ID of the actor that can bypass a ruleset. If `actor_type` is `Integration`, `actor_id` is a GitHub App ID. App ID can be obtained by following instructions from the [Get an App API docs](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-app). If `actor_type` is `User`, `actor_id` is the numeric GitHub user ID. Some actor types such as `DeployKey` do not have an ID.
+- `actor_id` - (Optional) (Number) The ID of the actor that can bypass a ruleset. If `actor_type` is `Integration`, `actor_id` is a GitHub App ID. App ID can be obtained by following instructions from the [Get an App API docs](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-app). If `actor_type` is `User`, `actor_id` is the numeric GitHub user ID. Some actor types such as `DeployKey` and `OrganizationAdmin` do not have an ID.
 
 - `actor_type` (String) The type of actor that can bypass a ruleset. Can be one of: `RepositoryRole`, `Team`, `Integration`, `OrganizationAdmin`, `DeployKey`, `User`.
 
@@ -233,7 +233,6 @@ The `rules` block supports the following:
 
 ~> Note: at the time of writing this, the following actor types correspond to the following actor IDs:
 
-- `OrganizationAdmin` -> `1`
 - `RepositoryRole` (This is the actor type, the following are the base repository roles and their associated IDs.)
   - `maintain` -> `2`
   - `write` -> `4`


### PR DESCRIPTION
 <!-- Please refer to our contributing docs for any questions on submitting a pull request -->
  <!-- Issues are required for both bug fixes and features. -->
  Resolves #3423

  ----

  ### Before the change?
  <!-- Please describe the current behavior that you are modifying. -->

  - `github_repository_ruleset` rejected `bypass_actors` with `actor_type = "User"` during schema validation, even though GitHub now supports user bypass actors for repository rulesets.

  ### After the change?
  <!-- Please describe the behavior or changes that are being added by this PR. -->

  - `github_repository_ruleset` accepts `actor_type = "User"` for `bypass_actors`.
  - The repository ruleset acceptance test now exercises a `User` bypass actor using the numeric GitHub user ID.
  - Repository ruleset documentation now lists `User` as a valid `actor_type` and clarifies that `actor_id` must be the numeric GitHub user ID.

  ### Pull request checklist

  - [ ] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
  - [x] Tests for the changes have been added (for bug fixes / features)
  - [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

  ### Does this introduce a breaking change?
  <!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

  Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

  - [ ] Yes
  - [x] No

  ----
