### PR TITLE
chore: Add new client rate limit logging

### DIFF
--- a/internal/ghclient/transport.go
+++ b/internal/ghclient/transport.go
@@ -7,7 +7,10 @@ import (
 
 	ghct "github.com/bored-engineer/github-conditional-http-transport"
 	ratelimit "github.com/gofri/go-github-ratelimit/v2/github_ratelimit"
+	ratelimitp "github.com/gofri/go-github-ratelimit/v2/github_ratelimit/github_primary_ratelimit"
+	ratelimits "github.com/gofri/go-github-ratelimit/v2/github_ratelimit/github_secondary_ratelimit"
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"golang.org/x/oauth2"
 )
@@ -65,7 +68,17 @@ func newTransport(tokenSource oauth2.TokenSource, opts Options) (http.RoundTripp
 	}
 
 	// Wrap with rate limit transport
-	tr = ratelimit.New(tr)
+	tr = ratelimit.New(tr, ratelimitp.WithLimitDetectedCallback(primaryRateLimitCallback), ratelimits.WithLimitDetectedCallback(secondaryRateLimitCallback))
 
 	return tr, nil
+}
+
+// primaryRateLimitCallback is a callback function that is called when the GitHub API primary rate limit is detected. It logs a warning message with the category of the rate limit and the reset time.
+func primaryRateLimitCallback(cb *ratelimitp.CallbackContext) {
+	tflog.Warn(cb.Request.Context(), "GitHub API primary rate limit detected.", map[string]any{"category": cb.Category, "reset_time": cb.ResetTime})
+}
+
+// secondaryRateLimitCallback is a callback function that is called when the GitHub API secondary rate limit is detected. It logs a warning message with the reset time.
+func secondaryRateLimitCallback(cb *ratelimits.CallbackContext) {
+	tflog.Warn(cb.Request.Context(), "GitHub API secondary rate limit detected.", map[string]any{"reset_time": cb.ResetTime})
 }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

-

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The new client writes warning logs when a rate limit is detected

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
