### PR TITLE
fix: Correctly parse acceptance test url

### DIFF
--- a/github/acc_test.go
+++ b/github/acc_test.go
@@ -36,6 +36,7 @@ type testAccConfig struct {
 	// Target configuration
 	legacyClient bool
 	baseURL      *url.URL
+	isGHES       bool
 
 	// Auth configuration
 	authMode          testMode
@@ -109,7 +110,7 @@ func TestMain(m *testing.M) {
 		u = DotComAPIURL
 	}
 
-	baseURL, _, err := getBaseURL(u)
+	baseURL, isGHES, err := getBaseURL(u)
 	if err != nil {
 		fmt.Printf("Error parsing base URL: %s\n", err)
 		os.Exit(1)
@@ -118,6 +119,7 @@ func TestMain(m *testing.M) {
 	config := testAccConfig{
 		legacyClient:                      os.Getenv("GITHUB_LEGACY_CLIENT") != "false",
 		baseURL:                           baseURL,
+		isGHES:                            isGHES,
 		authMode:                          authMode,
 		testPublicRepository:              "terraform-provider-github",
 		testPublicRepositoryOwner:         "integrations",
@@ -210,7 +212,12 @@ func getTestAppToken() (string, error) {
 		return "", fmt.Errorf("app auth not configured")
 	}
 
-	appToken, err := GenerateOAuthTokenFromApp(testAccConf.baseURL, testAccConf.appID, testAccConf.appInstallationID, testAccConf.appPEM)
+	restAPIPath := ""
+	if testAccConf.isGHES {
+		restAPIPath = GHESRESTAPIPath
+	}
+
+	appToken, err := GenerateOAuthTokenFromApp(testAccConf.baseURL.JoinPath(restAPIPath), testAccConf.appID, testAccConf.appInstallationID, testAccConf.appPEM)
 	if err != nil {
 		return "", err
 	}
@@ -228,10 +235,16 @@ func getTestToken() (string, error) {
 
 func getTestMeta() (*Owner, error) {
 	config := &Config{
+		RESTAPIPath:    "",
 		GraphQLAPIPath: "graphql",
 		LegacyClient:   testAccConf.legacyClient,
 		BaseURL:        testAccConf.baseURL,
 		Owner:          testAccConf.owner,
+	}
+
+	if testAccConf.isGHES {
+		config.RESTAPIPath = GHESRESTAPIPath
+		config.GraphQLAPIPath = GHESGraphQLAPIPath
 	}
 
 	if config.LegacyClient || testAccConf.appID == "" {

--- a/github/acc_test.go
+++ b/github/acc_test.go
@@ -109,7 +109,7 @@ func TestMain(m *testing.M) {
 		u = DotComAPIURL
 	}
 
-	baseURL, err := url.Parse(u)
+	baseURL, _, err := getBaseURL(u)
 	if err != nil {
 		fmt.Printf("Error parsing base URL: %s\n", err)
 		os.Exit(1)


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #3256
Closes #3258

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- Acceptance test URL didn't behave the same as the provider config

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Acceptance test URl behaves the same as the provider config

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
