### PR TITLE
chore: Update go-github to v88

### DIFF
--- a/github/acc_test.go
+++ b/github/acc_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )

--- a/github/config.go
+++ b/github/config.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
@@ -108,8 +108,10 @@ func (c *Config) NewRESTClient(client *http.Client) (*github.Client, error) {
 		path = GHESRESTAPIPath
 	}
 
-	v3client := github.NewClient(client)
-	v3client.BaseURL = c.BaseURL.JoinPath(path)
+	v3client, err := github.NewClient(github.WithHTTPClient(client), github.WithURLs(new(c.BaseURL.JoinPath(path).String()), nil))
+	if err != nil {
+		return nil, err
+	}
 
 	return v3client, nil
 }

--- a/github/data_source_github_actions_environment_secrets.go
+++ b/github/data_source_github_actions_environment_secrets.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/url"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/data_source_github_actions_environment_variables.go
+++ b/github/data_source_github_actions_environment_variables.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/url"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/data_source_github_actions_organization_secrets.go
+++ b/github/data_source_github_actions_organization_secrets.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/data_source_github_actions_organization_variables.go
+++ b/github/data_source_github_actions_organization_variables.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/data_source_github_actions_secrets.go
+++ b/github/data_source_github_actions_secrets.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/data_source_github_actions_variables.go
+++ b/github/data_source_github_actions_variables.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/data_source_github_app_token.go
+++ b/github/data_source_github_app_token.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"net/url"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -38,7 +39,9 @@ func dataSourceGithubAppToken() *schema.Resource {
 	}
 }
 
-func dataSourceGithubAppTokenRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func dataSourceGithubAppTokenRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+
 	appID := d.Get("app_id").(string)
 	installationID := d.Get("installation_id").(string)
 	pemFile := d.Get("pem_file").(string)
@@ -52,15 +55,20 @@ func dataSourceGithubAppTokenRead(ctx context.Context, d *schema.ResourceData, m
 	// actual new line character before decoding.
 	pemFile = strings.ReplaceAll(pemFile, `\n`, "\n")
 
-	token, err := GenerateOAuthTokenFromApp(meta.(*Owner).v3client.BaseURL, appID, installationID, pemFile)
+	u, err := url.Parse(meta.v3client.BaseURL())
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("token", token)
+
+	token, err := GenerateOAuthTokenFromApp(u, appID, installationID, pemFile)
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
 	d.SetId("id")
+	if err := d.Set("token", token); err != nil {
+		return diag.FromErr(err)
+	}
 
 	return nil
 }

--- a/github/data_source_github_app_token_test.go
+++ b/github/data_source_github_app_token_test.go
@@ -2,12 +2,9 @@ package github
 
 import (
 	"fmt"
-	"net/http"
-	"net/url"
 	"os"
 	"testing"
 
-	"github.com/google/go-github/v86/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -35,12 +32,7 @@ func TestAccGithubAppTokenDataSource(t *testing.T) {
 		})
 		defer ts.Close()
 
-		httpCl := http.DefaultClient
-		httpCl.Transport = http.DefaultTransport
-
-		client := github.NewClient(httpCl)
-		u, _ := url.Parse(ts.URL + "/")
-		client.BaseURL = u
+		client := mustGitHubClient(t, ts.URL)
 
 		meta := &Owner{
 			name:     owner,

--- a/github/data_source_github_branch.go
+++ b/github/data_source_github_branch.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/data_source_github_codespaces_organization_secrets.go
+++ b/github/data_source_github_codespaces_organization_secrets.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/data_source_github_codespaces_secrets.go
+++ b/github/data_source_github_codespaces_secrets.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/data_source_github_codespaces_user_secrets.go
+++ b/github/data_source_github_codespaces_user_secrets.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/data_source_github_collaborators.go
+++ b/github/data_source_github_collaborators.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/github/data_source_github_dependabot_organization_secrets.go
+++ b/github/data_source_github_dependabot_organization_secrets.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/data_source_github_dependabot_secrets.go
+++ b/github/data_source_github_dependabot_secrets.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/data_source_github_external_groups.go
+++ b/github/data_source_github_external_groups.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/data_source_github_organization.go
+++ b/github/data_source_github_organization.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/shurcooL/githubv4"

--- a/github/data_source_github_organization_app_installations.go
+++ b/github/data_source_github_organization_app_installations.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/data_source_github_organization_custom_role.go
+++ b/github/data_source_github_organization_custom_role.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/data_source_github_organization_role_teams.go
+++ b/github/data_source_github_organization_role_teams.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/data_source_github_organization_role_users.go
+++ b/github/data_source_github_organization_role_users.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/data_source_github_organization_team_sync_groups.go
+++ b/github/data_source_github_organization_team_sync_groups.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/data_source_github_organization_teams.go
+++ b/github/data_source_github_organization_teams.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/github/data_source_github_organization_webhooks.go
+++ b/github/data_source_github_organization_webhooks.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/data_source_github_ref.go
+++ b/github/data_source_github_ref.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/data_source_github_release.go
+++ b/github/data_source_github_release.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/data_source_github_repositories.go
+++ b/github/data_source_github_repositories.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/data_source_github_repository_autolink_references.go
+++ b/github/data_source_github_repository_autolink_references.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/data_source_github_repository_branches.go
+++ b/github/data_source_github_repository_branches.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/data_source_github_repository_custom_properties.go
+++ b/github/data_source_github_repository_custom_properties.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/data_source_github_repository_deploy_keys.go
+++ b/github/data_source_github_repository_deploy_keys.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/data_source_github_repository_deployment_branch_policies.go
+++ b/github/data_source_github_repository_deployment_branch_policies.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/data_source_github_repository_environment_deployment_policies.go
+++ b/github/data_source_github_repository_environment_deployment_policies.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/url"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/data_source_github_repository_environments.go
+++ b/github/data_source_github_repository_environments.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/data_source_github_repository_file.go
+++ b/github/data_source_github_repository_file.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/data_source_github_repository_pull_requests.go
+++ b/github/data_source_github_repository_pull_requests.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/github/data_source_github_repository_teams.go
+++ b/github/data_source_github_repository_teams.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/data_source_github_repository_webhooks.go
+++ b/github/data_source_github_repository_webhooks.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/data_source_github_team.go
+++ b/github/data_source_github_team.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 
 	"github.com/shurcooL/githubv4"
 

--- a/github/helpers_test.go
+++ b/github/helpers_test.go
@@ -1,0 +1,15 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/google/go-github/v88/github"
+)
+
+func mustGitHubClient(t *testing.T, baseURL string, opts ...github.ClientOptionsFunc) *github.Client {
+	client, err := github.NewClient(append([]github.ClientOptionsFunc{github.WithURLs(&baseURL, nil)}, opts...)...)
+	if err != nil {
+		t.Fatalf("failed to create GitHub client: %s", err)
+	}
+	return client
+}

--- a/github/resource_github_actions_environment_secret.go
+++ b/github/resource_github_actions_environment_secret.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/resource_github_actions_environment_secret_test.go
+++ b/github/resource_github_actions_environment_secret_test.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 

--- a/github/resource_github_actions_environment_variable.go
+++ b/github/resource_github_actions_environment_variable.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/resource_github_actions_environment_variable_test.go
+++ b/github/resource_github_actions_environment_variable_test.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"

--- a/github/resource_github_actions_hosted_runner.go
+++ b/github/resource_github_actions_hosted_runner.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/github/resource_github_actions_organization_oidc_subject_claim_customization_template.go
+++ b/github/resource_github_actions_organization_oidc_subject_claim_customization_template.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_actions_organization_permissions.go
+++ b/github/resource_github_actions_organization_permissions.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"log"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/github/resource_github_actions_organization_secret.go
+++ b/github/resource_github_actions_organization_secret.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/resource_github_actions_organization_secret_repositories.go
+++ b/github/resource_github_actions_organization_secret_repositories.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/resource_github_actions_organization_secret_repository.go
+++ b/github/resource_github_actions_organization_secret_repository.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/resource_github_actions_organization_secret_test.go
+++ b/github/resource_github_actions_organization_secret_test.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"

--- a/github/resource_github_actions_organization_variable.go
+++ b/github/resource_github_actions_organization_variable.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/github/resource_github_actions_organization_variable_repositories.go
+++ b/github/resource_github_actions_organization_variable_repositories.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/resource_github_actions_organization_variable_repository.go
+++ b/github/resource_github_actions_organization_variable_repository.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/resource_github_actions_organization_variable_test.go
+++ b/github/resource_github_actions_organization_variable_test.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"

--- a/github/resource_github_actions_organization_workflow_permissions.go
+++ b/github/resource_github_actions_organization_workflow_permissions.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/resource_github_actions_repository_access_level.go
+++ b/github/resource_github_actions_repository_access_level.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/github/resource_github_actions_repository_oidc_subject_claim_customization_template.go
+++ b/github/resource_github_actions_repository_oidc_subject_claim_customization_template.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/github/resource_github_actions_repository_permissions.go
+++ b/github/resource_github_actions_repository_permissions.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/github/resource_github_actions_runner_group.go
+++ b/github/resource_github_actions_runner_group.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/github/resource_github_actions_secret.go
+++ b/github/resource_github_actions_secret.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/resource_github_actions_secret_test.go
+++ b/github/resource_github_actions_secret_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"

--- a/github/resource_github_actions_variable.go
+++ b/github/resource_github_actions_variable.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/resource_github_actions_variable_test.go
+++ b/github/resource_github_actions_variable_test.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 

--- a/github/resource_github_app_installation_repositories.go
+++ b/github/resource_github_app_installation_repositories.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_app_installation_repository.go
+++ b/github/resource_github_app_installation_repository.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_branch.go
+++ b/github/resource_github_branch.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_branch_default.go
+++ b/github/resource_github_branch_default.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_branch_protection_v3.go
+++ b/github/resource_github_branch_protection_v3.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/github/resource_github_branch_protection_v3_utils.go
+++ b/github/resource_github_branch_protection_v3_utils.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_codespaces_organization_secret.go
+++ b/github/resource_github_codespaces_organization_secret.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/github/resource_github_codespaces_organization_secret_repositories.go
+++ b/github/resource_github_codespaces_organization_secret_repositories.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_codespaces_secret.go
+++ b/github/resource_github_codespaces_secret.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_codespaces_user_secret.go
+++ b/github/resource_github_codespaces_user_secret.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/github/resource_github_dependabot_organization_secret.go
+++ b/github/resource_github_dependabot_organization_secret.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/resource_github_dependabot_organization_secret_repositories.go
+++ b/github/resource_github_dependabot_organization_secret_repositories.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/resource_github_dependabot_organization_secret_repository.go
+++ b/github/resource_github_dependabot_organization_secret_repository.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/resource_github_dependabot_organization_secret_test.go
+++ b/github/resource_github_dependabot_organization_secret_test.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"

--- a/github/resource_github_dependabot_secret.go
+++ b/github/resource_github_dependabot_secret.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/resource_github_dependabot_secret_test.go
+++ b/github/resource_github_dependabot_secret_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 

--- a/github/resource_github_emu_group_mapping.go
+++ b/github/resource_github_emu_group_mapping.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/resource_github_enterprise_actions_permissions.go
+++ b/github/resource_github_enterprise_actions_permissions.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/github/resource_github_enterprise_actions_runner_group.go
+++ b/github/resource_github_enterprise_actions_runner_group.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/github/resource_github_enterprise_actions_workflow_permissions.go
+++ b/github/resource_github_enterprise_actions_workflow_permissions.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/github/resource_github_enterprise_organization.go
+++ b/github/resource_github_enterprise_organization.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/shurcooL/githubv4"
 )

--- a/github/resource_github_enterprise_organization_test.go
+++ b/github/resource_github_enterprise_organization_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )

--- a/github/resource_github_enterprise_security_analysis_settings.go
+++ b/github/resource_github_enterprise_security_analysis_settings.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_issue.go
+++ b/github/resource_github_issue.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_issue_label.go
+++ b/github/resource_github_issue_label.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_issue_labels.go
+++ b/github/resource_github_issue_labels.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_membership.go
+++ b/github/resource_github_membership.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/resource_github_membership_test.go
+++ b/github/resource_github_membership_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )

--- a/github/resource_github_organization_custom_properties.go
+++ b/github/resource_github_organization_custom_properties.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/github/resource_github_organization_custom_role.go
+++ b/github/resource_github_organization_custom_role.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_organization_project_test.go
+++ b/github/resource_github_organization_project_test.go
@@ -7,7 +7,7 @@ package github
 // 	"strings"
 // 	"testing"
 
-// 	"github.com/google/go-github/v86/github"
+// 	"github.com/google/go-github/v88/github"
 // 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 // 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 // )

--- a/github/resource_github_organization_repository_role.go
+++ b/github/resource_github_organization_repository_role.go
@@ -8,7 +8,7 @@ import (
 	"slices"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/resource_github_organization_role.go
+++ b/github/resource_github_organization_role.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/resource_github_organization_role_team.go
+++ b/github/resource_github_organization_role_team.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/resource_github_organization_role_team_assignment.go
+++ b/github/resource_github_organization_role_team_assignment.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_organization_role_user.go
+++ b/github/resource_github_organization_role_user.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/resource_github_organization_ruleset.go
+++ b/github/resource_github_organization_ruleset.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/resource_github_organization_security_manager.go
+++ b/github/resource_github_organization_security_manager.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_organization_settings.go
+++ b/github/resource_github_organization_settings.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/github/resource_github_organization_webhook.go
+++ b/github/resource_github_organization_webhook.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/resource_github_project_column_test.go
+++ b/github/resource_github_project_column_test.go
@@ -6,7 +6,7 @@ package github
 // 	"strconv"
 // 	"testing"
 
-// 	"github.com/google/go-github/v86/github"
+// 	"github.com/google/go-github/v88/github"
 // 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 // 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 // )

--- a/github/resource_github_release.go
+++ b/github/resource_github_release.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/resource_github_repository_autolink_reference.go
+++ b/github/resource_github_repository_autolink_reference.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/github/resource_github_repository_collaborator.go
+++ b/github/resource_github_repository_collaborator.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_repository_collaborators.go
+++ b/github/resource_github_repository_collaborators.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/github/resource_github_repository_custom_property.go
+++ b/github/resource_github_repository_custom_property.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/github/resource_github_repository_deploy_key.go
+++ b/github/resource_github_repository_deploy_key.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_repository_deployment_branch_policy.go
+++ b/github/resource_github_repository_deployment_branch_policy.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_repository_environment.go
+++ b/github/resource_github_repository_environment.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"

--- a/github/resource_github_repository_environment_deployment_policy.go
+++ b/github/resource_github_repository_environment_deployment_policy.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"

--- a/github/resource_github_repository_file.go
+++ b/github/resource_github_repository_file.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/resource_github_repository_file_migration_test.go
+++ b/github/resource_github_repository_file_migration_test.go
@@ -11,7 +11,7 @@ package github
 // 	"testing"
 
 // 	"github.com/google/go-cmp/cmp"
-// 	"github.com/google/go-github/v86/github"
+// 	"github.com/google/go-github/v88/github"
 // )
 
 // func buildMockResponsesForRepositoryFileMigrationV0toV1(mockOwner, mockRepo string, wantRepoID int) []*mockResponse {

--- a/github/resource_github_repository_milestone.go
+++ b/github/resource_github_repository_milestone.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/github/resource_github_repository_pages.go
+++ b/github/resource_github_repository_pages.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"

--- a/github/resource_github_repository_pull_request.go
+++ b/github/resource_github_repository_pull_request.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_repository_ruleset.go
+++ b/github/resource_github_repository_ruleset.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/resource_github_repository_topics.go
+++ b/github/resource_github_repository_topics.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"regexp"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/github/resource_github_repository_webhook.go
+++ b/github/resource_github_repository_webhook.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/resource_github_team.go
+++ b/github/resource_github_team.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/resource_github_team_members.go
+++ b/github/resource_github_team_members.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/shurcooL/githubv4"

--- a/github/resource_github_team_membership.go
+++ b/github/resource_github_team_membership.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/resource_github_team_membership_test.go
+++ b/github/resource_github_team_membership_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"

--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/resource_github_team_sync_group_mapping.go
+++ b/github/resource_github_team_sync_group_mapping.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_team_sync_group_mapping_test.go
+++ b/github/resource_github_team_sync_group_mapping_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/github/resource_github_user_gpg_key.go
+++ b/github/resource_github_user_gpg_key.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_user_ssh_key.go
+++ b/github/resource_github_user_ssh_key.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/resource_github_workflow_repository_permissions.go
+++ b/github/resource_github_workflow_repository_permissions.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )

--- a/github/resource_organization_block.go
+++ b/github/resource_organization_block.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/transport.go
+++ b/github/transport.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 )
 
 const (

--- a/github/transport_test.go
+++ b/github/transport_test.go
@@ -8,11 +8,10 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 )
 
 func TestEtagTransport(t *testing.T) {
@@ -29,13 +28,7 @@ func TestEtagTransport(t *testing.T) {
 	})
 	defer ts.Close()
 
-	httpClient := http.DefaultClient
-	httpClient.Transport = NewEtagTransport(http.DefaultTransport)
-
-	client := github.NewClient(httpClient)
-	u, _ := url.Parse(ts.URL + "/")
-	client.BaseURL = u
-
+	client := mustGitHubClient(t, ts.URL, github.WithTransport(NewEtagTransport(http.DefaultTransport)))
 	ctx := context.WithValue(t.Context(), ctxEtag, "something")
 	r, _, err := client.Repositories.Get(ctx, "test", "blah")
 	if err != nil {
@@ -142,12 +135,7 @@ func TestRateLimitTransport_abuseLimit_get(t *testing.T) {
 	})
 	defer ts.Close()
 
-	httpClient := http.DefaultClient
-	httpClient.Transport = NewRateLimitTransport(http.DefaultTransport)
-
-	client := github.NewClient(httpClient)
-	u, _ := url.Parse(ts.URL + "/")
-	client.BaseURL = u
+	client := mustGitHubClient(t, ts.URL, github.WithTransport(NewRateLimitTransport(http.DefaultTransport)))
 
 	ctx := context.WithValue(t.Context(), ctxId, t.Name())
 	r, _, err := client.Repositories.Get(ctx, "test", "blah")
@@ -176,12 +164,7 @@ func TestRateLimitTransport_abuseLimit_get_cancelled(t *testing.T) {
 	})
 	defer ts.Close()
 
-	httpClient := http.DefaultClient
-	httpClient.Transport = NewRateLimitTransport(http.DefaultTransport)
-
-	client := github.NewClient(httpClient)
-	u, _ := url.Parse(ts.URL + "/")
-	client.BaseURL = u
+	client := mustGitHubClient(t, ts.URL, github.WithTransport(NewRateLimitTransport(http.DefaultTransport)))
 
 	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
@@ -223,12 +206,7 @@ func TestRateLimitTransport_abuseLimit_post(t *testing.T) {
 	})
 	defer ts.Close()
 
-	httpClient := http.DefaultClient
-	httpClient.Transport = NewRateLimitTransport(http.DefaultTransport)
-
-	client := github.NewClient(httpClient)
-	u, _ := url.Parse(ts.URL + "/")
-	client.BaseURL = u
+	client := mustGitHubClient(t, ts.URL, github.WithTransport(NewRateLimitTransport(http.DefaultTransport)))
 
 	ctx := context.WithValue(t.Context(), ctxId, t.Name())
 	r, _, err := client.Repositories.Create(ctx, "tada", &github.Repository{
@@ -283,12 +261,7 @@ func TestRateLimitTransport_abuseLimit_post_error(t *testing.T) {
 	})
 	defer ts.Close()
 
-	httpClient := http.DefaultClient
-	httpClient.Transport = NewRateLimitTransport(http.DefaultTransport)
-
-	client := github.NewClient(httpClient)
-	u, _ := url.Parse(ts.URL + "/")
-	client.BaseURL = u
+	client := mustGitHubClient(t, ts.URL, github.WithTransport(NewRateLimitTransport(http.DefaultTransport)))
 
 	ctx := context.WithValue(t.Context(), ctxId, t.Name())
 	_, _, err := client.Repositories.Create(ctx, "tada", &github.Repository{
@@ -416,12 +389,7 @@ func TestRetryTransport_retry_post_error(t *testing.T) {
 	})
 	defer ts.Close()
 
-	httpClient := http.DefaultClient
-	httpClient.Transport = NewRetryTransport(http.DefaultTransport, WithMaxRetries(1))
-
-	client := github.NewClient(httpClient)
-	u, _ := url.Parse(ts.URL + "/")
-	client.BaseURL = u
+	client := mustGitHubClient(t, ts.URL, github.WithTransport(NewRetryTransport(http.DefaultTransport, WithMaxRetries(1))))
 
 	ctx := context.WithValue(t.Context(), ctxId, t.Name())
 	_, _, err := client.Repositories.Create(ctx, "tada", &github.Repository{
@@ -479,12 +447,7 @@ func TestRetryTransport_retry_post_success(t *testing.T) {
 	})
 	defer ts.Close()
 
-	httpClient := http.DefaultClient
-	httpClient.Transport = NewRetryTransport(http.DefaultTransport, WithMaxRetries(2), WithRetryDelay(time.Second))
-
-	client := github.NewClient(httpClient)
-	u, _ := url.Parse(ts.URL + "/")
-	client.BaseURL = u
+	client := mustGitHubClient(t, ts.URL, github.WithTransport(NewRetryTransport(http.DefaultTransport, WithMaxRetries(2), WithRetryDelay(time.Second))))
 
 	ctx := context.WithValue(t.Context(), ctxId, t.Name())
 	_, _, err := client.Repositories.Create(ctx, "tada", &github.Repository{

--- a/github/util.go
+++ b/github/util.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/github/util_diff.go
+++ b/github/util_diff.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/util_labels.go
+++ b/github/util_labels.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 )
 
 func flattenLabels(labels []*github.Label) []any {

--- a/github/util_repo.go
+++ b/github/util_repo.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 

--- a/github/util_rules.go
+++ b/github/util_rules.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/github/util_rules_test.go
+++ b/github/util_rules_test.go
@@ -3,7 +3,7 @@ package github
 import (
 	"testing"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/github/util_ruleset_validation.go
+++ b/github/util_ruleset_validation.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/github/util_ruleset_validation_test.go
+++ b/github/util_ruleset_validation_test.go
@@ -3,7 +3,7 @@ package github
 import (
 	"testing"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 )
 
 func Test_validateConditionsFieldForPushTarget(t *testing.T) {

--- a/github/util_team.go
+++ b/github/util_team.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/google/go-github/v86/github"
+	"github.com/google/go-github/v88/github"
 )
 
 // teamIdentity represents a GitHub team.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/google/go-cmp v0.7.0
-	github.com/google/go-github/v86 v86.0.0
+	github.com/google/go-github/v88 v88.0.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v86 v86.0.0 h1:S/6aANJhwRm8EQmGKVML3j41yq0h2BsTP8FnDkO7kcA=
-github.com/google/go-github/v86 v86.0.0/go.mod h1:zKv1l4SwDXNFMGByi2FWkq71KwSXqj/eQRZuqtmcot8=
+github.com/google/go-github/v88 v88.0.0 h1:dZA9IKkPK1eXZj4ypngnpRj5FwdpTv4whix2PrQMP7M=
+github.com/google/go-github/v88 v88.0.0/go.mod h1:rufTDgn2N45wjhukLTyxmvc9nilSp3mr3Rgtt6b1MPw=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

-

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `go-github` is updated to `v88.0.0`

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
