### PR TITLE
chore: Update valid permissions for organization repository role

### DIFF
--- a/github/resource_github_organization_repository_role.go
+++ b/github/resource_github_organization_repository_role.go
@@ -200,7 +200,7 @@ func resourceGithubOrganizationRepositoryRoleDelete(ctx context.Context, d *sche
 	return nil
 }
 
-// Snapshot of the response to https://docs.github.com/en/enterprise-cloud@latest/rest/orgs/custom-roles?apiVersion=2022-11-28#list-repository-fine-grained-permissions-for-an-organization
+// Snapshot of the response to https://docs.github.com/en/enterprise-cloud@latest/rest/orgs/custom-roles?apiVersion=2026-03-10#list-repository-fine-grained-permissions-for-an-organization
 // The endpoint isn't covered in the SDK yet.
 var validRolePermissions = []string{
 	"add_assignee",
@@ -235,6 +235,7 @@ var validRolePermissions = []string{
 	"push_protected_branch",
 	"read_code_quality",
 	"read_code_scanning",
+	"read_copilot_agent_settings",
 	"reopen_discussion",
 	"reopen_issue",
 	"reopen_pull_request",
@@ -251,11 +252,14 @@ var validRolePermissions = []string{
 	"view_secret_scanning_alerts",
 	"write_code_quality",
 	"write_code_scanning",
+	"write_copilot_agent_settings",
 	"write_repository_actions_environments",
 	"write_repository_actions_runners",
 	"write_repository_actions_secrets",
 	"write_repository_actions_settings",
 	"write_repository_actions_variables",
+	"write_repository_agent_secrets",
+	"write_repository_agent_variables",
 }
 
 func resourceGithubOrganizationRepositoryRoleCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, m any) error {

--- a/github/resource_github_organization_repository_role.go
+++ b/github/resource_github_organization_repository_role.go
@@ -200,8 +200,7 @@ func resourceGithubOrganizationRepositoryRoleDelete(ctx context.Context, d *sche
 	return nil
 }
 
-// Snapshot of the response to https://docs.github.com/en/enterprise-cloud@latest/rest/orgs/custom-roles?apiVersion=2026-03-10#list-repository-fine-grained-permissions-for-an-organization
-// The endpoint isn't covered in the SDK yet.
+// Snapshot of the response to https://docs.github.com/en/enterprise-cloud@latest/rest/orgs/custom-roles?apiVersion=2022-11-28#list-repository-fine-grained-permissions-for-an-organization
 var validRolePermissions = []string{
 	"add_assignee",
 	"add_label",


### PR DESCRIPTION
### Before the change?

- `validRolePermissions` in `github/resource_github_organization_repository_role.go` was a snapshot of the GitHub repository fine-grained permissions API and had drifted from the upstream response. It rejected newer permissions (`read_copilot_agent_settings`, `write_copilot_agent_settings`, `write_repository_agent_secrets`, `write_repository_agent_variables`) at plan time via `CustomizeDiff`, even though the GitHub API would accept them.
- The doc-link comment above the slice referenced `apiVersion=2022-11-28`, which is no longer the current version on the linked GitHub docs page.

### After the change?

- The four permissions above are added to `validRolePermissions` (kept alphabetically sorted) so configurations using them now pass validation.
- The doc-link comment is bumped to `apiVersion=2026-03-10` to match the current GitHub docs page for `GET /orgs/{org}/repository-fine-grained-permissions`.
- The list was generated by calling `GET /orgs/{org}/repository-fine-grained-permissions` against a real org and diffing the returned `name`s against the existing slice; only additions were observed (no permissions removed upstream).

### Pull request checklist

- [ ] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

Notes:
- `make generatedocs` produced no diff (the generated docs do not enumerate individual permissions).
- `make fmt`, `make lint`, and `make test` all pass locally.

### Does this introduce a breaking change?

- [ ] Yes
- [x] No