### PR TITLE
refactor: migrate resource_github_actions_environment_variable to tflog

### DIFF
--- a/github/resource_github_actions_environment_variable.go
+++ b/github/resource_github_actions_environment_variable.go
@@ -3,11 +3,11 @@ package github
 import (
 	"context"
 	"errors"
-	"log"
 	"net/http"
 	"net/url"
 
 	"github.com/google/go-github/v88/github"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -140,7 +140,9 @@ func resourceGithubActionsEnvironmentVariableRead(ctx context.Context, d *schema
 		var ghErr *github.ErrorResponse
 		if errors.As(err, &ghErr) {
 			if ghErr.Response.StatusCode == http.StatusNotFound {
-				log.Printf("[INFO] Removing actions variable %s from state because it no longer exists in GitHub", d.Id())
+				tflog.Info(ctx, "Removing actions variable from state because it no longer exists in GitHub", map[string]any{
+					"variable_id": d.Id(),
+				})
 				d.SetId("")
 				return nil
 			}


### PR DESCRIPTION
Replace Go standard `log` package with HashiCorp structured `tflog` for consistent logging across the provider.

Changes:
- Replace `log` import with tflog import
- Convert `log.Printf` to `tflog.Info` with structured fields

Resolves #3070 (partial — this PR covers one file)

This is a resubmission of #3325 (was closed due to inactivity / capacity).

---

### Before the change?

`resource_github_actions_environment_variable.go` uses Go's standard `log.Printf` for logging, which produces unstructured output inconsistent with the rest of the provider.

### After the change?

Logging uses HashiCorp's `tflog.Info` with structured key-value fields (`variable_id`), consistent with the pattern established in other migrated files like `resource_github_membership.go`.

### Pull request checklist

- [x] Schema migrations have been created if needed
- [x] Acceptance tests have been run (no behavioral changes — logging only)
- [x] Documentation has been updated if needed (N/A — internal refactor)
