### PR TITLE
refactor(runner_group): `selected_workflows` set

### DIFF
--- a/docs/resources/actions_runner_group.md
+++ b/docs/resources/actions_runner_group.md
@@ -29,7 +29,7 @@ The following arguments are supported:
 - `name` - (Required) Name of the runner group
 - `restricted_to_workflows` - (Optional) If true, the runner group will be restricted to running only the workflows specified in the selected_workflows array. Defaults to false.
 - `selected_repository_ids` - (Optional) IDs of the repositories which should be added to the runner group
-- `selected_workflows` - (Optional) List of workflows the runner group should be allowed to run. This setting will be ignored unless restricted_to_workflows is set to true.
+- `selected_workflows` - (Optional) Set of workflows the runner group should be allowed to run. The order of items is not significant. This setting will be ignored unless restricted_to_workflows is set to true.
 - `visibility` - (Optional) Visibility of a runner group. Whether the runner group can include `all`, `selected`, or `private` repositories. A value of `private` is not currently supported due to limitations in the GitHub API.
 - `allows_public_repositories` - (Optional) Whether public repositories can be added to the runner group. Defaults to false.
 
@@ -44,7 +44,7 @@ The following arguments are supported:
 - `selected_repositories_url` - GitHub API URL for the runner group's repositories
 - `visibility` - The visibility of the runner group
 - `restricted_to_workflows` - If true, the runner group will be restricted to running only the workflows specified in the selected_workflows array. Defaults to false.
-- `selected_workflows` - List of workflows the runner group should be allowed to run. This setting will be ignored unless restricted_to_workflows is set to true.
+- `selected_workflows` - Set of workflows the runner group should be allowed to run. The order of items is not significant. This setting will be ignored unless restricted_to_workflows is set to true.
 
 ## Import
 

--- a/docs/resources/enterprise_actions_runner_group.md
+++ b/docs/resources/enterprise_actions_runner_group.md
@@ -43,7 +43,7 @@ The following arguments are supported:
 - `selected_organization_ids` - (Optional) IDs of the organizations which should be added to the runner group
 - `allows_public_repositories` - (Optional) Whether public repositories can be added to the runner group. Defaults to false.
 - `restricted_to_workflows` - (Optional) If true, the runner group will be restricted to running only the workflows specified in the selected_workflows array. Defaults to false.
-- `selected_workflows` - (Optional) List of workflows the runner group should be allowed to run. This setting will be ignored unless restricted_to_workflows is set to true.
+- `selected_workflows` - (Optional) Set of workflows the runner group should be allowed to run. The order of items is not significant. This setting will be ignored unless restricted_to_workflows is set to true.
 
 ## Attributes Reference
 

--- a/github/resource_github_actions_runner_group.go
+++ b/github/resource_github_actions_runner_group.go
@@ -23,6 +23,15 @@ func resourceGithubActionsRunnerGroup() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceGithubActionsRunnerGroupV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceGithubActionsRunnerGroupStateUpgradeV0,
+				Version: 0,
+			},
+		},
+
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:        schema.TypeString,
@@ -87,7 +96,7 @@ func resourceGithubActionsRunnerGroup() *schema.Resource {
 				Description: "If 'true', the runner group will be restricted to running only the workflows specified in the 'selected_workflows' array. Defaults to 'false'.",
 			},
 			"selected_workflows": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,
 				Description: "List of workflows the runner group should be allowed to run. This setting will be ignored unless restricted_to_workflows is set to 'true'.",
@@ -112,7 +121,7 @@ func resourceGithubActionsRunnerGroupCreate(d *schema.ResourceData, meta any) er
 
 	selectedWorkflows := []string{}
 	if workflows, ok := d.GetOk("selected_workflows"); ok {
-		for _, workflow := range workflows.([]any) {
+		for _, workflow := range workflows.(*schema.Set).List() {
 			selectedWorkflows = append(selectedWorkflows, workflow.(string))
 		}
 	}
@@ -316,7 +325,7 @@ func resourceGithubActionsRunnerGroupUpdate(d *schema.ResourceData, meta any) er
 	selectedWorkflows := []string{}
 	allowsPublicRepositories := d.Get("allows_public_repositories").(bool)
 	if workflows, ok := d.GetOk("selected_workflows"); ok {
-		for _, workflow := range workflows.([]any) {
+		for _, workflow := range workflows.(*schema.Set).List() {
 			selectedWorkflows = append(selectedWorkflows, workflow.(string))
 		}
 	}

--- a/github/resource_github_actions_runner_group_migration.go
+++ b/github/resource_github_actions_runner_group_migration.go
@@ -1,0 +1,98 @@
+package github
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceGithubActionsRunnerGroupV0() *schema.Resource {
+	return &schema.Resource{
+		SchemaVersion: 0,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the runner group.",
+			},
+			"allows_public_repositories": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Whether public repositories can be added to the runner group.",
+			},
+			"default": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether this is the default runner group.",
+			},
+			"etag": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "An etag representing the runner group object",
+			},
+			"inherited": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the runner group is inherited from the enterprise level",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the runner group.",
+			},
+			"runners_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The GitHub API URL for the runner group's runners.",
+			},
+			"selected_repository_ids": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeInt,
+				},
+				Set:         schema.HashInt,
+				Optional:    true,
+				Description: "List of repository IDs that can access the runner group.",
+			},
+			"selected_repositories_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "GitHub API URL for the runner group's repositories.",
+			},
+			"visibility": {
+				Type:             schema.TypeString,
+				Required:         true,
+				Description:      "The visibility of the runner group.",
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"all", "selected", "private"}, false)),
+			},
+			"restricted_to_workflows": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "If 'true', the runner group will be restricted to running only the workflows specified in the 'selected_workflows' array. Defaults to 'false'.",
+			},
+			"selected_workflows": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Description: "List of workflows the runner group should be allowed to run. This setting will be ignored unless restricted_to_workflows is set to 'true'.",
+			},
+		},
+	}
+}
+
+func resourceGithubActionsRunnerGroupStateUpgradeV0(_ context.Context, rawState map[string]any, _ any) (map[string]any, error) {
+	log.Printf("[DEBUG] GitHub Actions Runner Group Attributes before migration: %#v", rawState)
+
+	// No transformation needed. The SDK re-encodes selected_workflows from
+	// TypeList (index-based keys) to TypeSet (hash-based keys) automatically
+	// when it persists the state with the new schema version.
+
+	log.Printf("[DEBUG] GitHub Actions Runner Group Attributes after migration: %#v", rawState)
+
+	return rawState, nil
+}

--- a/github/resource_github_actions_runner_group_test.go
+++ b/github/resource_github_actions_runner_group_test.go
@@ -68,16 +68,11 @@ func TestAccGithubActionsRunnerGroup(t *testing.T) {
 				githubRepository := state.RootModule().Resources["github_repository.test"].Primary
 				fullName := githubRepository.Attributes["full_name"]
 
-				runnerGroup := state.RootModule().Resources["github_actions_runner_group.test"].Primary
-				workflowActual := runnerGroup.Attributes["selected_workflows.0"]
-
 				workflowExpected := fmt.Sprintf("%s/.github/workflows/test.yml@refs/heads/main", fullName)
 
-				if workflowActual != workflowExpected {
-					return fmt.Errorf("actual selected workflows %s not the same as expected selected workflows %s",
-						workflowActual, workflowExpected)
-				}
-				return nil
+				return resource.TestCheckTypeSetElemAttr(
+					"github_actions_runner_group.test", "selected_workflows.*", workflowExpected,
+				)(state)
 			},
 			resource.TestCheckResourceAttr(
 				"github_actions_runner_group.test", "allows_public_repositories",

--- a/github/resource_github_enterprise_actions_runner_group.go
+++ b/github/resource_github_enterprise_actions_runner_group.go
@@ -24,6 +24,15 @@ func resourceGithubActionsEnterpriseRunnerGroup() *schema.Resource {
 			State: resourceGithubActionsEnterpriseRunnerGroupImport,
 		},
 
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceGithubActionsEnterpriseRunnerGroupV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceGithubActionsEnterpriseRunnerGroupStateUpgradeV0,
+				Version: 0,
+			},
+		},
+
 		Schema: map[string]*schema.Schema{
 			"enterprise_slug": {
 				Type:        schema.TypeString,
@@ -69,7 +78,7 @@ func resourceGithubActionsEnterpriseRunnerGroup() *schema.Resource {
 				Description: "If 'true', the runner group will be restricted to running only the workflows specified in the 'selected_workflows' array. Defaults to 'false'.",
 			},
 			"selected_workflows": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,
 				Description: "List of workflows the runner group should be allowed to run. This setting will be ignored unless restricted_to_workflows is set to 'true'.",
@@ -104,7 +113,7 @@ func resourceGithubActionsEnterpriseRunnerGroupCreate(d *schema.ResourceData, me
 
 	selectedWorkflows := []string{}
 	if workflows, ok := d.GetOk("selected_workflows"); ok {
-		for _, workflow := range workflows.([]any) {
+		for _, workflow := range workflows.(*schema.Set).List() {
 			selectedWorkflows = append(selectedWorkflows, workflow.(string))
 		}
 	}
@@ -291,7 +300,7 @@ func resourceGithubActionsEnterpriseRunnerGroupUpdate(d *schema.ResourceData, me
 	selectedWorkflows := []string{}
 	allowsPublicRepositories := d.Get("allows_public_repositories").(bool)
 	if workflows, ok := d.GetOk("selected_workflows"); ok {
-		for _, workflow := range workflows.([]any) {
+		for _, workflow := range workflows.(*schema.Set).List() {
 			selectedWorkflows = append(selectedWorkflows, workflow.(string))
 		}
 	}

--- a/github/resource_github_enterprise_actions_runner_group_migration.go
+++ b/github/resource_github_enterprise_actions_runner_group_migration.go
@@ -1,0 +1,93 @@
+package github
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceGithubActionsEnterpriseRunnerGroupV0() *schema.Resource {
+	return &schema.Resource{
+		SchemaVersion: 0,
+
+		Schema: map[string]*schema.Schema{
+			"enterprise_slug": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The slug of the enterprise.",
+			},
+			"allows_public_repositories": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Whether public repositories can be added to the runner group.",
+			},
+			"default": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether this is the default runner group.",
+			},
+			"etag": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "An etag representing the runner group object",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the runner group.",
+			},
+			"runners_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The GitHub API URL for the runner group's runners.",
+			},
+			"visibility": {
+				Type:             schema.TypeString,
+				Required:         true,
+				Description:      "The visibility of the runner group.",
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"all", "selected"}, false)),
+			},
+			"restricted_to_workflows": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "If 'true', the runner group will be restricted to running only the workflows specified in the 'selected_workflows' array. Defaults to 'false'.",
+			},
+			"selected_workflows": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Description: "List of workflows the runner group should be allowed to run. This setting will be ignored unless restricted_to_workflows is set to 'true'.",
+			},
+			"selected_organization_ids": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeInt,
+				},
+				Set:         schema.HashInt,
+				Optional:    true,
+				Description: "List of organization IDs that can access the runner group.",
+			},
+			"selected_organizations_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "GitHub API URL for the runner group's organizations.",
+			},
+		},
+	}
+}
+
+func resourceGithubActionsEnterpriseRunnerGroupStateUpgradeV0(_ context.Context, rawState map[string]any, _ any) (map[string]any, error) {
+	log.Printf("[DEBUG] GitHub Enterprise Actions Runner Group Attributes before migration: %#v", rawState)
+
+	// No transformation needed. The SDK re-encodes selected_workflows from
+	// TypeList (index-based keys) to TypeSet (hash-based keys) automatically
+	// when it persists the state with the new schema version.
+
+	log.Printf("[DEBUG] GitHub Enterprise Actions Runner Group Attributes after migration: %#v", rawState)
+
+	return rawState, nil
+}


### PR DESCRIPTION
Change `selected_workflows` from `TypeList` to `TypeSet` in both `github_actions_runner_group` and
`github_enterprise_actions_runner_group` resources. A `TypeList` is order-sensitive, causing Terraform to detect spurious drift when the GitHub API returns workflows in a different order than specified in configuration. A `TypeSet` compares elements regardless of order, eliminating the persistent plan diff.

Fix https://github.com/integrations/terraform-provider-github/issues/3478.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves https://github.com/integrations/terraform-provider-github/issues/3478.

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- Consistent drift shown for `selected_workflows`.
- `selected_workflows` in `github_actions_runner_group` and
  `github_enterprise_actions_runner_group` is defined as a `TypeList`,
  which is order-sensitive. When the GitHub API returns workflows in a
  different order than the Terraform configuration specifies, Terraform
  detects a spurious diff and plans an unnecessary update on every run.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- No changes should be shown as the set is identical, even though the list might be in different order.
- `selected_workflows` is now a `TypeSet`, which compares elements
  regardless of order. The persistent plan drift is eliminated.
- A `SchemaVersion` bump to `1` and `StateUpgraders` entry ensures
  existing state is migrated automatically on the next
  `terraform plan` or `terraform apply`.


### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [x] Yes
- [ ] No

*What changed:** The `selected_workflows` attribute type changed from
`TypeList` to `TypeSet`. Per the [breaking changes policy][breaking],
this qualifies as "changing the type of a response model field or
parameter."

**Impact:** Users who reference individual `selected_workflows` elements
by index will need to update their configurations:

```hcl
# Before, will no longer work when this PR is merged into default branch.
output "first_workflow" {
  value = github_actions_runner_group.example.selected_workflows[0]
}

# After this PR is merged into default branch.
output "first_workflow" {
  value = tolist(github_actions_runner_group.example.selected_workflows)[0]
}
```

**Migration steps:**
1. Upgrade the provider to the new version.
2. Run terraform plan. The state upgrader migrates existing state automatically; no manual intervention is required.
3. If your configuration references `selected_workflows` by index, wrap the attribute in `tolist(...)` as shown above.
4. Confirm no unexpected diffs appear in the plan output.

----
