### PR TITLE
fix: Stop repo collaborators drifting on owner

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,7 @@ linters:
     - errcheck
     - errname
     - errorlint
-    # - forcetypeassert TODO: Re-enable when we can fix the issues
+    # - forcetypeassert # TODO: Re-enable when we can fix the issues
     - godot
     - govet
     - ineffassign

--- a/docs/resources/repository_collaborators.md
+++ b/docs/resources/repository_collaborators.md
@@ -25,9 +25,7 @@ Teams will be added to the repository on apply, and removed if removed from the 
 
 ## Personal Repositories
 
-For personal repositories, collaborators can only be granted [write](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/repository-access-and-collaboration/permission-levels-for-a-personal-account-repository#collaborator-access-for-a-repository-owned-by-a-personal-account) permission.
-
-!> If the repository owner is not added as a collaborator with admin access, the provider will churn this resource on every plan/apply. To prevent this, ensure that the repository owner is included in the set of user collaborators.
+For personal repositories, non-owner collaborators can only be granted [write](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/repository-access-and-collaboration/permission-levels-for-a-personal-account-repository#collaborator-access-for-a-repository-owned-by-a-personal-account) permission. Owners will be ignored unless they are explicitly added, in which case they must be granted `admin` permission.
 
 ## Users
 
@@ -90,14 +88,15 @@ resource "github_repository_collaborators" "some_repo_collaborators" {
 - `repository_id` (Number) ID of the repository.
 
 <a id="nestedblock--ignore_team"></a>
+
 ### Nested Schema for `ignore_team`
 
 Required:
 
 - `team_id` (String) ID or slug of the team to ignore.
 
-
 <a id="nestedblock--team"></a>
+
 ### Nested Schema for `team`
 
 Required:
@@ -108,8 +107,8 @@ Optional:
 
 - `permission` (String) Permission to grant to the team. Must be one of `pull`, `triage`, `push`, `maintain`, `admin` or the name of an existing [custom repository role](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-peoples-access-to-your-organization-with-roles/managing-custom-repository-roles-for-an-organization) within the organization. Defaults to `push`.
 
-
 <a id="nestedblock--user"></a>
+
 ### Nested Schema for `user`
 
 Required:

--- a/docs/resources/repository_collaborators.md
+++ b/docs/resources/repository_collaborators.md
@@ -86,6 +86,7 @@ resource "github_repository_collaborators" "some_repo_collaborators" {
 
 - `id` (String) The ID of this resource.
 - `invitation_ids` (Map of String) Map of usernames to invitation ID for users that haven't yet accepted their invitation to become a collaborator. This is only set on read, and is used internally to track pending invitations for users that aren't yet collaborators.
+- `owner_configured` (Boolean) Indicates whether the owner of a personal repository is configured as a collaborator.
 - `repository_id` (Number) ID of the repository.
 
 <a id="nestedblock--ignore_team"></a>

--- a/docs/resources/repository_collaborators.md
+++ b/docs/resources/repository_collaborators.md
@@ -88,15 +88,14 @@ resource "github_repository_collaborators" "some_repo_collaborators" {
 - `repository_id` (Number) ID of the repository.
 
 <a id="nestedblock--ignore_team"></a>
-
 ### Nested Schema for `ignore_team`
 
 Required:
 
 - `team_id` (String) ID or slug of the team to ignore.
 
-<a id="nestedblock--team"></a>
 
+<a id="nestedblock--team"></a>
 ### Nested Schema for `team`
 
 Required:
@@ -107,8 +106,8 @@ Optional:
 
 - `permission` (String) Permission to grant to the team. Must be one of `pull`, `triage`, `push`, `maintain`, `admin` or the name of an existing [custom repository role](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-peoples-access-to-your-organization-with-roles/managing-custom-repository-roles-for-an-organization) within the organization. Defaults to `push`.
 
-<a id="nestedblock--user"></a>
 
+<a id="nestedblock--user"></a>
 ### Nested Schema for `user`
 
 Required:

--- a/github/resource_github_repository_collaborators.go
+++ b/github/resource_github_repository_collaborators.go
@@ -18,12 +18,17 @@ import (
 
 func resourceGithubRepositoryCollaborators() *schema.Resource {
 	return &schema.Resource{
-		SchemaVersion: 1,
+		SchemaVersion: 2,
 		StateUpgraders: []schema.StateUpgrader{
 			{
 				Type:    resourceGithubRepositoryCollaboratorsV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: resourceGithubRepositoryCollaboratorsStateUpgradeV0,
 				Version: 0,
+			},
+			{
+				Type:    resourceGithubRepositoryCollaboratorsV1().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceGithubRepositoryCollaboratorsStateUpgradeV1,
+				Version: 1,
 			},
 		},
 
@@ -145,32 +150,6 @@ func resourceGithubRepositoryCollaboratorsDiff(ctx context.Context, d *schema.Re
 		}
 	}
 
-	if meta.IsOrganization {
-		if err := d.SetNew("owner_configured", false); err != nil {
-			return fmt.Errorf("error setting owner_configured: %w", err)
-		}
-	} else if d.NewValueKnown("user") {
-		users := d.Get("user").(*schema.Set).List()
-		ownerConfigured := false
-		owner := strings.ToLower(meta.name)
-
-		for _, u := range users {
-			user := u.(map[string]any)
-			if strings.ToLower(user["username"].(string)) == owner {
-				ownerConfigured = true
-				break
-			}
-		}
-
-		if err := d.SetNew("owner_configured", ownerConfigured); err != nil {
-			return fmt.Errorf("error setting owner_configured: %w", err)
-		}
-	} else {
-		if err := d.SetNewComputed("owner_configured"); err != nil {
-			return fmt.Errorf("error setting owner_configured to computed: %w", err)
-		}
-	}
-
 	if d.HasChange("team") && d.NewValueKnown("team") {
 		v, diags := d.GetRawConfigAt(cty.GetAttrPath("team"))
 		if diags.HasError() {
@@ -196,7 +175,61 @@ func resourceGithubRepositoryCollaboratorsDiff(ctx context.Context, d *schema.Re
 		}
 	}
 
-	if len(d.Id()) == 0 {
+	if meta.IsOrganization {
+		// If the repository belongs to an organization the owner cannot be a,
+		// collaborator, so owner_configured is always false.
+
+		if err := d.SetNew("owner_configured", false); err != nil {
+			return fmt.Errorf("error setting owner_configured: %w", err)
+		}
+	} else if d.NewValueKnown("user") {
+		// If the repository belongs to a user and we know the new value of user,
+		// then we can determine the value of owner_configured by checking if
+		// the owner is included in the list of users.
+
+		ownerConfigured := false
+		owner := strings.ToLower(meta.name)
+
+		usersVal := d.Get("user")
+		if users, ok := usersVal.(*schema.Set); ok {
+			for _, u := range users.List() {
+				user, ok := u.(map[string]any)
+				if !ok {
+					continue
+				}
+
+				usernameVal, ok := user["username"]
+				if !ok {
+					continue
+				}
+
+				username, ok := usernameVal.(string)
+				if !ok {
+					continue
+				}
+
+				if strings.ToLower(username) == owner {
+					ownerConfigured = true
+					break
+				}
+			}
+		}
+
+		if err := d.SetNew("owner_configured", ownerConfigured); err != nil {
+			return fmt.Errorf("error setting owner_configured: %w", err)
+		}
+	} else {
+		// If the repository belongs to a user but we don't know the new value of user,
+		// then we don't know if the owner is configured as a collaborator or not,
+		// so we set owner_configured to computed to indicate that Terraform should
+		// determine the value during apply.
+
+		if err := d.SetNewComputed("owner_configured"); err != nil {
+			return fmt.Errorf("error setting owner_configured to computed: %w", err)
+		}
+	}
+
+	if d.Id() == "" {
 		return nil
 	}
 
@@ -227,9 +260,23 @@ func resourceGithubRepositoryCollaboratorsCreate(ctx context.Context, d *schema.
 		return diag.FromErr(err)
 	}
 
+	ownerConfigured := false
 	inIgnoreUsers := make([]string, 0)
-	if !isOrg && !d.Get("owner_configured").(bool) {
-		inIgnoreUsers = append(inIgnoreUsers, strings.ToLower(owner))
+	if !isOrg {
+		ownerConfigured, _ = d.Get("owner_configured").(bool)
+
+		if !ownerConfigured {
+			for _, u := range inUsers {
+				if strings.EqualFold(u.login, owner) {
+					ownerConfigured = true
+					break
+				}
+			}
+
+			if !ownerConfigured {
+				inIgnoreUsers = append(inIgnoreUsers, strings.ToLower(owner))
+			}
+		}
 	}
 
 	inTeams, err := getTeamCollaborators(teams)
@@ -281,9 +328,10 @@ func resourceGithubRepositoryCollaboratorsRead(ctx context.Context, d *schema.Re
 	repoName := d.Get("repository").(string)
 	teams := d.Get("team").(*schema.Set).List()
 	ignoreTeams := d.Get("ignore_team").(*schema.Set).List()
+	ownerConfigured, _ := d.Get("owner_configured").(bool)
 
 	inIgnoreUsers := make([]string, 0)
-	if !isOrg && !d.Get("owner_configured").(bool) {
+	if !isOrg && !ownerConfigured {
 		inIgnoreUsers = append(inIgnoreUsers, strings.ToLower(owner))
 	}
 
@@ -357,9 +405,23 @@ func resourceGithubRepositoryCollaboratorsUpdate(ctx context.Context, d *schema.
 		return diag.FromErr(err)
 	}
 
+	ownerConfigured := false
 	inIgnoreUsers := make([]string, 0)
-	if !isOrg && !d.Get("owner_configured").(bool) {
-		inIgnoreUsers = append(inIgnoreUsers, strings.ToLower(owner))
+	if !isOrg {
+		ownerConfigured, _ = d.Get("owner_configured").(bool)
+
+		if !ownerConfigured {
+			for _, u := range inUsers {
+				if strings.EqualFold(u.login, owner) {
+					ownerConfigured = true
+					break
+				}
+			}
+
+			if !ownerConfigured {
+				inIgnoreUsers = append(inIgnoreUsers, strings.ToLower(owner))
+			}
+		}
 	}
 
 	inTeams, err := getTeamCollaborators(teams)

--- a/github/resource_github_repository_collaborators.go
+++ b/github/resource_github_repository_collaborators.go
@@ -133,16 +133,32 @@ func resourceGithubRepositoryCollaborators() *schema.Resource {
 func resourceGithubRepositoryCollaboratorsDiff(ctx context.Context, d *schema.ResourceDiff, m any) error {
 	tflog.Debug(ctx, "Diffing collaborators")
 
-	meta := m.(*Owner)
+	meta, _ := m.(*Owner)
 
 	if d.HasChange("user") {
-		users := d.Get("user").(*schema.Set).List()
+		users, ok := d.Get("user").(*schema.Set)
+		if !ok {
+			return fmt.Errorf("error reading user config")
+		}
+
 		seen := make(map[string]any)
+		for _, u := range users.List() {
+			user, ok := u.(map[string]any)
+			if !ok {
+				return fmt.Errorf("error reading user config")
+			}
 
-		for _, u := range users {
-			user := u.(map[string]any)
-			username := strings.ToLower(user["username"].(string))
+			usernameVal, ok := user["username"]
+			if !ok {
+				return fmt.Errorf("error reading user config")
+			}
 
+			username, ok := usernameVal.(string)
+			if !ok {
+				return fmt.Errorf("error reading user config")
+			}
+
+			username = strings.ToLower(username)
 			if _, ok := seen[username]; ok {
 				return fmt.Errorf("duplicate username %s found in user collaborators", username)
 			}
@@ -188,30 +204,32 @@ func resourceGithubRepositoryCollaboratorsDiff(ctx context.Context, d *schema.Re
 		// the owner is included in the list of users.
 
 		ownerConfigured := false
-		owner := strings.ToLower(meta.name)
+		owner := meta.name
 
-		usersVal := d.Get("user")
-		if users, ok := usersVal.(*schema.Set); ok {
-			for _, u := range users.List() {
-				user, ok := u.(map[string]any)
-				if !ok {
-					continue
-				}
+		users, ok := d.Get("user").(*schema.Set)
+		if !ok {
+			return fmt.Errorf("error reading user config")
+		}
 
-				usernameVal, ok := user["username"]
-				if !ok {
-					continue
-				}
+		for _, u := range users.List() {
+			user, ok := u.(map[string]any)
+			if !ok {
+				return fmt.Errorf("error reading user config")
+			}
 
-				username, ok := usernameVal.(string)
-				if !ok {
-					continue
-				}
+			usernameVal, ok := user["username"]
+			if !ok {
+				return fmt.Errorf("error reading user config")
+			}
 
-				if strings.ToLower(username) == owner {
-					ownerConfigured = true
-					break
-				}
+			username, ok := usernameVal.(string)
+			if !ok {
+				return fmt.Errorf("error reading user config")
+			}
+
+			if strings.EqualFold(username, owner) {
+				ownerConfigured = true
+				break
 			}
 		}
 
@@ -271,6 +289,10 @@ func resourceGithubRepositoryCollaboratorsCreate(ctx context.Context, d *schema.
 					ownerConfigured = true
 					break
 				}
+			}
+
+			if !ownerConfigured {
+				inIgnoreUsers = append(inIgnoreUsers, strings.ToLower(owner))
 			}
 
 			if !ownerConfigured {
@@ -420,6 +442,10 @@ func resourceGithubRepositoryCollaboratorsUpdate(ctx context.Context, d *schema.
 
 			if !ownerConfigured {
 				inIgnoreUsers = append(inIgnoreUsers, strings.ToLower(owner))
+			}
+
+			if err := d.Set("owner_configured", ownerConfigured); err != nil {
+				return diag.FromErr(err)
 			}
 		}
 	}

--- a/github/resource_github_repository_collaborators.go
+++ b/github/resource_github_repository_collaborators.go
@@ -295,8 +295,8 @@ func resourceGithubRepositoryCollaboratorsCreate(ctx context.Context, d *schema.
 				inIgnoreUsers = append(inIgnoreUsers, strings.ToLower(owner))
 			}
 
-			if !ownerConfigured {
-				inIgnoreUsers = append(inIgnoreUsers, strings.ToLower(owner))
+			if err := d.Set("owner_configured", ownerConfigured); err != nil {
+				return diag.FromErr(err)
 			}
 		}
 	}

--- a/github/resource_github_repository_collaborators.go
+++ b/github/resource_github_repository_collaborators.go
@@ -89,6 +89,11 @@ func resourceGithubRepositoryCollaborators() *schema.Resource {
 					},
 				},
 			},
+			"owner_configured": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Indicates whether the owner of a personal repository is configured as a collaborator.",
+			},
 			"invitation_ids": {
 				Type:        schema.TypeMap,
 				Description: "Map of usernames to invitation ID for users that haven't yet accepted their invitation to become a collaborator. This is only set on read, and is used internally to track pending invitations for users that aren't yet collaborators.",
@@ -121,19 +126,48 @@ func resourceGithubRepositoryCollaborators() *schema.Resource {
 }
 
 func resourceGithubRepositoryCollaboratorsDiff(ctx context.Context, d *schema.ResourceDiff, m any) error {
-	tflog.Debug(ctx, "Diffing user collaborators")
+	tflog.Debug(ctx, "Diffing collaborators")
+
+	meta := m.(*Owner)
+
 	if d.HasChange("user") {
 		users := d.Get("user").(*schema.Set).List()
 		seen := make(map[string]any)
 
 		for _, u := range users {
 			user := u.(map[string]any)
-			username := user["username"].(string)
+			username := strings.ToLower(user["username"].(string))
 
 			if _, ok := seen[username]; ok {
 				return fmt.Errorf("duplicate username %s found in user collaborators", username)
 			}
 			seen[username] = nil
+		}
+	}
+
+	if meta.IsOrganization {
+		if err := d.SetNew("owner_configured", false); err != nil {
+			return fmt.Errorf("error setting owner_configured: %w", err)
+		}
+	} else if d.NewValueKnown("user") {
+		users := d.Get("user").(*schema.Set).List()
+		ownerConfigured := false
+		owner := strings.ToLower(meta.name)
+
+		for _, u := range users {
+			user := u.(map[string]any)
+			if strings.ToLower(user["username"].(string)) == owner {
+				ownerConfigured = true
+				break
+			}
+		}
+
+		if err := d.SetNew("owner_configured", ownerConfigured); err != nil {
+			return fmt.Errorf("error setting owner_configured: %w", err)
+		}
+	} else {
+		if err := d.SetNewComputed("owner_configured"); err != nil {
+			return fmt.Errorf("error setting owner_configured to computed: %w", err)
 		}
 	}
 
@@ -186,14 +220,16 @@ func resourceGithubRepositoryCollaboratorsCreate(ctx context.Context, d *schema.
 	teams := d.Get("team").(*schema.Set).List()
 	ignoreTeams := d.Get("ignore_team").(*schema.Set).List()
 
-	tflog.Debug(ctx, "Creating repository collaborators", map[string]any{
-		"users":       users,
-		"teams":       teams,
-		"ignoreTeams": ignoreTeams,
-	})
+	tflog.Debug(ctx, "Creating repository collaborators", map[string]any{"users": users, "teams": teams, "ignoreTeams": ignoreTeams})
+
 	inUsers, err := getUserCollaborators(users)
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	inIgnoreUsers := make([]string, 0)
+	if !isOrg && !d.Get("owner_configured").(bool) {
+		inIgnoreUsers = append(inIgnoreUsers, strings.ToLower(owner))
 	}
 
 	inTeams, err := getTeamCollaborators(teams)
@@ -206,7 +242,7 @@ func resourceGithubRepositoryCollaboratorsCreate(ctx context.Context, d *schema.
 		return diag.FromErr(err)
 	}
 
-	invitations, err := updateUserCollaboratorsAndInvites(ctx, client, owner, repoName, inUsers)
+	invitations, err := updateUserCollaboratorsAndInvites(ctx, client, owner, repoName, inUsers, inIgnoreUsers)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -246,6 +282,11 @@ func resourceGithubRepositoryCollaboratorsRead(ctx context.Context, d *schema.Re
 	teams := d.Get("team").(*schema.Set).List()
 	ignoreTeams := d.Get("ignore_team").(*schema.Set).List()
 
+	inIgnoreUsers := make([]string, 0)
+	if !isOrg && !d.Get("owner_configured").(bool) {
+		inIgnoreUsers = append(inIgnoreUsers, strings.ToLower(owner))
+	}
+
 	inTeams, err := getTeamCollaborators(teams)
 	if err != nil {
 		return diag.FromErr(err)
@@ -256,7 +297,7 @@ func resourceGithubRepositoryCollaboratorsRead(ctx context.Context, d *schema.Re
 		return diag.FromErr(err)
 	}
 
-	ghUsers, err := listUserCollaborators(ctx, client, owner, repoName)
+	ghUsers, err := listUserCollaborators(ctx, client, owner, repoName, inIgnoreUsers)
 	if err != nil {
 		if err, ok := errors.AsType[*github.ErrorResponse](err); ok && err.Response.StatusCode == 404 {
 			tflog.Debug(ctx, fmt.Sprintf("Repository %s not found when listing users, removing from state.", repoName))
@@ -316,6 +357,11 @@ func resourceGithubRepositoryCollaboratorsUpdate(ctx context.Context, d *schema.
 		return diag.FromErr(err)
 	}
 
+	inIgnoreUsers := make([]string, 0)
+	if !isOrg && !d.Get("owner_configured").(bool) {
+		inIgnoreUsers = append(inIgnoreUsers, strings.ToLower(owner))
+	}
+
 	inTeams, err := getTeamCollaborators(teams)
 	if err != nil {
 		return diag.FromErr(err)
@@ -326,7 +372,7 @@ func resourceGithubRepositoryCollaboratorsUpdate(ctx context.Context, d *schema.
 		return diag.FromErr(err)
 	}
 
-	invitations, err := updateUserCollaboratorsAndInvites(ctx, client, owner, repoName, inUsers)
+	invitations, err := updateUserCollaboratorsAndInvites(ctx, client, owner, repoName, inUsers, inIgnoreUsers)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -362,14 +408,12 @@ func resourceGithubRepositoryCollaboratorsDelete(ctx context.Context, d *schema.
 
 	tflog.Debug(ctx, fmt.Sprintf("Removing all collaborators from repository %s.", repoName))
 
-	_, err = updateUserCollaboratorsAndInvites(ctx, client, owner, repoName, nil)
-	if err != nil {
+	if _, err := updateUserCollaboratorsAndInvites(ctx, client, owner, repoName, nil, nil); err != nil {
 		return diag.FromErr(err)
 	}
 
 	if isOrg {
-		err = updateTeamCollaborators(ctx, client, meta.id, owner, repoName, nil, inIgnoreTeams)
-		if err != nil {
+		if err := updateTeamCollaborators(ctx, client, meta.id, owner, repoName, nil, inIgnoreTeams); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -462,7 +506,7 @@ func getTeamCollaborators(col []any) (teamCollaborators, error) {
 
 		permission, ok := m["permission"].(string)
 		if !ok || len(permission) == 0 {
-			return nil, fmt.Errorf("team input must include 'permission'")
+			return nil, fmt.Errorf("team input must include permission")
 		}
 
 		collaborators[i] = teamCollaborator{
@@ -498,7 +542,7 @@ func getTeamIdentity(d any) (teamIdentity, error) {
 
 	o, ok := m["team_id"]
 	if !ok {
-		return teamIdentity{}, fmt.Errorf("team input must include 'team_id'")
+		return teamIdentity{}, fmt.Errorf("team input must include team_id")
 	}
 
 	id, ok := o.(string)
@@ -509,7 +553,7 @@ func getTeamIdentity(d any) (teamIdentity, error) {
 	return newLegacyTeamIdentity(id), nil
 }
 
-func listUserCollaborators(ctx context.Context, client *github.Client, owner, repoName string) (userCollaborators, error) {
+func listUserCollaborators(ctx context.Context, client *github.Client, owner, repoName string, ignoreUsers []string) (userCollaborators, error) {
 	col := make([]userCollaborator, 0)
 	tflog.Debug(ctx, "Listing user collaborators", map[string]any{
 		"owner":    owner,
@@ -531,6 +575,10 @@ func listUserCollaborators(ctx context.Context, client *github.Client, owner, re
 			}
 
 			for _, c := range collaborators {
+				if slices.Contains(ignoreUsers, strings.ToLower(c.GetLogin())) {
+					continue
+				}
+
 				col = append(col, userCollaborator{
 					userIdentity: userIdentity{
 						login: c.GetLogin(),
@@ -642,7 +690,7 @@ func listTeamCollaborators(ctx context.Context, client *github.Client, orgName, 
 	return col, nil
 }
 
-func updateUserCollaboratorsAndInvites(ctx context.Context, client *github.Client, owner, repoName string, inUsers userCollaborators) (userCollaborators, error) {
+func updateUserCollaboratorsAndInvites(ctx context.Context, client *github.Client, owner, repoName string, inUsers userCollaborators, ignoreUsers []string) (userCollaborators, error) {
 	lookup := make(map[string]userCollaborator)
 	seen := make(map[string]any)
 	remove := make([]string, 0)
@@ -659,7 +707,7 @@ func updateUserCollaboratorsAndInvites(ctx context.Context, client *github.Clien
 		"remove":   remove,
 	})
 
-	ghUsers, err := listUserCollaborators(ctx, client, owner, repoName)
+	ghUsers, err := listUserCollaborators(ctx, client, owner, repoName, ignoreUsers)
 	if err != nil {
 		return nil, err
 	}
@@ -717,6 +765,7 @@ func updateUserCollaboratorsAndInvites(ctx context.Context, client *github.Clien
 		if err != nil {
 			return nil, err
 		}
+
 		// AddCollaborator returns 204 No Content (inv == nil) when the invitee
 		// is an organization member gaining direct access without an
 		// invitation. In that case there is no invitation ID to record.

--- a/github/resource_github_repository_collaborators_migration.go
+++ b/github/resource_github_repository_collaborators_migration.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -88,7 +89,7 @@ func resourceGithubRepositoryCollaboratorsStateUpgradeV0(ctx context.Context, ra
 	client := meta.v3client
 	owner := meta.name
 
-	log.Printf("[DEBUG] GitHub Repository Collaborators Attributes before migration: %#v", rawState)
+	log.Printf("[DEBUG] GitHub Repository Collaborators Attributes before migration to v1: %#v", rawState)
 
 	repoName, ok := rawState["repository"].(string)
 	if !ok {
@@ -103,7 +104,141 @@ func resourceGithubRepositoryCollaboratorsStateUpgradeV0(ctx context.Context, ra
 	rawState["id"] = strconv.FormatInt(repo.GetID(), 10)
 	rawState["repository_id"] = int(repo.GetID())
 
-	log.Printf("[DEBUG] GitHub Repository Collaborators Attributes after migration: %#v", rawState)
+	log.Printf("[DEBUG] GitHub Repository Collaborators Attributes after migration to v1: %#v", rawState)
+
+	return rawState, nil
+}
+
+func resourceGithubRepositoryCollaboratorsV1() *schema.Resource {
+	return &schema.Resource{
+		SchemaVersion: 1,
+
+		Schema: map[string]*schema.Schema{
+			"repository": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the repository.",
+			},
+			"repository_id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "ID of the repository.",
+			},
+			"user": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Users to grant access to the repository.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"username": {
+							Type:             schema.TypeString,
+							Description:      "Login for the user to add to the repository as a collaborator.",
+							Required:         true,
+							DiffSuppressFunc: caseInsensitive(),
+						},
+						"permission": {
+							Type:        schema.TypeString,
+							Description: "Permission to grant to the user. Must be one of `pull`, `triage`, `push`, `maintain`, `admin` or the name of an existing [custom repository role](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-peoples-access-to-your-organization-with-roles/managing-custom-repository-roles-for-an-organization) within the organization. Must be `push` for personal repositories. Defaults to `push`.",
+							Optional:    true,
+							Default:     "push",
+						},
+					},
+				},
+			},
+			"team": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Teams to grant access to the repository.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"team_id": {
+							Type:        schema.TypeString,
+							Description: "ID or slug of the team to add to the repository as a collaborator.",
+							Required:    true,
+						},
+						"permission": {
+							Type:        schema.TypeString,
+							Description: "Permission to grant to the team. Must be one of `pull`, `triage`, `push`, `maintain`, `admin` or the name of an existing [custom repository role](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-peoples-access-to-your-organization-with-roles/managing-custom-repository-roles-for-an-organization) within the organization. Defaults to `push`.",
+							Optional:    true,
+							Default:     "push",
+						},
+					},
+				},
+			},
+			"invitation_ids": {
+				Type:        schema.TypeMap,
+				Description: "Map of usernames to invitation ID for users that haven't yet accepted their invitation to become a collaborator. This is only set on read, and is used internally to track pending invitations for users that aren't yet collaborators.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed: true,
+			},
+			"ignore_team": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Teams to ignore when managing repository collaborators.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"team_id": {
+							Type:        schema.TypeString,
+							Description: "ID or slug of the team to ignore.",
+							Required:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceGithubRepositoryCollaboratorsStateUpgradeV1(_ context.Context, rawState map[string]any, m any) (map[string]any, error) {
+	meta, _ := m.(*Owner)
+
+	log.Printf("[DEBUG] GitHub Repository Collaborators Attributes before migration to v2: %#v", rawState)
+
+	if meta.IsOrganization {
+		// If the repository belongs to an organization the owner cannot be a,
+		// collaborator, so owner_configured is always false.
+
+		rawState["owner_configured"] = false
+	} else {
+		// If the repository belongs to a user and we know the new value of user
+		// we can determine the value of owner_configured by checking if the owner
+		// is included in the list of users.
+
+		ownerConfigured := false
+		owner := strings.ToLower(meta.name)
+
+		if usersVal, ok := rawState["user"]; ok {
+			if users, ok := usersVal.([]any); ok {
+				for _, userVal := range users {
+					user, ok := userVal.(map[string]any)
+					if !ok {
+						continue
+					}
+
+					usernameVal, ok := user["username"]
+					if !ok {
+						continue
+					}
+
+					username, ok := usernameVal.(string)
+					if !ok {
+						continue
+					}
+
+					if strings.ToLower(username) == owner {
+						ownerConfigured = true
+						break
+					}
+				}
+			}
+		}
+
+		rawState["owner_configured"] = ownerConfigured
+	}
+
+	log.Printf("[DEBUG] GitHub Repository Collaborators Attributes after migration to v2: %#v", rawState)
 
 	return rawState, nil
 }

--- a/github/resource_github_repository_collaborators_migration.go
+++ b/github/resource_github_repository_collaborators_migration.go
@@ -207,7 +207,7 @@ func resourceGithubRepositoryCollaboratorsStateUpgradeV1(_ context.Context, rawS
 		// is included in the list of users.
 
 		ownerConfigured := false
-		owner := strings.ToLower(meta.name)
+		owner := meta.name
 
 		if usersVal, ok := rawState["user"]; ok {
 			if users, ok := usersVal.([]any); ok {
@@ -227,7 +227,7 @@ func resourceGithubRepositoryCollaboratorsStateUpgradeV1(_ context.Context, rawS
 						continue
 					}
 
-					if strings.ToLower(username) == owner {
+					if strings.EqualFold(username, owner) {
 						ownerConfigured = true
 						break
 					}

--- a/github/resource_github_repository_collaborators_migration_test.go
+++ b/github/resource_github_repository_collaborators_migration_test.go
@@ -1,5 +1,11 @@
 package github
 
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
 // TODO: Enable this test once we have a pattern to create a mock client for the test.
 // func Test_resourceGithubRepositoryCollaboratorsStateUpgradeV0(t *testing.T) {
 // 	t.Parallel()
@@ -38,3 +44,90 @@ package github
 // 		})
 // 	}
 // }
+
+func Test_resourceGithubRepositoryCollaboratorsStateUpgradeV1(t *testing.T) {
+	t.Parallel()
+
+	for _, d := range []struct {
+		testName string
+		meta     *Owner
+		rawState map[string]any
+		want     map[string]any
+	}{
+		{
+			testName: "organization_repository",
+			meta:     &Owner{name: "test", IsOrganization: true},
+			rawState: map[string]any{
+				"id":            "test-repo",
+				"repository":    "test-repo",
+				"repository_id": "123456",
+			},
+			want: map[string]any{
+				"id":               "test-repo",
+				"repository":       "test-repo",
+				"repository_id":    "123456",
+				"owner_configured": false,
+			},
+		},
+		{
+			testName: "personal_repository_owner_configured",
+			meta:     &Owner{name: "test", IsOrganization: false},
+			rawState: map[string]any{
+				"id":            "test-repo",
+				"repository":    "test-repo",
+				"repository_id": "123456",
+				"user": []any{
+					map[string]any{
+						"username": "test",
+					},
+				},
+			},
+			want: map[string]any{
+				"id":            "test-repo",
+				"repository":    "test-repo",
+				"repository_id": "123456",
+				"user": []any{
+					map[string]any{
+						"username": "test",
+					},
+				},
+				"owner_configured": true,
+			},
+		},
+		{
+			testName: "personal_repository_owner_not_configured",
+			meta:     &Owner{name: "test", IsOrganization: false},
+			rawState: map[string]any{
+				"id":            "test-repo",
+				"repository":    "test-repo",
+				"repository_id": "123456",
+				"user": []any{
+					map[string]any{
+						"username": "other-user",
+					},
+				},
+			},
+			want: map[string]any{
+				"id":            "test-repo",
+				"repository":    "test-repo",
+				"repository_id": "123456",
+				"user": []any{
+					map[string]any{
+						"username": "other-user",
+					},
+				},
+				"owner_configured": false,
+			},
+		},
+	} {
+		t.Run(d.testName, func(t *testing.T) {
+			t.Parallel()
+
+			got, _ := resourceGithubRepositoryCollaboratorsStateUpgradeV1(t.Context(), d.rawState, d.meta)
+
+			if diff := cmp.Diff(got, d.want); diff != "" {
+				t.Fatalf("got %+v, want %+v, diff %s", got, d.want, diff)
+			}
+		})
+	}
+}

--- a/github/resource_github_repository_collaborators_test.go
+++ b/github/resource_github_repository_collaborators_test.go
@@ -88,7 +88,7 @@ resource "github_repository_collaborators" "test" {
 					ImportState:             true,
 					ImportStateId:           repoName,
 					ImportStateVerify:       true,
-					ImportStateVerifyIgnore: []string{"user", "team", "invitation_ids"},
+					ImportStateVerifyIgnore: []string{"user", "team", "invitation_ids", "owner_configured"},
 				},
 			},
 		})
@@ -140,8 +140,7 @@ resource "github_repository_collaborators" "test" {
 
 		config := fmt.Sprintf(`
 resource "github_repository" "test" {
-	name       = "%s"
-	visibility = "private"
+	name = "%s"
 }
 
 resource "github_repository_collaborators" "test" {
@@ -159,6 +158,7 @@ resource "github_repository_collaborators" "test" {
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("user"), knownvalue.SetSizeExact(0)),
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("team"), knownvalue.SetSizeExact(0)),
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(0)),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("owner_configured"), knownvalue.Bool(false)),
 					},
 				},
 				{
@@ -176,8 +176,7 @@ resource "github_repository_collaborators" "test" {
 
 		config := fmt.Sprintf(`
 resource "github_repository" "test" {
-	name       = "%s"
-	visibility = "private"
+	name = "%s"
 }
 
 resource "github_repository_collaborators" "test" {
@@ -205,7 +204,13 @@ resource "github_repository_collaborators" "test" {
 						})),
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("team"), knownvalue.SetSizeExact(0)),
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(0)),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("owner_configured"), knownvalue.Bool(true)),
 					},
+				},
+				{
+					Config:             config,
+					PlanOnly:           true,
+					ExpectNonEmptyPlan: false,
 				},
 			},
 		})
@@ -348,7 +353,7 @@ resource "github_repository_collaborators" "test" {
 `, configPre)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnauthenticated(t) },
+			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{

--- a/github/resource_github_repository_collaborators_test.go
+++ b/github/resource_github_repository_collaborators_test.go
@@ -134,6 +134,83 @@ resource "github_repository_collaborators" "test" {
 		})
 	})
 
+	t.Run("personal_repo_ignores_owner_when_not_configured", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+
+		config := fmt.Sprintf(`
+resource "github_repository" "test" {
+	name       = "%s"
+	visibility = "private"
+}
+
+resource "github_repository_collaborators" "test" {
+	repository = github_repository.test.name
+}
+`, repoName)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessMode(t, individual) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("user"), knownvalue.SetSizeExact(0)),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("team"), knownvalue.SetSizeExact(0)),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(0)),
+					},
+				},
+				{
+					Config:             config,
+					PlanOnly:           true,
+					ExpectNonEmptyPlan: false,
+				},
+			},
+		})
+	})
+
+	t.Run("personal_repo_keeps_owner_when_configured", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+
+		config := fmt.Sprintf(`
+resource "github_repository" "test" {
+	name       = "%s"
+	visibility = "private"
+}
+
+resource "github_repository_collaborators" "test" {
+	repository = github_repository.test.name
+
+	user {
+		username   = "%s"
+		permission = "admin"
+	}
+}
+`, repoName, testAccConf.owner)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessMode(t, individual) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("user"), knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.MapExact(map[string]knownvalue.Check{
+								"username":   knownvalue.StringExact(testAccConf.owner),
+								"permission": knownvalue.StringExact("admin"),
+							}),
+						})),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("team"), knownvalue.SetSizeExact(0)),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(0)),
+					},
+				},
+			},
+		})
+	})
+
 	t.Run("update_teams", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)

--- a/templates/resources/repository_collaborators.md.tmpl
+++ b/templates/resources/repository_collaborators.md.tmpl
@@ -25,9 +25,7 @@ Teams will be added to the repository on apply, and removed if removed from the 
 
 ## Personal Repositories
 
-For personal repositories, collaborators can only be granted [write](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/repository-access-and-collaboration/permission-levels-for-a-personal-account-repository#collaborator-access-for-a-repository-owned-by-a-personal-account) permission.
-
-!> If the repository owner is not added as a collaborator with admin access, the provider will churn this resource on every plan/apply. To prevent this, ensure that the repository owner is included in the set of user collaborators.
+For personal repositories, non-owner collaborators can only be granted [write](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/repository-access-and-collaboration/permission-levels-for-a-personal-account-repository#collaborator-access-for-a-repository-owned-by-a-personal-account) permission. Owners will be ignored unless they are explicitly added, in which case they must be granted `admin` permission.
 
 ## Users
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #3434

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- The `github_repository_collaborators` resource drifts when the rpo is personally and the owner hasn't been configured

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The `github_repository_collaborators` resource ignores the owner if no configured
- Added `owner_configured` computed attribute to `github_repository_collaborators` resource

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
