### PR TITLE
feat: Add explicit concurrency control for new client

### DIFF
--- a/github/acc_test.go
+++ b/github/acc_test.go
@@ -94,7 +94,7 @@ var testAccConf *testAccConfig
 var providerFactories = map[string]func() (*schema.Provider, error){
 	//nolint:unparam
 	"github": func() (*schema.Provider, error) {
-		return NewProvider()(), nil
+		return NewProvider("acctest", "none")(), nil
 	},
 }
 
@@ -246,7 +246,7 @@ func getTestMeta() (*Owner, error) {
 		config.AppPEM = []byte(testAccConf.appPEM)
 	}
 
-	return configureProviderMeta(context.Background(), config)
+	return configureProviderMeta(context.Background(), "test", config)
 }
 
 func configureSweepers() {

--- a/github/config.go
+++ b/github/config.go
@@ -20,7 +20,7 @@ type Config struct {
 	AppInstallationID *string
 	AppPEM            []byte
 	BaseURL           *url.URL
-	CachePath         *string
+	CachePath         string
 	GraphQLAPIPath    string
 	Insecure          bool
 	LegacyClient      bool

--- a/github/config.go
+++ b/github/config.go
@@ -143,7 +143,7 @@ func (c *Config) ConfigureOwner(owner *Owner) (*Owner, error) {
 // https://godoc.org/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#ConfigureFunc
 // Deprecated: Use [configureProviderMeta] instead.
 func (c *Config) Meta() (any, error) {
-	return configureProviderMeta(context.Background(), c)
+	return configureProviderMeta(context.Background(), "", c)
 }
 
 type previewHeaderInjectorTransport struct {

--- a/github/provider.go
+++ b/github/provider.go
@@ -498,7 +498,7 @@ func configureProvider() func(context.Context, *schema.ResourceData) (any, diag.
 		if v, ok := d.GetOk("cache_path"); ok {
 			if s, ok := v.(string); ok && s != "" {
 				tflog.Debug(ctx, "Using cache path from provider configuration.", map[string]any{"cache_path": s})
-				config.CachePath = &s
+				config.CachePath = s
 			}
 		}
 
@@ -538,8 +538,8 @@ func configureProviderMeta(ctx context.Context, c *Config) (*Owner, error) {
 		owner.v4client = v4client
 	} else {
 		options := ghclient.Options{
-			RESTAPIURL:   new(c.BaseURL.JoinPath(c.RESTAPIPath).String()),
-			GraphQLURL:   new(c.BaseURL.JoinPath(c.GraphQLAPIPath).String()),
+			RESTAPIURL:   c.BaseURL.JoinPath(c.RESTAPIPath).String(),
+			GraphQLURL:   c.BaseURL.JoinPath(c.GraphQLAPIPath).String(),
 			CachePath:    c.CachePath,
 			RetryMax:     c.MaxRetries,
 			RetryWaitMin: c.RetryDelay,

--- a/github/provider.go
+++ b/github/provider.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"time"
 
@@ -18,12 +19,17 @@ import (
 	"github.com/integrations/terraform-provider-github/v6/internal/ghclient"
 )
 
+const (
+	providerName = "terraform-provider-github"
+	providerURL  = "https://github.com/integrations/terraform-provider-github"
+)
+
 func init() {
 	schema.DescriptionKind = schema.StringMarkdown
 }
 
 // NewProvider returns a function that returns the schema.Provider for this provider.
-func NewProvider() func() *schema.Provider {
+func NewProvider(version, commit string) func() *schema.Provider {
 	return func() *schema.Provider {
 		return &schema.Provider{
 			Schema: map[string]*schema.Schema{
@@ -320,14 +326,16 @@ func NewProvider() func() *schema.Provider {
 				"github_repository_environment_deployment_policies":                     dataSourceGithubRepositoryEnvironmentDeploymentPolicies(),
 			},
 
-			ConfigureContextFunc: configureProvider(),
+			ConfigureContextFunc: configureProvider(version, commit),
 		}
 	}
 }
 
 // configureProvider initializes the provider meta parameter with the necessary clients and owner information based on the provided configuration. It returns the initialized meta parameter or an error if the configuration is invalid or if there are issues initializing the clients.
-func configureProvider() func(context.Context, *schema.ResourceData) (any, diag.Diagnostics) {
+func configureProvider(version, commit string) func(context.Context, *schema.ResourceData) (any, diag.Diagnostics) {
 	return func(ctx context.Context, d *schema.ResourceData) (any, diag.Diagnostics) {
+		tflog.Debug(ctx, "Configuring provider.", map[string]any{"name": providerName, "url": providerURL, "version": version, "commit": commit})
+
 		baseURL, err := url.Parse(DotComAPIURL)
 		if err != nil {
 			return nil, diag.FromErr(err)
@@ -502,7 +510,7 @@ func configureProvider() func(context.Context, *schema.ResourceData) (any, diag.
 			}
 		}
 
-		meta, err := configureProviderMeta(ctx, config)
+		meta, err := configureProviderMeta(ctx, version, config)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}
@@ -512,7 +520,7 @@ func configureProvider() func(context.Context, *schema.ResourceData) (any, diag.
 }
 
 // configureProviderMeta initializes the provider metadata, including setting up the GitHub API clients based on the provided configuration. It returns the initialized metadata or an error if the configuration is invalid or if there are issues initializing the clients.
-func configureProviderMeta(ctx context.Context, c *Config) (*Owner, error) {
+func configureProviderMeta(ctx context.Context, version string, c *Config) (*Owner, error) {
 	owner := &Owner{
 		name: c.Owner,
 	}
@@ -540,6 +548,7 @@ func configureProviderMeta(ctx context.Context, c *Config) (*Owner, error) {
 		options := ghclient.Options{
 			RESTAPIURL:   c.BaseURL.JoinPath(c.RESTAPIPath).String(),
 			GraphQLURL:   c.BaseURL.JoinPath(c.GraphQLAPIPath).String(),
+			UserAgent:    fmt.Sprintf("%s/%s (+%s; go/%s; os/%s; arch/%s)", providerName, version, providerURL, runtime.Version(), runtime.GOOS, runtime.GOARCH),
 			CachePath:    c.CachePath,
 			RetryMax:     c.MaxRetries,
 			RetryWaitMin: c.RetryDelay,

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestProvider(t *testing.T) {
 	t.Run("validate", func(t *testing.T) {
-		if err := NewProvider()().InternalValidate(); err != nil {
+		if err := NewProvider("test", "none")().InternalValidate(); err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	})
@@ -38,7 +38,7 @@ func Test_configureProviderMeta(t *testing.T) {
 					LegacyClient: tt.legacyClient,
 				}
 
-				meta, err := configureProviderMeta(t.Context(), config)
+				meta, err := configureProviderMeta(t.Context(), "test", config)
 				if err != nil {
 					t.Fatalf("failed to return meta without error: %s", err.Error())
 				}
@@ -61,7 +61,7 @@ func Test_configureProviderMeta(t *testing.T) {
 					LegacyClient:   tt.legacyClient,
 				}
 
-				meta, err := configureProviderMeta(t.Context(), config)
+				meta, err := configureProviderMeta(t.Context(), "test", config)
 				if err != nil {
 					t.Fatalf("failed to return meta without error: %s", err.Error())
 				}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/shurcooL/githubv4 v0.0.0-20260209031235-2402fdf4a9ed
 	golang.org/x/crypto v0.52.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.20.0
 )
 
 require (
@@ -65,7 +66,6 @@ require (
 	go.etcd.io/bbolt v1.4.3 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.54.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect

--- a/internal/ghclient/anonymous.go
+++ b/internal/ghclient/anonymous.go
@@ -2,9 +2,12 @@ package ghclient
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	"github.com/google/go-github/v88/github"
 	"github.com/shurcooL/githubv4"
+	"golang.org/x/sync/semaphore"
 )
 
 // anonymousSource is a concrete implementation of a [Source] that creates GitHub clients without authentication.
@@ -14,15 +17,29 @@ type anonymousSource struct {
 }
 
 // NewAnonymousSource creates a new anonymousSource that provides an unauthenticated GitHub client. This client will have limited access to public resources and will be subject to stricter rate limits compared to authenticated clients.
-func NewAnonymousSource(options Options) (*anonymousSource, error) {
-	options.cacheRef = new("anonymous-rest")
-	client, err := NewAnonymousRESTClient(options)
+func NewAnonymousSource(opts Options) (*anonymousSource, error) {
+	if opts.CachePath == "" {
+		s, err := os.MkdirTemp("", "*")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create temporary cache directory: %w", err)
+		}
+		opts.CachePath = s
+	}
+
+	opts.sema = semaphore.NewWeighted(maxConcurrentRequests)
+
+	opts.maxIdleConns = maxIdleConnsREST
+	opts.idleConnTimeout = idleConnTimeoutREST
+	opts.cacheRef = "anonymous-rest"
+	client, err := NewAnonymousRESTClient(opts)
 	if err != nil {
 		return nil, err
 	}
 
-	options.cacheRef = new("anonymous-graphql")
-	graphQLClient, err := NewAnonymousGraphQLClient(options)
+	opts.maxIdleConns = maxIdleConnsGraphQL
+	opts.idleConnTimeout = idleConnTimeoutGraphQL
+	opts.cacheRef = "anonymous-graphql"
+	graphQLClient, err := NewAnonymousGraphQLClient(opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ghclient/anonymous_test.go
+++ b/internal/ghclient/anonymous_test.go
@@ -7,7 +7,7 @@ import (
 func TestNewAnonymousSource(t *testing.T) {
 	t.Parallel()
 
-	source, err := NewAnonymousSource(Options{})
+	source, err := NewAnonymousSource(testOptions(t))
 	if err != nil {
 		t.Fatalf("failed to create anonymous source: %v", err)
 	}
@@ -23,7 +23,7 @@ func Test_anonymousSource(t *testing.T) {
 	t.Run("RESTClient", func(t *testing.T) {
 		t.Parallel()
 
-		source, err := NewAnonymousSource(Options{})
+		source, err := NewAnonymousSource(testOptions(t))
 		if err != nil {
 			t.Fatalf("failed to create anonymous source: %v", err)
 		}
@@ -41,7 +41,7 @@ func Test_anonymousSource(t *testing.T) {
 	t.Run("OwnerRESTClient", func(t *testing.T) {
 		t.Parallel()
 
-		source, err := NewAnonymousSource(Options{})
+		source, err := NewAnonymousSource(testOptions(t))
 		if err != nil {
 			t.Fatalf("failed to create anonymous source: %v", err)
 		}
@@ -64,7 +64,7 @@ func Test_anonymousSource(t *testing.T) {
 	t.Run("GraphQLClient", func(t *testing.T) {
 		t.Parallel()
 
-		source, err := NewAnonymousSource(Options{})
+		source, err := NewAnonymousSource(testOptions(t))
 		if err != nil {
 			t.Fatalf("failed to create anonymous source: %v", err)
 		}
@@ -82,7 +82,7 @@ func Test_anonymousSource(t *testing.T) {
 	t.Run("OwnerGraphQLClient", func(t *testing.T) {
 		t.Parallel()
 
-		source, err := NewAnonymousSource(Options{})
+		source, err := NewAnonymousSource(testOptions(t))
 		if err != nil {
 			t.Fatalf("failed to create anonymous source: %v", err)
 		}

--- a/internal/ghclient/anonymous_test.go
+++ b/internal/ghclient/anonymous_test.go
@@ -1,104 +1,105 @@
 package ghclient
 
 import (
+	"os"
 	"testing"
 )
 
 func TestNewAnonymousSource(t *testing.T) {
 	t.Parallel()
 
-	source, err := NewAnonymousSource(testOptions(t))
-	if err != nil {
-		t.Fatalf("failed to create anonymous source: %v", err)
-	}
+	cacheBasePath := mustMkdirTemp(t, "", "*")
+	t.Cleanup(func() {
+		_ = os.RemoveAll(cacheBasePath)
+	})
 
-	if source == nil {
-		t.Fatal("expected anonymous source to be non-nil")
+	for _, tt := range []struct {
+		name string
+		opts Options
+	}{
+		{
+			name: "default",
+			opts: Options{
+				RESTAPIURL: "https://api.github.com/",
+				GraphQLURL: "https://api.github.com/graphql",
+			},
+		},
+		{
+			name: "with_cache_path",
+			opts: Options{
+				RESTAPIURL: "https://api.github.com/",
+				GraphQLURL: "https://api.github.com/graphql",
+				CachePath:  mustMkdirTemp(t, cacheBasePath, "*"),
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			source, err := NewAnonymousSource(tt.opts)
+			if err != nil {
+				t.Fatalf("failed to create anonymous source: %v", err)
+			}
+
+			if source == nil {
+				t.Fatal("expected anonymous source to be non-nil")
+			}
+		})
 	}
 }
 
 func Test_anonymousSource(t *testing.T) {
 	t.Parallel()
 
-	t.Run("RESTClient", func(t *testing.T) {
-		t.Parallel()
-
-		source, err := NewAnonymousSource(testOptions(t))
-		if err != nil {
-			t.Fatalf("failed to create anonymous source: %v", err)
-		}
-
-		client, err := source.RESTClient()
-		if err != nil {
-			t.Fatalf("failed to get rest client: %v", err)
-		}
-
-		if client == nil {
-			t.Fatal("expected rest client to be non-nil")
-		}
+	cacheBasePath := mustMkdirTemp(t, "", "*")
+	t.Cleanup(func() {
+		_ = os.RemoveAll(cacheBasePath)
 	})
 
-	t.Run("OwnerRESTClient", func(t *testing.T) {
-		t.Parallel()
+	opts := Options{
+		RESTAPIURL: "https://api.github.com/",
+		GraphQLURL: "https://api.github.com/graphql",
+		CachePath:  mustMkdirTemp(t, cacheBasePath, "*"),
+	}
 
-		source, err := NewAnonymousSource(testOptions(t))
-		if err != nil {
-			t.Fatalf("failed to create anonymous source: %v", err)
-		}
+	source, err := NewAnonymousSource(opts)
+	if err != nil {
+		t.Fatalf("failed to create anonymous source: %v", err)
+	}
 
-		defaultClient, err := source.RESTClient()
-		if err != nil {
-			t.Fatalf("failed to get default rest client: %v", err)
-		}
+	restClient, err := source.RESTClient()
+	if err != nil {
+		t.Fatalf("failed to get rest client: %v", err)
+	}
 
-		ownerClient, err := source.OwnerRESTClient(t.Context(), "octocat")
-		if err != nil {
-			t.Fatalf("failed to get owner rest client: %v", err)
-		}
+	if restClient == nil {
+		t.Fatal("expected rest client to be non-nil")
+	}
 
-		if ownerClient != defaultClient {
-			t.Fatal("expected owner rest client to be the same client as default rest client")
-		}
-	})
+	ownerRESTClient, err := source.OwnerRESTClient(t.Context(), "octocat")
+	if err != nil {
+		t.Fatalf("failed to get owner rest client: %v", err)
+	}
 
-	t.Run("GraphQLClient", func(t *testing.T) {
-		t.Parallel()
+	if ownerRESTClient != restClient {
+		t.Fatal("expected owner rest client to be the same client as default rest client")
+	}
 
-		source, err := NewAnonymousSource(testOptions(t))
-		if err != nil {
-			t.Fatalf("failed to create anonymous source: %v", err)
-		}
+	graphQLClient, err := source.GraphQLClient()
+	if err != nil {
+		t.Fatalf("failed to get graphql client: %v", err)
+	}
 
-		client, err := source.GraphQLClient()
-		if err != nil {
-			t.Fatalf("failed to get graphql client: %v", err)
-		}
+	if graphQLClient == nil {
+		t.Fatal("expected graphql client to be non-nil")
+	}
 
-		if client == nil {
-			t.Fatal("expected graphql client to be non-nil")
-		}
-	})
+	ownerGraphQLClient, err := source.OwnerGraphQLClient(t.Context(), "octocat")
+	if err != nil {
+		t.Fatalf("failed to get owner graphql client: %v", err)
+	}
 
-	t.Run("OwnerGraphQLClient", func(t *testing.T) {
-		t.Parallel()
-
-		source, err := NewAnonymousSource(testOptions(t))
-		if err != nil {
-			t.Fatalf("failed to create anonymous source: %v", err)
-		}
-
-		defaultClient, err := source.GraphQLClient()
-		if err != nil {
-			t.Fatalf("failed to get default graphql client: %v", err)
-		}
-
-		ownerClient, err := source.OwnerGraphQLClient(t.Context(), "octocat")
-		if err != nil {
-			t.Fatalf("failed to get owner graphql client: %v", err)
-		}
-
-		if ownerClient != defaultClient {
-			t.Fatal("expected owner graphql client to be the same client as default graphql client")
-		}
-	})
+	if ownerGraphQLClient != graphQLClient {
+		t.Fatal("expected owner graphql client to be the same client as default graphql client")
+	}
 }

--- a/internal/ghclient/app.go
+++ b/internal/ghclient/app.go
@@ -19,6 +19,7 @@ const appClientCacheSize = 8
 type appSource struct {
 	clientID           string
 	privateKey         []byte
+	semaCache          *lru.Cache[string, *semaphore.Weighted]
 	restClientCache    *lru.Cache[string, *github.Client]
 	graphQLClientCache *lru.Cache[string, *githubv4.Client]
 	opts               Options
@@ -26,6 +27,11 @@ type appSource struct {
 
 // NewAppSource creates a new appSource that provides GitHub clients authenticated as either the app itself or as an installation.
 func NewAppSource(clientID string, privateKey []byte, opts Options) (*appSource, error) {
+	semaCache, err := lru.New[string, *semaphore.Weighted](appClientCacheSize)
+	if err != nil {
+		return nil, err
+	}
+
 	restClientCache, err := lru.New[string, *github.Client](appClientCacheSize)
 	if err != nil {
 		return nil, err
@@ -44,11 +50,10 @@ func NewAppSource(clientID string, privateKey []byte, opts Options) (*appSource,
 		opts.CachePath = s
 	}
 
-	opts.sema = semaphore.NewWeighted(maxConcurrentRequests)
-
 	return &appSource{
 		clientID:           clientID,
 		privateKey:         privateKey,
+		semaCache:          semaCache,
 		restClientCache:    restClientCache,
 		graphQLClientCache: graphQLClientCache,
 		opts:               opts,
@@ -62,7 +67,14 @@ func (s *appSource) RESTClient() (*github.Client, error) {
 		return c, nil
 	}
 
+	sema, ok := s.semaCache.Get(key)
+	if !ok {
+		sema = semaphore.NewWeighted(maxConcurrentRequests)
+		s.semaCache.Add(key, sema)
+	}
+
 	opts := s.opts
+	opts.sema = sema
 	opts.maxIdleConns = maxIdleConnsREST
 	opts.idleConnTimeout = idleConnTimeoutREST
 	opts.cacheRef = "app-rest-" + s.clientID
@@ -83,12 +95,19 @@ func (s *appSource) OwnerRESTClient(ctx context.Context, owner string) (*github.
 		return c, nil
 	}
 
+	sema, ok := s.semaCache.Get(key)
+	if !ok {
+		sema = semaphore.NewWeighted(maxConcurrentRequests)
+		s.semaCache.Add(key, sema)
+	}
+
 	installationID, err := s.GetInstallationID(ctx, owner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get installation id for owner %q: %w", owner, err)
 	}
 
 	opts := s.opts
+	opts.sema = sema
 	opts.cacheRef = fmt.Sprintf("app-rest-%s-%s", s.clientID, owner)
 	opts.maxIdleConns = maxIdleConnsREST
 	opts.idleConnTimeout = idleConnTimeoutREST
@@ -109,7 +128,14 @@ func (s *appSource) GraphQLClient() (*githubv4.Client, error) {
 		return c, nil
 	}
 
+	sema, ok := s.semaCache.Get(key)
+	if !ok {
+		sema = semaphore.NewWeighted(maxConcurrentRequests)
+		s.semaCache.Add(key, sema)
+	}
+
 	opts := s.opts
+	opts.sema = sema
 	opts.maxIdleConns = maxIdleConnsGraphQL
 	opts.idleConnTimeout = idleConnTimeoutGraphQL
 	opts.cacheRef = "app-graphql-" + s.clientID
@@ -130,12 +156,19 @@ func (s *appSource) OwnerGraphQLClient(ctx context.Context, owner string) (*gith
 		return c, nil
 	}
 
+	sema, ok := s.semaCache.Get(key)
+	if !ok {
+		sema = semaphore.NewWeighted(maxConcurrentRequests)
+		s.semaCache.Add(key, sema)
+	}
+
 	installationID, err := s.GetInstallationID(ctx, owner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get installation id for owner %q: %w", owner, err)
 	}
 
 	opts := s.opts
+	opts.sema = sema
 	opts.cacheRef = fmt.Sprintf("app-graphql-%s-%s", s.clientID, owner)
 	opts.maxIdleConns = maxIdleConnsGraphQL
 	opts.idleConnTimeout = idleConnTimeoutGraphQL

--- a/internal/ghclient/app.go
+++ b/internal/ghclient/app.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/google/go-github/v88/github"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/shurcooL/githubv4"
+	"golang.org/x/sync/semaphore"
 )
 
 // appClientCacheSize defines the maximum number of app clients to cache in the appSource. This is used to limit memory usage while still providing efficient access to clients for different owners.
@@ -19,11 +21,11 @@ type appSource struct {
 	privateKey         []byte
 	restClientCache    *lru.Cache[string, *github.Client]
 	graphQLClientCache *lru.Cache[string, *githubv4.Client]
-	options            Options
+	opts               Options
 }
 
 // NewAppSource creates a new appSource that provides GitHub clients authenticated as either the app itself or as an installation.
-func NewAppSource(clientID string, privateKey []byte, options Options) (*appSource, error) {
+func NewAppSource(clientID string, privateKey []byte, opts Options) (*appSource, error) {
 	restClientCache, err := lru.New[string, *github.Client](appClientCacheSize)
 	if err != nil {
 		return nil, err
@@ -34,12 +36,22 @@ func NewAppSource(clientID string, privateKey []byte, options Options) (*appSour
 		return nil, err
 	}
 
+	if opts.CachePath == "" {
+		s, err := os.MkdirTemp("", "*")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create temporary cache directory: %w", err)
+		}
+		opts.CachePath = s
+	}
+
+	opts.sema = semaphore.NewWeighted(maxConcurrentRequests)
+
 	return &appSource{
 		clientID:           clientID,
 		privateKey:         privateKey,
 		restClientCache:    restClientCache,
 		graphQLClientCache: graphQLClientCache,
-		options:            options,
+		opts:               opts,
 	}, nil
 }
 
@@ -50,8 +62,10 @@ func (s *appSource) RESTClient() (*github.Client, error) {
 		return c, nil
 	}
 
-	opts := s.options
-	opts.cacheRef = new("app-rest-" + s.clientID)
+	opts := s.opts
+	opts.maxIdleConns = maxIdleConnsREST
+	opts.idleConnTimeout = idleConnTimeoutREST
+	opts.cacheRef = "app-rest-" + s.clientID
 
 	c, err := NewAppRESTClient(s.clientID, s.privateKey, nil, opts)
 	if err != nil {
@@ -74,8 +88,10 @@ func (s *appSource) OwnerRESTClient(ctx context.Context, owner string) (*github.
 		return nil, fmt.Errorf("failed to get installation id for owner %q: %w", owner, err)
 	}
 
-	opts := s.options
-	opts.cacheRef = new(fmt.Sprintf("app-rest-%s-%s", s.clientID, owner))
+	opts := s.opts
+	opts.cacheRef = fmt.Sprintf("app-rest-%s-%s", s.clientID, owner)
+	opts.maxIdleConns = maxIdleConnsREST
+	opts.idleConnTimeout = idleConnTimeoutREST
 
 	c, err := NewAppRESTClient(s.clientID, s.privateKey, installationID, opts)
 	if err != nil {
@@ -93,8 +109,10 @@ func (s *appSource) GraphQLClient() (*githubv4.Client, error) {
 		return c, nil
 	}
 
-	opts := s.options
-	opts.cacheRef = new("app-graphql-" + s.clientID)
+	opts := s.opts
+	opts.maxIdleConns = maxIdleConnsGraphQL
+	opts.idleConnTimeout = idleConnTimeoutGraphQL
+	opts.cacheRef = "app-graphql-" + s.clientID
 
 	c, err := NewAppGraphQLClient(s.clientID, s.privateKey, nil, opts)
 	if err != nil {
@@ -117,8 +135,10 @@ func (s *appSource) OwnerGraphQLClient(ctx context.Context, owner string) (*gith
 		return nil, fmt.Errorf("failed to get installation id for owner %q: %w", owner, err)
 	}
 
-	opts := s.options
-	opts.cacheRef = new(fmt.Sprintf("app-graphql-%s-%s", s.clientID, owner))
+	opts := s.opts
+	opts.cacheRef = fmt.Sprintf("app-graphql-%s-%s", s.clientID, owner)
+	opts.maxIdleConns = maxIdleConnsGraphQL
+	opts.idleConnTimeout = idleConnTimeoutGraphQL
 
 	c, err := NewAppGraphQLClient(s.clientID, s.privateKey, installationID, opts)
 	if err != nil {

--- a/internal/ghclient/app_test.go
+++ b/internal/ghclient/app_test.go
@@ -1,216 +1,177 @@
 package ghclient
 
 import (
+	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"os"
 	"strings"
-	"sync/atomic"
 	"testing"
 )
 
 func TestNewAppSource(t *testing.T) {
 	t.Parallel()
 
-	privateKeyData := mustReadTestAppPrivateKey(t)
+	privateKeyData := mustReadAppPrivateKey(t)
 
-	source, err := NewAppSource("123456789", privateKeyData, testOptions(t))
-	if err != nil {
-		t.Fatalf("failed to create app source: %v", err)
-	}
+	cacheBasePath := mustMkdirTemp(t, "", "*")
+	t.Cleanup(func() {
+		_ = os.RemoveAll(cacheBasePath)
+	})
 
-	if source == nil {
-		t.Fatal("expected app source to be non-nil")
+	for _, tt := range []struct {
+		name string
+		opts Options
+	}{
+		{
+			name: "default",
+			opts: Options{
+				RESTAPIURL: "https://api.github.com/",
+				GraphQLURL: "https://api.github.com/graphql",
+			},
+		},
+		{
+			name: "with_cache_path",
+			opts: Options{
+				RESTAPIURL: "https://api.github.com/",
+				GraphQLURL: "https://api.github.com/graphql",
+				CachePath:  mustMkdirTemp(t, cacheBasePath, "*"),
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			source, err := NewAppSource("123456789", privateKeyData, tt.opts)
+			if err != nil {
+				t.Fatalf("failed to create app source: %v", err)
+			}
+
+			if source == nil {
+				t.Fatal("expected app source to be non-nil")
+			}
+		})
 	}
 }
 
 func Test_appSource(t *testing.T) {
 	t.Parallel()
 
-	t.Run("RESTClient_cache", func(t *testing.T) {
-		t.Parallel()
+	owner1 := "octocat"
+	owner2 := "acme"
 
-		var requestCount atomic.Int32
-		source := mustTestAppSource(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			requestCount.Add(1)
-			w.WriteHeader(http.StatusInternalServerError)
-		}))
-
-		firstClient, err := source.RESTClient()
-		if err != nil {
-			t.Fatalf("failed to get first rest client: %v", err)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, fmt.Sprintf("/orgs/%s/installation", owner1)) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id": 1000}`))
+			return
 		}
 
-		secondClient, err := source.RESTClient()
-		if err != nil {
-			t.Fatalf("failed to get second rest client: %v", err)
+		if strings.HasSuffix(r.URL.Path, fmt.Sprintf("/orgs/%s/installation", owner2)) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id": 1001}`))
+			return
 		}
 
-		if firstClient != secondClient {
-			t.Fatal("expected rest client to be cached")
-		}
-
-		if requestCount.Load() != 0 {
-			t.Fatalf("expected no HTTP requests when building cached rest client, got %d", requestCount.Load())
-		}
+		w.WriteHeader(http.StatusNotFound)
 	})
 
-	t.Run("OwnerClient_cache_by_owner", func(t *testing.T) {
-		t.Parallel()
-		var orgRequests atomic.Int32
-		source := mustTestAppSource(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasSuffix(r.URL.Path, "/orgs/acme/installation") {
-				orgRequests.Add(1)
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(`{"id": 1001}`))
-				return
-			}
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
 
-			w.WriteHeader(http.StatusNotFound)
-		}))
-
-		firstRESTClient, err := source.OwnerRESTClient(t.Context(), "acme")
-		if err != nil {
-			t.Fatalf("failed to get first owner rest client: %v", err)
-		}
-
-		secondRESTClient, err := source.OwnerRESTClient(t.Context(), "acme")
-		if err != nil {
-			t.Fatalf("failed to get second owner rest client: %v", err)
-		}
-
-		if firstRESTClient != secondRESTClient {
-			t.Fatal("expected owner rest client to be cached")
-		}
-
-		if orgRequests.Load() != 1 {
-			t.Fatalf("expected one organization installation lookup after rest client requests, got %d", orgRequests.Load())
-		}
-
-		firstGraphQLClient, err := source.OwnerGraphQLClient(t.Context(), "acme")
-		if err != nil {
-			t.Fatalf("failed to get first owner graphql client: %v", err)
-		}
-
-		secondGraphQLClient, err := source.OwnerGraphQLClient(t.Context(), "acme")
-		if err != nil {
-			t.Fatalf("failed to get second owner graphql client: %v", err)
-		}
-
-		if firstGraphQLClient != secondGraphQLClient {
-			t.Fatal("expected owner graphql client to be cached")
-		}
-
-		if orgRequests.Load() != 2 {
-			t.Fatalf("expected one organization installation lookup per client type, got %d", orgRequests.Load())
-		}
+	cacheBasePath := mustMkdirTemp(t, "", "*")
+	t.Cleanup(func() {
+		_ = os.RemoveAll(cacheBasePath)
 	})
 
-	t.Run("GetInstallationID_scenarios", func(t *testing.T) {
-		t.Parallel()
+	opts := Options{
+		RESTAPIURL: ts.URL,
+		GraphQLURL: ts.URL,
+		CachePath:  mustMkdirTemp(t, cacheBasePath, "*"),
+	}
 
-		fallbackID := int64(2002)
+	source, err := NewAppSource("123456789", mustReadAppPrivateKey(t), opts)
+	if err != nil {
+		t.Fatalf("failed to create app source: %v", err)
+	}
 
-		t.Run("fallback_to_user", func(t *testing.T) {
-			t.Parallel()
+	restClient, err := source.RESTClient()
+	if err != nil {
+		t.Fatalf("failed to get rest client: %v", err)
+	}
 
-			var orgRequests atomic.Int32
-			var userRequests atomic.Int32
-			source := mustTestAppSource(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if strings.HasSuffix(r.URL.Path, "/orgs/octocat/installation") {
-					orgRequests.Add(1)
-					w.WriteHeader(http.StatusNotFound)
-					return
-				}
-				if strings.HasSuffix(r.URL.Path, "/users/octocat/installation") {
-					userRequests.Add(1)
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write([]byte(`{"id": 2002}`))
-					return
-				}
-				w.WriteHeader(http.StatusNotFound)
-			}))
+	if restClient == nil {
+		t.Fatal("expected rest client to be non-nil")
+	}
 
-			installationID, err := source.GetInstallationID(t.Context(), "octocat")
-			if err != nil {
-				t.Fatalf("expected success, got error: %v", err)
-			}
+	ownerRESTClientFirst, err := source.OwnerRESTClient(t.Context(), owner1)
+	if err != nil {
+		t.Fatalf("failed to get first owner rest client: %v", err)
+	}
 
-			if installationID == nil || *installationID != fallbackID {
-				t.Fatalf("expected installation id %d, got %v", fallbackID, installationID)
-			}
+	if ownerRESTClientFirst == nil {
+		t.Fatal("expected first owner rest client to be non-nil")
+	}
 
-			if orgRequests.Load() != 1 {
-				t.Fatalf("expected 1 org request, got %d", orgRequests.Load())
-			}
+	ownerRESTClientFirstAgain, err := source.OwnerRESTClient(t.Context(), owner1)
+	if err != nil {
+		t.Fatalf("failed to get first owner rest client again: %v", err)
+	}
 
-			if userRequests.Load() != 1 {
-				t.Fatalf("expected 1 user request, got %d", userRequests.Load())
-			}
-		})
+	if ownerRESTClientFirstAgain != ownerRESTClientFirst {
+		t.Fatal("expected first owner rest client to be cached and reused")
+	}
 
-		t.Run("org_lookup_error", func(t *testing.T) {
-			t.Parallel()
+	ownerRESTClientSecond, err := source.OwnerRESTClient(t.Context(), owner2)
+	if err != nil {
+		t.Fatalf("failed to get second owner rest client: %v", err)
+	}
 
-			var orgRequests atomic.Int32
-			var userRequests atomic.Int32
-			source := mustTestAppSource(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if strings.HasSuffix(r.URL.Path, "/orgs/acme/installation") {
-					orgRequests.Add(1)
-					w.WriteHeader(http.StatusInternalServerError)
-					_, _ = w.Write([]byte(`{"message": "boom"}`))
-					return
-				}
-				w.WriteHeader(http.StatusNotFound)
-			}))
+	if ownerRESTClientSecond == nil {
+		t.Fatal("expected second owner rest client to be non-nil")
+	}
 
-			_, err := source.GetInstallationID(t.Context(), "acme")
-			if err == nil {
-				t.Fatal("expected error")
-			}
+	if ownerRESTClientFirst == ownerRESTClientSecond {
+		t.Fatal("expected different owner rest clients for different owners")
+	}
 
-			if !strings.Contains(err.Error(), `failed to get installation for owner "acme"`) {
-				t.Fatalf("expected installation lookup error, got %v", err)
-			}
+	graphQLClient, err := source.GraphQLClient()
+	if err != nil {
+		t.Fatalf("failed to get graphql client: %v", err)
+	}
 
-			if orgRequests.Load() != 1 {
-				t.Fatalf("expected 1 org request, got %d", orgRequests.Load())
-			}
+	if graphQLClient == nil {
+		t.Fatal("expected graphql client to be non-nil")
+	}
 
-			if userRequests.Load() != 0 {
-				t.Fatalf("expected 0 user requests, got %d", userRequests.Load())
-			}
-		})
+	ownerGraphQLClientFirst, err := source.OwnerGraphQLClient(t.Context(), owner1)
+	if err != nil {
+		t.Fatalf("failed to get first owner graphql client: %v", err)
+	}
 
-		t.Run("no_installation_id", func(t *testing.T) {
-			t.Parallel()
+	if ownerGraphQLClientFirst == nil {
+		t.Fatal("expected first owner graphql client to be non-nil")
+	}
 
-			var orgRequests atomic.Int32
-			var userRequests atomic.Int32
-			source := mustTestAppSource(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if strings.HasSuffix(r.URL.Path, "/orgs/acme/installation") {
-					orgRequests.Add(1)
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write([]byte(`{}`))
-					return
-				}
-				w.WriteHeader(http.StatusNotFound)
-			}))
+	ownerGraphQLClientFirstAgain, err := source.OwnerGraphQLClient(t.Context(), owner1)
+	if err != nil {
+		t.Fatalf("failed to get first owner graphql client again: %v", err)
+	}
 
-			_, err := source.GetInstallationID(t.Context(), "acme")
-			if err == nil {
-				t.Fatal("expected error")
-			}
+	if ownerGraphQLClientFirstAgain != ownerGraphQLClientFirst {
+		t.Fatal("expected first owner graphql client to be cached and reused")
+	}
 
-			if !strings.Contains(err.Error(), `no installation found for owner "acme"`) {
-				t.Fatalf("expected missing installation error, got %v", err)
-			}
+	ownerGraphQLClientSecond, err := source.OwnerGraphQLClient(t.Context(), owner2)
+	if err != nil {
+		t.Fatalf("failed to get second owner graphql client: %v", err)
+	}
 
-			if orgRequests.Load() != 1 {
-				t.Fatalf("expected 1 org request, got %d", orgRequests.Load())
-			}
+	if ownerGraphQLClientSecond == nil {
+		t.Fatal("expected second owner graphql client to be non-nil")
+	}
 
-			if userRequests.Load() != 0 {
-				t.Fatalf("expected 0 user requests, got %d", userRequests.Load())
-			}
-		})
-	})
+	if ownerGraphQLClientFirst == ownerGraphQLClientSecond {
+		t.Fatal("expected different owner graphql clients for different owners")
+	}
 }

--- a/internal/ghclient/app_test.go
+++ b/internal/ghclient/app_test.go
@@ -1,7 +1,6 @@
 package ghclient
 
 import (
-	"context"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -13,7 +12,7 @@ func TestNewAppSource(t *testing.T) {
 
 	privateKeyData := mustReadTestAppPrivateKey(t)
 
-	source, err := NewAppSource("123456789", privateKeyData, Options{})
+	source, err := NewAppSource("123456789", privateKeyData, testOptions(t))
 	if err != nil {
 		t.Fatalf("failed to create app source: %v", err)
 	}
@@ -56,57 +55,52 @@ func Test_appSource(t *testing.T) {
 
 	t.Run("OwnerClient_cache_by_owner", func(t *testing.T) {
 		t.Parallel()
+		var orgRequests atomic.Int32
+		source := mustTestAppSource(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasSuffix(r.URL.Path, "/orgs/acme/installation") {
+				orgRequests.Add(1)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"id": 1001}`))
+				return
+			}
 
-		for _, tt := range []struct {
-			name       string
-			callClient func(context.Context, *appSource, string) (any, error)
-		}{
-			{
-				name: "rest",
-				callClient: func(ctx context.Context, source *appSource, owner string) (any, error) {
-					return source.OwnerRESTClient(ctx, owner)
-				},
-			},
-			{
-				name: "graphql",
-				callClient: func(ctx context.Context, source *appSource, owner string) (any, error) {
-					return source.OwnerGraphQLClient(ctx, owner)
-				},
-			},
-		} {
-			t.Run(tt.name, func(t *testing.T) {
-				t.Parallel()
+			w.WriteHeader(http.StatusNotFound)
+		}))
 
-				var orgRequests atomic.Int32
-				source := mustTestAppSource(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if strings.HasSuffix(r.URL.Path, "/orgs/acme/installation") {
-						orgRequests.Add(1)
-						w.WriteHeader(http.StatusOK)
-						_, _ = w.Write([]byte(`{"id": 1001}`))
-						return
-					}
+		firstRESTClient, err := source.OwnerRESTClient(t.Context(), "acme")
+		if err != nil {
+			t.Fatalf("failed to get first owner rest client: %v", err)
+		}
 
-					w.WriteHeader(http.StatusNotFound)
-				}))
+		secondRESTClient, err := source.OwnerRESTClient(t.Context(), "acme")
+		if err != nil {
+			t.Fatalf("failed to get second owner rest client: %v", err)
+		}
 
-				firstClient, err := tt.callClient(t.Context(), source, "acme")
-				if err != nil {
-					t.Fatalf("failed to get first owner client: %v", err)
-				}
+		if firstRESTClient != secondRESTClient {
+			t.Fatal("expected owner rest client to be cached")
+		}
 
-				secondClient, err := tt.callClient(t.Context(), source, "acme")
-				if err != nil {
-					t.Fatalf("failed to get second owner client: %v", err)
-				}
+		if orgRequests.Load() != 1 {
+			t.Fatalf("expected one organization installation lookup after rest client requests, got %d", orgRequests.Load())
+		}
 
-				if firstClient != secondClient {
-					t.Fatal("expected owner client to be cached")
-				}
+		firstGraphQLClient, err := source.OwnerGraphQLClient(t.Context(), "acme")
+		if err != nil {
+			t.Fatalf("failed to get first owner graphql client: %v", err)
+		}
 
-				if orgRequests.Load() != 1 {
-					t.Fatalf("expected one organization installation lookup, got %d", orgRequests.Load())
-				}
-			})
+		secondGraphQLClient, err := source.OwnerGraphQLClient(t.Context(), "acme")
+		if err != nil {
+			t.Fatalf("failed to get second owner graphql client: %v", err)
+		}
+
+		if firstGraphQLClient != secondGraphQLClient {
+			t.Fatal("expected owner graphql client to be cached")
+		}
+
+		if orgRequests.Load() != 2 {
+			t.Fatalf("expected one organization installation lookup per client type, got %d", orgRequests.Load())
 		}
 	})
 
@@ -115,103 +109,108 @@ func Test_appSource(t *testing.T) {
 
 		fallbackID := int64(2002)
 
-		for _, tt := range []struct {
-			name            string
-			owner           string
-			handleRequest   func(w http.ResponseWriter, r *http.Request, orgRequests, userRequests *atomic.Int32)
-			expectError     bool
-			errorContains   string
-			expectedID      *int64
-			expectedOrgReq  int32
-			expectedUserReq int32
-		}{
-			{
-				name:  "fallback_to_user",
-				owner: "octocat",
-				handleRequest: func(w http.ResponseWriter, r *http.Request, orgRequests, userRequests *atomic.Int32) {
-					if strings.HasSuffix(r.URL.Path, "/orgs/octocat/installation") {
-						orgRequests.Add(1)
-						w.WriteHeader(http.StatusNotFound)
-						return
-					}
-					if strings.HasSuffix(r.URL.Path, "/users/octocat/installation") {
-						userRequests.Add(1)
-						w.WriteHeader(http.StatusOK)
-						_, _ = w.Write([]byte(`{"id": 2002}`))
-						return
-					}
-					w.WriteHeader(http.StatusNotFound)
-				},
-				expectedID:      &fallbackID,
-				expectedOrgReq:  1,
-				expectedUserReq: 1,
-			},
-			{
-				name:  "org_lookup_error",
-				owner: "acme",
-				handleRequest: func(w http.ResponseWriter, r *http.Request, orgRequests, _ *atomic.Int32) {
-					if strings.HasSuffix(r.URL.Path, "/orgs/acme/installation") {
-						orgRequests.Add(1)
-						w.WriteHeader(http.StatusInternalServerError)
-						_, _ = w.Write([]byte(`{"message": "boom"}`))
-						return
-					}
-					w.WriteHeader(http.StatusNotFound)
-				},
-				expectError:    true,
-				errorContains:  `failed to get installation for owner "acme"`,
-				expectedOrgReq: 1,
-			},
-			{
-				name:  "no_installation_id",
-				owner: "acme",
-				handleRequest: func(w http.ResponseWriter, r *http.Request, orgRequests, _ *atomic.Int32) {
-					if strings.HasSuffix(r.URL.Path, "/orgs/acme/installation") {
-						orgRequests.Add(1)
-						w.WriteHeader(http.StatusOK)
-						_, _ = w.Write([]byte(`{}`))
-						return
-					}
-					w.WriteHeader(http.StatusNotFound)
-				},
-				expectError:    true,
-				errorContains:  `no installation found for owner "acme"`,
-				expectedOrgReq: 1,
-			},
-		} {
-			t.Run(tt.name, func(t *testing.T) {
-				t.Parallel()
+		t.Run("fallback_to_user", func(t *testing.T) {
+			t.Parallel()
 
-				var orgRequests atomic.Int32
-				var userRequests atomic.Int32
-				source := mustTestAppSource(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					tt.handleRequest(w, r, &orgRequests, &userRequests)
-				}))
+			var orgRequests atomic.Int32
+			var userRequests atomic.Int32
+			source := mustTestAppSource(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasSuffix(r.URL.Path, "/orgs/octocat/installation") {
+					orgRequests.Add(1)
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				if strings.HasSuffix(r.URL.Path, "/users/octocat/installation") {
+					userRequests.Add(1)
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"id": 2002}`))
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}))
 
-				installationID, err := source.GetInstallationID(t.Context(), tt.owner)
-				if tt.expectError {
-					if err == nil {
-						t.Fatal("expected error")
-					}
-					if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
-						t.Fatalf("expected error containing %q, got %v", tt.errorContains, err)
-					}
-				} else {
-					if err != nil {
-						t.Fatalf("expected success, got error: %v", err)
-					}
-					if tt.expectedID != nil && (installationID == nil || *installationID != *tt.expectedID) {
-						t.Fatalf("expected installation id %d, got %v", *tt.expectedID, installationID)
-					}
-				}
+			installationID, err := source.GetInstallationID(t.Context(), "octocat")
+			if err != nil {
+				t.Fatalf("expected success, got error: %v", err)
+			}
 
-				if orgRequests.Load() != tt.expectedOrgReq {
-					t.Fatalf("expected %d org requests, got %d", tt.expectedOrgReq, orgRequests.Load())
+			if installationID == nil || *installationID != fallbackID {
+				t.Fatalf("expected installation id %d, got %v", fallbackID, installationID)
+			}
+
+			if orgRequests.Load() != 1 {
+				t.Fatalf("expected 1 org request, got %d", orgRequests.Load())
+			}
+
+			if userRequests.Load() != 1 {
+				t.Fatalf("expected 1 user request, got %d", userRequests.Load())
+			}
+		})
+
+		t.Run("org_lookup_error", func(t *testing.T) {
+			t.Parallel()
+
+			var orgRequests atomic.Int32
+			var userRequests atomic.Int32
+			source := mustTestAppSource(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasSuffix(r.URL.Path, "/orgs/acme/installation") {
+					orgRequests.Add(1)
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write([]byte(`{"message": "boom"}`))
+					return
 				}
-				if userRequests.Load() != tt.expectedUserReq {
-					t.Fatalf("expected %d user requests, got %d", tt.expectedUserReq, userRequests.Load())
+				w.WriteHeader(http.StatusNotFound)
+			}))
+
+			_, err := source.GetInstallationID(t.Context(), "acme")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+
+			if !strings.Contains(err.Error(), `failed to get installation for owner "acme"`) {
+				t.Fatalf("expected installation lookup error, got %v", err)
+			}
+
+			if orgRequests.Load() != 1 {
+				t.Fatalf("expected 1 org request, got %d", orgRequests.Load())
+			}
+
+			if userRequests.Load() != 0 {
+				t.Fatalf("expected 0 user requests, got %d", userRequests.Load())
+			}
+		})
+
+		t.Run("no_installation_id", func(t *testing.T) {
+			t.Parallel()
+
+			var orgRequests atomic.Int32
+			var userRequests atomic.Int32
+			source := mustTestAppSource(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasSuffix(r.URL.Path, "/orgs/acme/installation") {
+					orgRequests.Add(1)
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{}`))
+					return
 				}
-			})
-		}
+				w.WriteHeader(http.StatusNotFound)
+			}))
+
+			_, err := source.GetInstallationID(t.Context(), "acme")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+
+			if !strings.Contains(err.Error(), `no installation found for owner "acme"`) {
+				t.Fatalf("expected missing installation error, got %v", err)
+			}
+
+			if orgRequests.Load() != 1 {
+				t.Fatalf("expected 1 org request, got %d", orgRequests.Load())
+			}
+
+			if userRequests.Load() != 0 {
+				t.Fatalf("expected 0 user requests, got %d", userRequests.Load())
+			}
+		})
 	})
 }

--- a/internal/ghclient/cache.go
+++ b/internal/ghclient/cache.go
@@ -1,29 +1,24 @@
 package ghclient
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
-	ghct "github.com/bored-engineer/github-conditional-http-transport"
 	ghctbbolt "github.com/bored-engineer/github-conditional-http-transport/bbolt"
 )
 
 // createCacheStore creates a new bbolt storage for caching GitHub API responses. It creates a temporary directory and returns a storage instance pointing to a file in that directory.
-func createCacheStore(path, ref *string) (ghct.Storage, error) {
-	var cacheDir string
-	if path != nil && *path != "" {
-		cacheDir = filepath.Join(*path, "terraform-provider-github")
-	} else {
-		tmpDir, err := os.MkdirTemp("", "terraform-provider-github-*")
-		if err != nil {
-			return nil, fmt.Errorf("failed to create temporary cache directory: %w", err)
-		}
-		cacheDir = tmpDir
+func createCacheStore(path, ref string) (*ghctbbolt.Storage, error) {
+	if path == "" {
+		return nil, errors.New("cache path cannot be empty")
 	}
 
-	if ref != nil && *ref != "" {
-		cacheDir = filepath.Join(cacheDir, *ref)
+	cacheDir := filepath.Join(path, "terraform-provider-github")
+
+	if ref != "" {
+		cacheDir = filepath.Join(cacheDir, ref)
 	}
 
 	if err := os.MkdirAll(cacheDir, 0o700); err != nil {

--- a/internal/ghclient/cache_test.go
+++ b/internal/ghclient/cache_test.go
@@ -30,7 +30,7 @@ func Test_createCacheStore(t *testing.T) {
 		},
 		{
 			name:      "errors_with_invalid_path",
-			path:      "a/b\x00c",
+			path:      "\x00c",
 			wantError: "failed to create cache directory",
 		},
 	} {

--- a/internal/ghclient/cache_test.go
+++ b/internal/ghclient/cache_test.go
@@ -1,55 +1,50 @@
 package ghclient
 
 import (
-	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 )
 
 func Test_createCacheStore(t *testing.T) {
 	t.Parallel()
 
-	tempPath := t.TempDir()
-	basePath := filepath.Join(tempPath, "cache-root")
-	ref := "feature-branch"
-	invalidPath := filepath.Join(tempPath, "not-a-dir")
-	if err := os.WriteFile(invalidPath, []byte("x"), 0o600); err != nil {
-		t.Fatalf("failed to create invalid path fixture: %v", err)
-	}
-
 	for _, tt := range []struct {
-		name        string
-		path        *string
-		ref         *string
-		expectError bool
-		verify      func(t *testing.T)
+		name      string
+		path      string
+		ref       string
+		wantError string
 	}{
 		{
+			name: "with_path",
+			path: t.TempDir(),
+		},
+		{
 			name: "with_path_and_ref",
-			path: &basePath,
-			ref:  &ref,
-			verify: func(t *testing.T) {
-				t.Helper()
-				cacheDBPath := filepath.Join(basePath, "terraform-provider-github", ref, "cache.db")
-				if _, err := os.Stat(cacheDBPath); err != nil {
-					t.Fatalf("expected cache db to exist at %q: %v", cacheDBPath, err)
-				}
-			},
+			path: t.TempDir(),
+			ref:  "test-ref",
 		},
 		{
-			name: "without_path",
+			name:      "errors_without_path",
+			wantError: "cache path cannot be empty",
 		},
 		{
-			name:        "invalid_path",
-			path:        &invalidPath,
-			expectError: true,
+			name:      "errors_with_invalid_path",
+			path:      "a/b\x00c",
+			wantError: "failed to create cache directory",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			store, err := createCacheStore(tt.path, tt.ref)
-			if tt.expectError {
+
+			if tt.wantError != "" {
 				if err == nil {
-					t.Fatal("expected error")
+					t.Fatalf("expected error %q, got nil", tt.wantError)
+				}
+				if !regexp.MustCompile(regexp.QuoteMeta(tt.wantError)).MatchString(err.Error()) {
+					t.Fatalf("expected error %q, got %q", tt.wantError, err.Error())
 				}
 				return
 			}
@@ -58,16 +53,16 @@ func Test_createCacheStore(t *testing.T) {
 				t.Fatalf("expected store to be created, got error: %v", err)
 			}
 
-			if tt.verify != nil {
-				tt.verify(t)
+			if store == nil {
+				t.Fatal("expected store to be non-nil")
 			}
+			defer func() {
+				_ = store.DB.Close()
+			}()
 
-			if closer, ok := store.(interface{ Close() error }); ok {
-				t.Cleanup(func() {
-					if err := closer.Close(); err != nil {
-						t.Fatalf("failed to close store: %v", err)
-					}
-				})
+			wantPath := filepath.Join(tt.path, "terraform-provider-github", tt.ref, "cache.db")
+			if store.DB.Path() != wantPath {
+				t.Fatalf("expected store path to be %q, got %q", wantPath, store.DB.Path())
 			}
 		})
 	}

--- a/internal/ghclient/const.go
+++ b/internal/ghclient/const.go
@@ -3,8 +3,11 @@ package ghclient
 import "time"
 
 const (
+	// githubSecondaryRateLimitMaxConcurrency defines the maximum number of concurrent requests allowed to the GitHub API under secondary rate limits.
+	githubSecondaryRateLimitMaxConcurrency int64 = 100
+
 	// maxConcurrentRequests defines the maximum number of concurrent requests allowed to the GitHub API.
-	maxConcurrentRequests int64 = 100
+	maxConcurrentRequests int64 = githubSecondaryRateLimitMaxConcurrency
 
 	// maxIdleConnsREST defines the maximum number of idle connections for REST API requests.
 	maxIdleConnsREST int = 100

--- a/internal/ghclient/const.go
+++ b/internal/ghclient/const.go
@@ -2,5 +2,22 @@ package ghclient
 
 import "time"
 
-// clientTimeout defines the timeout duration for GitHub API requests. This is set to 5 minutes to accommodate potentially long-running operations while still providing a reasonable upper limit on request duration.
-const clientTimeout = 5 * time.Minute
+const (
+	// maxConcurrentRequests defines the maximum number of concurrent requests allowed to the GitHub API.
+	maxConcurrentRequests int64 = 100
+
+	// maxIdleConnsREST defines the maximum number of idle connections for REST API requests.
+	maxIdleConnsREST int = 100
+
+	// maxIdleConnsGraphQL defines the maximum number of idle connections for GraphQL API requests.
+	maxIdleConnsGraphQL int = 10
+
+	// idleConnTimeoutREST defines the timeout duration for idle REST API connections.
+	idleConnTimeoutREST = 90 * time.Second
+
+	// idleConnTimeoutGraphQL defines the timeout duration for idle GraphQL API connections.
+	idleConnTimeoutGraphQL = 120 * time.Second
+
+	// clientTimeout defines the timeout duration for GitHub API requests.
+	clientTimeout = 5 * time.Minute
+)

--- a/internal/ghclient/graphql.go
+++ b/internal/ghclient/graphql.go
@@ -10,12 +10,12 @@ import (
 )
 
 // NewAnonymousGraphQLClient creates a new GitHub GraphQL client that is unauthenticated. This client will have limited access to public resources and will be subject to stricter rate limits compared to authenticated clients.
-func NewAnonymousGraphQLClient(options Options) (*githubv4.Client, error) {
-	return newGraphQLClient(nil, options)
+func NewAnonymousGraphQLClient(opts Options) (*githubv4.Client, error) {
+	return newGraphQLClient(nil, opts)
 }
 
 // NewAppGraphQLClient creates a new GitHub GraphQL client authenticated as either the app itself (if installationID is nil) or as the specified installation (if installationID is provided), using the app's private key.
-func NewAppGraphQLClient(clientID string, privateKey []byte, installationID *int64, options Options) (*githubv4.Client, error) {
+func NewAppGraphQLClient(clientID string, privateKey []byte, installationID *int64, opts Options) (*githubv4.Client, error) {
 	tokenSource, err := githubauth.NewApplicationTokenSource(clientID, privateKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create app token source: %w", err)
@@ -25,14 +25,14 @@ func NewAppGraphQLClient(clientID string, privateKey []byte, installationID *int
 		tokenSource = githubauth.NewInstallationTokenSource(*installationID, tokenSource)
 	}
 
-	return newGraphQLClient(tokenSource, options)
+	return newGraphQLClient(tokenSource, opts)
 }
 
 // NewTokenGraphQLClient creates a new GitHub GraphQL client authenticated with the provided personal access token.
-func NewTokenGraphQLClient(token string, options Options) (*githubv4.Client, error) {
+func NewTokenGraphQLClient(token string, opts Options) (*githubv4.Client, error) {
 	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 
-	return newGraphQLClient(tokenSource, options)
+	return newGraphQLClient(tokenSource, opts)
 }
 
 // newGraphQLClient creates a new GitHub GraphQL client using the provided OAuth2 token source and options. It sets up the client's transport with caching and rate limit handling, and configures the client's API URL based on the provided options.
@@ -44,9 +44,5 @@ func newGraphQLClient(tokenSource oauth2.TokenSource, opts Options) (*githubv4.C
 
 	client := &http.Client{Transport: tr, Timeout: clientTimeout}
 
-	if opts.GraphQLURL == nil {
-		return githubv4.NewClient(client), nil
-	}
-
-	return githubv4.NewEnterpriseClient(*opts.GraphQLURL, client), nil
+	return githubv4.NewEnterpriseClient(opts.GraphQLURL, client), nil
 }

--- a/internal/ghclient/graphql.go
+++ b/internal/ghclient/graphql.go
@@ -44,5 +44,9 @@ func newGraphQLClient(tokenSource oauth2.TokenSource, opts Options) (*githubv4.C
 
 	client := &http.Client{Transport: tr, Timeout: clientTimeout}
 
+	if opts.GraphQLURL == "" {
+		return githubv4.NewClient(client), nil
+	}
+
 	return githubv4.NewEnterpriseClient(opts.GraphQLURL, client), nil
 }

--- a/internal/ghclient/graphql_test.go
+++ b/internal/ghclient/graphql_test.go
@@ -1,45 +1,20 @@
 package ghclient
 
-import "testing"
+import (
+	"regexp"
+	"testing"
 
-func Test_newGraphQLClient(t *testing.T) {
-	t.Parallel()
-
-	for _, tt := range []struct {
-		name       string
-		graphQLURL string
-	}{
-		{
-			name:       "default_URL",
-			graphQLURL: "https://api.github.com/graphql",
-		},
-		{
-			name:       "enterprise_URL",
-			graphQLURL: "https://ghe.example.com/api/graphql",
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			opts := testOptions(t)
-			opts.GraphQLURL = tt.graphQLURL
-
-			client, err := newGraphQLClient(nil, opts)
-			if err != nil {
-				t.Fatalf("failed to create graphql client: %v", err)
-			}
-
-			if client == nil {
-				t.Fatal("expected graphql client to be non-nil")
-			}
-		})
-	}
-}
+	"golang.org/x/oauth2"
+)
 
 func TestNewAnonymousGraphQLClient(t *testing.T) {
 	t.Parallel()
 
-	client, err := NewAnonymousGraphQLClient(testOptions(t))
+	opts := Options{
+		GraphQLURL: "https://api.github.com/graphql",
+	}
+
+	client, err := NewAnonymousGraphQLClient(opts)
 	if err != nil {
 		t.Fatalf("failed to create anonymous graphql client: %v", err)
 	}
@@ -51,41 +26,128 @@ func TestNewAnonymousGraphQLClient(t *testing.T) {
 
 func TestNewAppGraphQLClient(t *testing.T) {
 	t.Parallel()
-	privateKeyData := mustReadTestAppPrivateKey(t)
+
+	privateKeyData := mustReadAppPrivateKey(t)
 
 	for _, tt := range []struct {
-		name       string
-		privateKey []byte
-		expectErr  bool
+		name           string
+		privateKey     []byte
+		installationID *int64
+		opts           Options
+		wantErr        string
 	}{
 		{
-			name:       "invalid_private_key",
-			privateKey: []byte("invalid-private-key"),
-			expectErr:  true,
+			name:           "app_client",
+			privateKey:     privateKeyData,
+			installationID: nil,
+			opts:           Options{GraphQLURL: "https://api.github.com/graphql"},
 		},
 		{
-			name:       "valid_private_key",
-			privateKey: privateKeyData,
+			name:           "installation_client",
+			privateKey:     privateKeyData,
+			installationID: new(int64(8888)),
+			opts:           Options{GraphQLURL: "https://api.github.com/graphql"},
+		},
+		{
+			name:           "handles_token_source_error",
+			privateKey:     []byte("invalid-private-key"),
+			installationID: nil,
+			opts:           Options{GraphQLURL: "https://api.github.com/graphql"},
+			wantErr:        "failed to create app token source",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			client, err := NewAppGraphQLClient("123456789", tt.privateKey, nil, testOptions(t))
-			if tt.expectErr {
-				if err == nil {
-					t.Fatal("expected app graphql client creation to fail for invalid private key")
+			client, err := NewAppGraphQLClient("123456789", tt.privateKey, tt.installationID, tt.opts)
+			if err != nil {
+				if tt.wantErr == "" {
+					t.Fatalf("failed to create app graphql client: %v", err)
+				}
+
+				if !regexp.MustCompile(regexp.QuoteMeta(tt.wantErr)).MatchString(err.Error()) {
+					t.Fatalf("expected error to match %q, got %v", tt.wantErr, err)
 				}
 
 				return
 			}
 
-			if err != nil {
-				t.Fatalf("failed to create app graphql client: %v", err)
+			if tt.wantErr != "" {
+				t.Fatalf("expected error %q, got nil", tt.wantErr)
 			}
 
 			if client == nil {
 				t.Fatal("expected app graphql client to be non-nil")
+			}
+		})
+	}
+}
+
+func TestNewTokenGraphQLClient(t *testing.T) {
+	t.Parallel()
+
+	opts := Options{
+		GraphQLURL: "https://api.github.com/graphql",
+	}
+
+	client, err := NewTokenGraphQLClient("test-token", opts)
+	if err != nil {
+		t.Fatalf("failed to create token graphql client: %v", err)
+	}
+
+	if client == nil {
+		t.Fatal("expected token graphql client to be non-nil")
+	}
+}
+
+func Test_newGraphQLClient(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name        string
+		tokenSource oauth2.TokenSource
+		opts        Options
+		wantErr     string
+	}{
+		{
+			name:        "with_token_source",
+			tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
+			opts:        Options{GraphQLURL: "https://api.github.com/graphql"},
+		},
+		{
+			name:        "without_token_source",
+			tokenSource: nil,
+			opts:        Options{GraphQLURL: "https://api.github.com/graphql"},
+		},
+		{
+			name:        "errors_if_transport_cannot_be_created",
+			tokenSource: nil,
+			opts:        Options{GraphQLURL: "https://api.github.com/graphql", CachePath: "\x00c"},
+			wantErr:     "failed to create transport",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := newGraphQLClient(tt.tokenSource, tt.opts)
+			if err != nil {
+				if tt.wantErr == "" {
+					t.Fatalf("failed to create graphql client: %v", err)
+				}
+
+				if !regexp.MustCompile(regexp.QuoteMeta(tt.wantErr)).MatchString(err.Error()) {
+					t.Fatalf("expected error to match %q, got %v", tt.wantErr, err)
+				}
+
+				return
+			}
+
+			if tt.wantErr != "" {
+				t.Fatalf("expected error %q, got nil", tt.wantErr)
+			}
+
+			if got == nil {
+				t.Fatal("expected graphql client to be non-nil")
 			}
 		})
 	}

--- a/internal/ghclient/graphql_test.go
+++ b/internal/ghclient/graphql_test.go
@@ -5,38 +5,41 @@ import "testing"
 func Test_newGraphQLClient(t *testing.T) {
 	t.Parallel()
 
-	t.Run("default_URL", func(t *testing.T) {
-		t.Parallel()
+	for _, tt := range []struct {
+		name       string
+		graphQLURL string
+	}{
+		{
+			name:       "default_URL",
+			graphQLURL: "https://api.github.com/graphql",
+		},
+		{
+			name:       "enterprise_URL",
+			graphQLURL: "https://ghe.example.com/api/graphql",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-		client, err := newGraphQLClient(nil, Options{})
-		if err != nil {
-			t.Fatalf("failed to create graphql client with default url: %v", err)
-		}
+			opts := testOptions(t)
+			opts.GraphQLURL = tt.graphQLURL
 
-		if client == nil {
-			t.Fatal("expected graphql client to be non-nil")
-		}
-	})
+			client, err := newGraphQLClient(nil, opts)
+			if err != nil {
+				t.Fatalf("failed to create graphql client: %v", err)
+			}
 
-	t.Run("enterprise_URL", func(t *testing.T) {
-		t.Parallel()
-
-		graphQLURL := "https://ghe.example.com/api/graphql"
-		client, err := newGraphQLClient(nil, Options{GraphQLURL: &graphQLURL})
-		if err != nil {
-			t.Fatalf("failed to create graphql client with enterprise url: %v", err)
-		}
-
-		if client == nil {
-			t.Fatal("expected graphql client to be non-nil")
-		}
-	})
+			if client == nil {
+				t.Fatal("expected graphql client to be non-nil")
+			}
+		})
+	}
 }
 
 func TestNewAnonymousGraphQLClient(t *testing.T) {
 	t.Parallel()
 
-	client, err := NewAnonymousGraphQLClient(Options{})
+	client, err := NewAnonymousGraphQLClient(testOptions(t))
 	if err != nil {
 		t.Fatalf("failed to create anonymous graphql client: %v", err)
 	}
@@ -48,28 +51,42 @@ func TestNewAnonymousGraphQLClient(t *testing.T) {
 
 func TestNewAppGraphQLClient(t *testing.T) {
 	t.Parallel()
+	privateKeyData := mustReadTestAppPrivateKey(t)
 
-	t.Run("invalid_private_key", func(t *testing.T) {
-		t.Parallel()
+	for _, tt := range []struct {
+		name       string
+		privateKey []byte
+		expectErr  bool
+	}{
+		{
+			name:       "invalid_private_key",
+			privateKey: []byte("invalid-private-key"),
+			expectErr:  true,
+		},
+		{
+			name:       "valid_private_key",
+			privateKey: privateKeyData,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-		_, err := NewAppGraphQLClient("123456789", []byte("invalid-private-key"), nil, Options{})
-		if err == nil {
-			t.Fatal("expected app graphql client creation to fail for invalid private key")
-		}
-	})
+			client, err := NewAppGraphQLClient("123456789", tt.privateKey, nil, testOptions(t))
+			if tt.expectErr {
+				if err == nil {
+					t.Fatal("expected app graphql client creation to fail for invalid private key")
+				}
 
-	t.Run("valid_private_key", func(t *testing.T) {
-		t.Parallel()
+				return
+			}
 
-		privateKeyData := mustReadTestAppPrivateKey(t)
+			if err != nil {
+				t.Fatalf("failed to create app graphql client: %v", err)
+			}
 
-		client, err := NewAppGraphQLClient("123456789", privateKeyData, nil, Options{})
-		if err != nil {
-			t.Fatalf("failed to create app graphql client: %v", err)
-		}
-
-		if client == nil {
-			t.Fatal("expected app graphql client to be non-nil")
-		}
-	})
+			if client == nil {
+				t.Fatal("expected app graphql client to be non-nil")
+			}
+		})
+	}
 }

--- a/internal/ghclient/graphql_test.go
+++ b/internal/ghclient/graphql_test.go
@@ -10,9 +10,7 @@ import (
 func TestNewAnonymousGraphQLClient(t *testing.T) {
 	t.Parallel()
 
-	opts := Options{
-		GraphQLURL: "https://api.github.com/graphql",
-	}
+	opts := Options{}
 
 	client, err := NewAnonymousGraphQLClient(opts)
 	if err != nil {
@@ -40,19 +38,19 @@ func TestNewAppGraphQLClient(t *testing.T) {
 			name:           "app_client",
 			privateKey:     privateKeyData,
 			installationID: nil,
-			opts:           Options{GraphQLURL: "https://api.github.com/graphql"},
+			opts:           Options{},
 		},
 		{
 			name:           "installation_client",
 			privateKey:     privateKeyData,
 			installationID: new(int64(8888)),
-			opts:           Options{GraphQLURL: "https://api.github.com/graphql"},
+			opts:           Options{},
 		},
 		{
 			name:           "handles_token_source_error",
 			privateKey:     []byte("invalid-private-key"),
 			installationID: nil,
-			opts:           Options{GraphQLURL: "https://api.github.com/graphql"},
+			opts:           Options{},
 			wantErr:        "failed to create app token source",
 		},
 	} {
@@ -86,9 +84,7 @@ func TestNewAppGraphQLClient(t *testing.T) {
 func TestNewTokenGraphQLClient(t *testing.T) {
 	t.Parallel()
 
-	opts := Options{
-		GraphQLURL: "https://api.github.com/graphql",
-	}
+	opts := Options{}
 
 	client, err := NewTokenGraphQLClient("test-token", opts)
 	if err != nil {
@@ -110,19 +106,24 @@ func Test_newGraphQLClient(t *testing.T) {
 		wantErr     string
 	}{
 		{
-			name:        "with_token_source",
-			tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
-			opts:        Options{GraphQLURL: "https://api.github.com/graphql"},
+			name:        "minimal",
+			tokenSource: nil,
+			opts:        Options{},
 		},
 		{
-			name:        "without_token_source",
+			name:        "with_token_source",
+			tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
+			opts:        Options{},
+		},
+		{
+			name:        "with_url",
 			tokenSource: nil,
 			opts:        Options{GraphQLURL: "https://api.github.com/graphql"},
 		},
 		{
 			name:        "errors_if_transport_cannot_be_created",
 			tokenSource: nil,
-			opts:        Options{GraphQLURL: "https://api.github.com/graphql", CachePath: "\x00c"},
+			opts:        Options{CachePath: "\x00c"},
 			wantErr:     "failed to create transport",
 		},
 	} {

--- a/internal/ghclient/helpers_test.go
+++ b/internal/ghclient/helpers_test.go
@@ -1,30 +1,40 @@
 package ghclient
 
 import (
-	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 )
 
-type staticRoundTripper struct{}
-
-func (s *staticRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
-	return nil, fmt.Errorf("not used")
+type testRoundTripper struct {
+	called atomic.Int32
+	resp   *http.Response
+	err    error
 }
 
-func testOptions(t *testing.T) Options {
+func (r *testRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	r.called.Add(1)
+	if r.err != nil {
+		return nil, r.err
+	}
+
+	return r.resp, nil
+}
+
+func mustMkdirTemp(t *testing.T, dir, pattern string) string {
 	t.Helper()
 
-	return Options{
-		RESTAPIURL: "https://api.github.com/",
-		GraphQLURL: "https://api.github.com/graphql",
+	dir, err := os.MkdirTemp(dir, pattern) //nolint:usetesting
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
 	}
+
+	return dir
 }
 
-func mustReadTestAppPrivateKey(t *testing.T) []byte {
+func mustReadAppPrivateKey(t *testing.T) []byte {
 	t.Helper()
 
 	privateKeyData, err := os.ReadFile(filepath.Join("..", "..", "github", "test-fixtures", "github-app-key.pem"))
@@ -33,24 +43,4 @@ func mustReadTestAppPrivateKey(t *testing.T) []byte {
 	}
 
 	return privateKeyData
-}
-
-func mustTestAppSource(t *testing.T, handler http.Handler) *appSource {
-	t.Helper()
-
-	ts := httptest.NewServer(handler)
-	t.Cleanup(ts.Close)
-
-	privateKeyData := mustReadTestAppPrivateKey(t)
-
-	apiURL := ts.URL + "/"
-	opts := testOptions(t)
-	opts.RESTAPIURL = apiURL
-
-	source, err := NewAppSource("123456789", privateKeyData, opts)
-	if err != nil {
-		t.Fatalf("failed to create app source: %v", err)
-	}
-
-	return source
 }

--- a/internal/ghclient/helpers_test.go
+++ b/internal/ghclient/helpers_test.go
@@ -15,6 +15,15 @@ func (s *staticRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) 
 	return nil, fmt.Errorf("not used")
 }
 
+func testOptions(t *testing.T) Options {
+	t.Helper()
+
+	return Options{
+		RESTAPIURL: "https://api.github.com/",
+		GraphQLURL: "https://api.github.com/graphql",
+	}
+}
+
 func mustReadTestAppPrivateKey(t *testing.T) []byte {
 	t.Helper()
 
@@ -35,9 +44,10 @@ func mustTestAppSource(t *testing.T, handler http.Handler) *appSource {
 	privateKeyData := mustReadTestAppPrivateKey(t)
 
 	apiURL := ts.URL + "/"
-	uploadURL := ts.URL + "/"
+	opts := testOptions(t)
+	opts.RESTAPIURL = apiURL
 
-	source, err := NewAppSource("123456789", privateKeyData, Options{RESTAPIURL: &apiURL, RESTUploadURL: &uploadURL})
+	source, err := NewAppSource("123456789", privateKeyData, opts)
 	if err != nil {
 		t.Fatalf("failed to create app source: %v", err)
 	}

--- a/internal/ghclient/options.go
+++ b/internal/ghclient/options.go
@@ -10,6 +10,7 @@ import (
 type Options struct {
 	RESTAPIURL   string
 	GraphQLURL   string
+	UserAgent    string
 	CachePath    string
 	RetryMax     int
 	RetryWaitMin time.Duration

--- a/internal/ghclient/options.go
+++ b/internal/ghclient/options.go
@@ -1,15 +1,23 @@
 package ghclient
 
-import "time"
+import (
+	"time"
+
+	"golang.org/x/sync/semaphore"
+)
 
 // Options defines the configuration options for creating GitHub clients.
 type Options struct {
-	RESTAPIURL    *string
-	RESTUploadURL *string
-	GraphQLURL    *string
-	CachePath     *string
-	cacheRef      *string
-	RetryMax      int
-	RetryWaitMin  time.Duration
-	RetryWaitMax  time.Duration
+	RESTAPIURL   string
+	GraphQLURL   string
+	CachePath    string
+	RetryMax     int
+	RetryWaitMin time.Duration
+	RetryWaitMax time.Duration
+
+	// Set per usage.
+	sema            *semaphore.Weighted
+	maxIdleConns    int
+	idleConnTimeout time.Duration
+	cacheRef        string
 }

--- a/internal/ghclient/rest.go
+++ b/internal/ghclient/rest.go
@@ -41,5 +41,19 @@ func newRESTClient(tokenSource oauth2.TokenSource, opts Options) (*github.Client
 		return nil, fmt.Errorf("failed to create transport: %w", err)
 	}
 
-	return github.NewClient(github.WithTransport(tr), github.WithTimeout(clientTimeout), github.WithDisableRateLimitCheck(), github.WithURLs(&opts.RESTAPIURL, nil))
+	clientOpts := []github.ClientOptionsFunc{
+		github.WithTransport(tr),
+		github.WithTimeout(clientTimeout),
+		github.WithDisableRateLimitCheck(),
+	}
+
+	if opts.UserAgent != "" {
+		clientOpts = append(clientOpts, github.WithUserAgent(opts.UserAgent))
+	}
+
+	if opts.RESTAPIURL != "" {
+		clientOpts = append(clientOpts, github.WithURLs(&opts.RESTAPIURL, nil))
+	}
+
+	return github.NewClient(clientOpts...)
 }

--- a/internal/ghclient/rest.go
+++ b/internal/ghclient/rest.go
@@ -9,12 +9,12 @@ import (
 )
 
 // NewAnonymousRESTClient creates a new GitHub client that is unauthenticated. This client will have limited access to public resources and will be subject to stricter rate limits compared to authenticated clients.
-func NewAnonymousRESTClient(options Options) (*github.Client, error) {
-	return newRESTClient(nil, options)
+func NewAnonymousRESTClient(opts Options) (*github.Client, error) {
+	return newRESTClient(nil, opts)
 }
 
 // NewAppRESTClient creates a new GitHub client authenticated as either the app itself (if installationID is nil) or as the specified installation (if installationID is provided), using the app's private key.
-func NewAppRESTClient(clientID string, privateKey []byte, installationID *int64, options Options) (*github.Client, error) {
+func NewAppRESTClient(clientID string, privateKey []byte, installationID *int64, opts Options) (*github.Client, error) {
 	tokenSource, err := githubauth.NewApplicationTokenSource(clientID, privateKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create app token source: %w", err)
@@ -24,14 +24,14 @@ func NewAppRESTClient(clientID string, privateKey []byte, installationID *int64,
 		tokenSource = githubauth.NewInstallationTokenSource(*installationID, tokenSource)
 	}
 
-	return newRESTClient(tokenSource, options)
+	return newRESTClient(tokenSource, opts)
 }
 
 // NewTokenRESTClient creates a new GitHub client authenticated with the provided personal access token.
-func NewTokenRESTClient(token string, options Options) (*github.Client, error) {
+func NewTokenRESTClient(token string, opts Options) (*github.Client, error) {
 	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 
-	return newRESTClient(tokenSource, options)
+	return newRESTClient(tokenSource, opts)
 }
 
 // newRESTClient creates a new GitHub client using the provided OAuth2 token source and options. It sets up the client's transport with caching and rate limit handling, and configures the client's API URLs based on the provided options.
@@ -41,5 +41,5 @@ func newRESTClient(tokenSource oauth2.TokenSource, opts Options) (*github.Client
 		return nil, fmt.Errorf("failed to create transport: %w", err)
 	}
 
-	return github.NewClient(github.WithTransport(tr), github.WithTimeout(clientTimeout), github.WithDisableRateLimitCheck(), github.WithURLs(opts.RESTAPIURL, opts.RESTUploadURL))
+	return github.NewClient(github.WithTransport(tr), github.WithTimeout(clientTimeout), github.WithDisableRateLimitCheck(), github.WithURLs(&opts.RESTAPIURL, nil))
 }

--- a/internal/ghclient/rest_test.go
+++ b/internal/ghclient/rest_test.go
@@ -7,7 +7,7 @@ import (
 func Test_newRESTClient(t *testing.T) {
 	t.Parallel()
 
-	client, err := newRESTClient(nil, Options{})
+	client, err := newRESTClient(nil, testOptions(t))
 	if err != nil {
 		t.Fatalf("failed to create rest client: %v", err)
 	}
@@ -20,7 +20,7 @@ func Test_newRESTClient(t *testing.T) {
 func TestNewAnonymousRESTClient(t *testing.T) {
 	t.Parallel()
 
-	client, err := NewAnonymousRESTClient(Options{})
+	client, err := NewAnonymousRESTClient(testOptions(t))
 	if err != nil {
 		t.Fatalf("failed to create anonymous rest client: %v", err)
 	}
@@ -32,28 +32,42 @@ func TestNewAnonymousRESTClient(t *testing.T) {
 
 func TestNewAppRESTClient(t *testing.T) {
 	t.Parallel()
+	privateKeyData := mustReadTestAppPrivateKey(t)
 
-	t.Run("invalid_private_key", func(t *testing.T) {
-		t.Parallel()
+	for _, tt := range []struct {
+		name       string
+		privateKey []byte
+		expectErr  bool
+	}{
+		{
+			name:       "invalid_private_key",
+			privateKey: []byte("invalid-private-key"),
+			expectErr:  true,
+		},
+		{
+			name:       "valid_private_key",
+			privateKey: privateKeyData,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-		_, err := NewAppRESTClient("123456789", []byte("invalid-private-key"), nil, Options{})
-		if err == nil {
-			t.Fatal("expected app rest client creation to fail for invalid private key")
-		}
-	})
+			client, err := NewAppRESTClient("123456789", tt.privateKey, nil, testOptions(t))
+			if tt.expectErr {
+				if err == nil {
+					t.Fatal("expected app rest client creation to fail for invalid private key")
+				}
 
-	t.Run("valid_private_key", func(t *testing.T) {
-		t.Parallel()
+				return
+			}
 
-		privateKeyData := mustReadTestAppPrivateKey(t)
+			if err != nil {
+				t.Fatalf("failed to create app rest client: %v", err)
+			}
 
-		client, err := NewAppRESTClient("123456789", privateKeyData, nil, Options{})
-		if err != nil {
-			t.Fatalf("failed to create app rest client: %v", err)
-		}
-
-		if client == nil {
-			t.Fatal("expected app rest client to be non-nil")
-		}
-	})
+			if client == nil {
+				t.Fatal("expected app rest client to be non-nil")
+			}
+		})
+	}
 }

--- a/internal/ghclient/rest_test.go
+++ b/internal/ghclient/rest_test.go
@@ -1,26 +1,20 @@
 package ghclient
 
 import (
+	"regexp"
 	"testing"
+
+	"golang.org/x/oauth2"
 )
-
-func Test_newRESTClient(t *testing.T) {
-	t.Parallel()
-
-	client, err := newRESTClient(nil, testOptions(t))
-	if err != nil {
-		t.Fatalf("failed to create rest client: %v", err)
-	}
-
-	if client == nil {
-		t.Fatal("expected rest client to be non-nil")
-	}
-}
 
 func TestNewAnonymousRESTClient(t *testing.T) {
 	t.Parallel()
 
-	client, err := NewAnonymousRESTClient(testOptions(t))
+	opts := Options{
+		RESTAPIURL: "https://api.github.com/",
+	}
+
+	client, err := NewAnonymousRESTClient(opts)
 	if err != nil {
 		t.Fatalf("failed to create anonymous rest client: %v", err)
 	}
@@ -32,41 +26,128 @@ func TestNewAnonymousRESTClient(t *testing.T) {
 
 func TestNewAppRESTClient(t *testing.T) {
 	t.Parallel()
-	privateKeyData := mustReadTestAppPrivateKey(t)
+
+	privateKeyData := mustReadAppPrivateKey(t)
 
 	for _, tt := range []struct {
-		name       string
-		privateKey []byte
-		expectErr  bool
+		name           string
+		privateKey     []byte
+		installationID *int64
+		opts           Options
+		wantErr        string
 	}{
 		{
-			name:       "invalid_private_key",
-			privateKey: []byte("invalid-private-key"),
-			expectErr:  true,
+			name:           "app_client",
+			privateKey:     privateKeyData,
+			installationID: nil,
+			opts:           Options{RESTAPIURL: "https://api.github.com/"},
 		},
 		{
-			name:       "valid_private_key",
-			privateKey: privateKeyData,
+			name:           "installation_client",
+			privateKey:     privateKeyData,
+			installationID: new(int64(8888)),
+			opts:           Options{RESTAPIURL: "https://api.github.com/"},
+		},
+		{
+			name:           "handles_token_source_error",
+			privateKey:     []byte("invalid-private-key"),
+			installationID: nil,
+			opts:           Options{RESTAPIURL: "https://api.github.com/"},
+			wantErr:        "failed to create app token source",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			client, err := NewAppRESTClient("123456789", tt.privateKey, nil, testOptions(t))
-			if tt.expectErr {
-				if err == nil {
-					t.Fatal("expected app rest client creation to fail for invalid private key")
+			client, err := NewAppRESTClient("123456789", tt.privateKey, tt.installationID, tt.opts)
+			if err != nil {
+				if tt.wantErr == "" {
+					t.Fatalf("failed to create app rest client: %v", err)
+				}
+
+				if !regexp.MustCompile(regexp.QuoteMeta(tt.wantErr)).MatchString(err.Error()) {
+					t.Fatalf("expected error to match %q, got %v", tt.wantErr, err)
 				}
 
 				return
 			}
 
-			if err != nil {
-				t.Fatalf("failed to create app rest client: %v", err)
+			if tt.wantErr != "" {
+				t.Fatalf("expected error %q, got nil", tt.wantErr)
 			}
 
 			if client == nil {
 				t.Fatal("expected app rest client to be non-nil")
+			}
+		})
+	}
+}
+
+func TestNewTokenRESTClient(t *testing.T) {
+	t.Parallel()
+
+	opts := Options{
+		RESTAPIURL: "https://api.github.com/",
+	}
+
+	client, err := NewTokenRESTClient("test-token", opts)
+	if err != nil {
+		t.Fatalf("failed to create token rest client: %v", err)
+	}
+
+	if client == nil {
+		t.Fatal("expected token rest client to be non-nil")
+	}
+}
+
+func Test_newRESTClient(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name        string
+		tokenSource oauth2.TokenSource
+		opts        Options
+		wantErr     string
+	}{
+		{
+			name:        "with_token_source",
+			tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
+			opts:        Options{RESTAPIURL: "https://api.github.com/"},
+		},
+		{
+			name:        "without_token_source",
+			tokenSource: nil,
+			opts:        Options{RESTAPIURL: "https://api.github.com/"},
+		},
+		{
+			name:        "errors_if_transport_cannot_be_created",
+			tokenSource: nil,
+			opts:        Options{RESTAPIURL: "https://api.github.com/", CachePath: "\x00c"},
+			wantErr:     "failed to create transport",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := newRESTClient(tt.tokenSource, tt.opts)
+			if err != nil {
+				if tt.wantErr == "" {
+					t.Fatalf("failed to create rest client: %v", err)
+				}
+
+				if !regexp.MustCompile(regexp.QuoteMeta(tt.wantErr)).MatchString(err.Error()) {
+					t.Fatalf("expected error to match %q, got %v", tt.wantErr, err)
+				}
+
+				return
+			}
+
+			if tt.wantErr != "" {
+				t.Fatalf("expected error %q, got nil", tt.wantErr)
+			}
+
+			if got == nil {
+				t.Fatal("expected rest client to be non-nil")
 			}
 		})
 	}

--- a/internal/ghclient/rest_test.go
+++ b/internal/ghclient/rest_test.go
@@ -10,9 +10,7 @@ import (
 func TestNewAnonymousRESTClient(t *testing.T) {
 	t.Parallel()
 
-	opts := Options{
-		RESTAPIURL: "https://api.github.com/",
-	}
+	opts := Options{}
 
 	client, err := NewAnonymousRESTClient(opts)
 	if err != nil {
@@ -40,19 +38,19 @@ func TestNewAppRESTClient(t *testing.T) {
 			name:           "app_client",
 			privateKey:     privateKeyData,
 			installationID: nil,
-			opts:           Options{RESTAPIURL: "https://api.github.com/"},
+			opts:           Options{},
 		},
 		{
 			name:           "installation_client",
 			privateKey:     privateKeyData,
 			installationID: new(int64(8888)),
-			opts:           Options{RESTAPIURL: "https://api.github.com/"},
+			opts:           Options{},
 		},
 		{
 			name:           "handles_token_source_error",
 			privateKey:     []byte("invalid-private-key"),
 			installationID: nil,
-			opts:           Options{RESTAPIURL: "https://api.github.com/"},
+			opts:           Options{},
 			wantErr:        "failed to create app token source",
 		},
 	} {
@@ -86,9 +84,7 @@ func TestNewAppRESTClient(t *testing.T) {
 func TestNewTokenRESTClient(t *testing.T) {
 	t.Parallel()
 
-	opts := Options{
-		RESTAPIURL: "https://api.github.com/",
-	}
+	opts := Options{}
 
 	client, err := NewTokenRESTClient("test-token", opts)
 	if err != nil {
@@ -110,19 +106,29 @@ func Test_newRESTClient(t *testing.T) {
 		wantErr     string
 	}{
 		{
-			name:        "with_token_source",
-			tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
-			opts:        Options{RESTAPIURL: "https://api.github.com/"},
+			name:        "minimal",
+			tokenSource: nil,
+			opts:        Options{},
 		},
 		{
-			name:        "without_token_source",
+			name:        "with_token_source",
+			tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
+			opts:        Options{},
+		},
+		{
+			name:        "with_user_agent",
+			tokenSource: nil,
+			opts:        Options{UserAgent: "test-user-agent"},
+		},
+		{
+			name:        "with_url",
 			tokenSource: nil,
 			opts:        Options{RESTAPIURL: "https://api.github.com/"},
 		},
 		{
 			name:        "errors_if_transport_cannot_be_created",
 			tokenSource: nil,
-			opts:        Options{RESTAPIURL: "https://api.github.com/", CachePath: "\x00c"},
+			opts:        Options{CachePath: "\x00c"},
 			wantErr:     "failed to create transport",
 		},
 	} {

--- a/internal/ghclient/throttle.go
+++ b/internal/ghclient/throttle.go
@@ -1,0 +1,51 @@
+package ghclient
+
+import (
+	"io"
+	"net/http"
+	"sync"
+
+	"golang.org/x/sync/semaphore"
+)
+
+// throttlerReadCloser is a wrapper around an io.ReadCloser that releases a semaphore weight when the ReadCloser is closed. This is used to ensure that the semaphore controlling concurrent requests is properly released after the response body has been fully read and closed, preventing resource leaks and allowing other requests to proceed.
+type throttlerReadCloser struct {
+	io.ReadCloser
+	sema *semaphore.Weighted
+	once sync.Once
+}
+
+// Close releases the semaphore weight when the ReadCloser is closed. It ensures that the release operation is only performed once, even if Close is called multiple times, preventing potential double-release issues that could lead to incorrect semaphore state.
+func (c *throttlerReadCloser) Close() error {
+	err := c.ReadCloser.Close()
+	c.once.Do(func() {
+		c.sema.Release(1)
+	})
+	return err
+}
+
+// throttler is an HTTP RoundTripper that limits the number of concurrent requests to a specified maximum. It uses a weighted semaphore to control access to the underlying RoundTripper, ensuring that no more than the allowed number of requests are in flight at any given time. This is useful for preventing overwhelming a server or API with too many simultaneous requests.
+type throttler struct {
+	sema  *semaphore.Weighted
+	inner http.RoundTripper
+}
+
+// RoundTrip implements the http.RoundTripper interface for the throttler. It acquires a semaphore weight before proceeding with the request, ensuring that the number of concurrent requests does not exceed the specified limit. After the request is completed, it releases the semaphore weight, allowing other requests to proceed. If acquiring the semaphore fails, it returns an error.
+func (t *throttler) RoundTrip(req *http.Request) (*http.Response, error) {
+	if err := t.sema.Acquire(req.Context(), 1); err != nil {
+		return nil, err
+	}
+
+	res, err := t.inner.RoundTrip(req)
+	if err != nil {
+		t.sema.Release(1)
+		return nil, err
+	}
+
+	res.Body = &throttlerReadCloser{
+		ReadCloser: res.Body,
+		sema:       t.sema,
+	}
+
+	return res, nil
+}

--- a/internal/ghclient/throttle_test.go
+++ b/internal/ghclient/throttle_test.go
@@ -1,0 +1,171 @@
+package ghclient
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+)
+
+type testRoundTripper struct {
+	called atomic.Int32
+	resp   *http.Response
+	err    error
+}
+
+func (r *testRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	r.called.Add(1)
+	if r.err != nil {
+		return nil, r.err
+	}
+
+	return r.resp, nil
+}
+
+func Test_throttlerReadCloser_Close_releases_once(t *testing.T) {
+	t.Parallel()
+
+	sema := semaphore.NewWeighted(1)
+	if err := sema.Acquire(t.Context(), 1); err != nil {
+		t.Fatalf("failed to acquire semaphore for setup: %v", err)
+	}
+
+	rc := &throttlerReadCloser{
+		ReadCloser: io.NopCloser(strings.NewReader("ok")),
+		sema:       sema,
+	}
+
+	if err := rc.Close(); err != nil {
+		t.Fatalf("failed to close read closer: %v", err)
+	}
+
+	if err := rc.Close(); err != nil {
+		t.Fatalf("failed to close read closer on second close: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	if err := sema.Acquire(ctx, 1); err != nil {
+		t.Fatalf("expected semaphore to be released after close, got error: %v", err)
+	}
+
+	ctx2, cancel2 := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	defer cancel2()
+
+	if err := sema.Acquire(ctx2, 1); err == nil {
+		t.Fatal("expected second acquire to fail because close should release exactly once")
+	}
+}
+
+func Test_throttler_RoundTrip_acquire_error(t *testing.T) {
+	t.Parallel()
+
+	inner := &testRoundTripper{}
+	tr := &throttler{
+		sema:  semaphore.NewWeighted(1),
+		inner: inner,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	_, err = tr.RoundTrip(req)
+	if err == nil {
+		t.Fatal("expected acquire error from canceled context")
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled error, got %v", err)
+	}
+
+	if inner.called.Load() != 0 {
+		t.Fatalf("expected inner transport not to be called, got %d calls", inner.called.Load())
+	}
+}
+
+func Test_throttler_RoundTrip_inner_error_releases_semaphore(t *testing.T) {
+	t.Parallel()
+
+	inner := &testRoundTripper{err: errors.New("boom")}
+	sema := semaphore.NewWeighted(1)
+	tr := &throttler{
+		sema:  sema,
+		inner: inner,
+	}
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	_, err = tr.RoundTrip(req)
+	if err == nil {
+		t.Fatal("expected round trip to fail")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	if err := sema.Acquire(ctx, 1); err != nil {
+		t.Fatalf("expected semaphore to be released when inner transport fails, got %v", err)
+	}
+
+	if inner.called.Load() != 1 {
+		t.Fatalf("expected inner transport to be called once, got %d", inner.called.Load())
+	}
+}
+
+func Test_throttler_RoundTrip_success_releases_on_body_close(t *testing.T) {
+	t.Parallel()
+
+	inner := &testRoundTripper{resp: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("ok"))}}
+	sema := semaphore.NewWeighted(1)
+	tr := &throttler{
+		sema:  sema,
+		inner: inner,
+	}
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("expected round trip to succeed, got error: %v", err)
+	}
+
+	blockedCtx, blockedCancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	defer blockedCancel()
+
+	if err := sema.Acquire(blockedCtx, 1); err == nil {
+		t.Fatal("expected acquire to block before response body is closed")
+	}
+
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("failed to close response body: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	if err := sema.Acquire(ctx, 1); err != nil {
+		t.Fatalf("expected semaphore to be released after closing response body, got %v", err)
+	}
+
+	if inner.called.Load() != 1 {
+		t.Fatalf("expected inner transport to be called once, got %d", inner.called.Load())
+	}
+}

--- a/internal/ghclient/throttle_test.go
+++ b/internal/ghclient/throttle_test.go
@@ -6,29 +6,12 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"sync/atomic"
 	"testing"
-	"time"
 
 	"golang.org/x/sync/semaphore"
 )
 
-type testRoundTripper struct {
-	called atomic.Int32
-	resp   *http.Response
-	err    error
-}
-
-func (r *testRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
-	r.called.Add(1)
-	if r.err != nil {
-		return nil, r.err
-	}
-
-	return r.resp, nil
-}
-
-func Test_throttlerReadCloser_Close_releases_once(t *testing.T) {
+func Test_throttlerReadCloser_Close(t *testing.T) {
 	t.Parallel()
 
 	sema := semaphore.NewWeighted(1)
@@ -48,124 +31,108 @@ func Test_throttlerReadCloser_Close_releases_once(t *testing.T) {
 	if err := rc.Close(); err != nil {
 		t.Fatalf("failed to close read closer on second close: %v", err)
 	}
-
-	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
-	defer cancel()
-
-	if err := sema.Acquire(ctx, 1); err != nil {
-		t.Fatalf("expected semaphore to be released after close, got error: %v", err)
-	}
-
-	ctx2, cancel2 := context.WithTimeout(t.Context(), 10*time.Millisecond)
-	defer cancel2()
-
-	if err := sema.Acquire(ctx2, 1); err == nil {
-		t.Fatal("expected second acquire to fail because close should release exactly once")
-	}
 }
 
-func Test_throttler_RoundTrip_acquire_error(t *testing.T) {
+func Test_throttler_RoundTrip(t *testing.T) {
 	t.Parallel()
 
-	inner := &testRoundTripper{}
-	tr := &throttler{
-		sema:  semaphore.NewWeighted(1),
-		inner: inner,
-	}
+	t.Run("handles_acquire_error", func(t *testing.T) {
+		t.Parallel()
 
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
+		inner := &testRoundTripper{}
+		tr := &throttler{
+			sema:  semaphore.NewWeighted(1),
+			inner: inner,
+		}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com", nil)
-	if err != nil {
-		t.Fatalf("failed to create request: %v", err)
-	}
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
 
-	_, err = tr.RoundTrip(req)
-	if err == nil {
-		t.Fatal("expected acquire error from canceled context")
-	}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com", nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %v", err)
+		}
 
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("expected context canceled error, got %v", err)
-	}
+		_, err = tr.RoundTrip(req)
+		if err == nil {
+			t.Fatal("expected acquire error from canceled context")
+		}
 
-	if inner.called.Load() != 0 {
-		t.Fatalf("expected inner transport not to be called, got %d calls", inner.called.Load())
-	}
-}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context canceled error, got %v", err)
+		}
 
-func Test_throttler_RoundTrip_inner_error_releases_semaphore(t *testing.T) {
-	t.Parallel()
+		if inner.called.Load() != 0 {
+			t.Fatalf("expected inner transport not to be called, got %d calls", inner.called.Load())
+		}
+	})
 
-	inner := &testRoundTripper{err: errors.New("boom")}
-	sema := semaphore.NewWeighted(1)
-	tr := &throttler{
-		sema:  sema,
-		inner: inner,
-	}
+	t.Run("handles_inner_error", func(t *testing.T) {
+		t.Parallel()
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com", nil)
-	if err != nil {
-		t.Fatalf("failed to create request: %v", err)
-	}
+		inner := &testRoundTripper{err: errors.New("boom")}
+		tr := &throttler{
+			sema:  semaphore.NewWeighted(1),
+			inner: inner,
+		}
 
-	_, err = tr.RoundTrip(req)
-	if err == nil {
-		t.Fatal("expected round trip to fail")
-	}
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com", nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %v", err)
+		}
 
-	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
-	defer cancel()
+		_, err = tr.RoundTrip(req)
+		if err == nil {
+			t.Fatal("expected round trip to fail")
+		}
 
-	if err := sema.Acquire(ctx, 1); err != nil {
-		t.Fatalf("expected semaphore to be released when inner transport fails, got %v", err)
-	}
+		if !errors.Is(err, inner.err) {
+			t.Fatalf("expected inner transport error, got %v", err)
+		}
 
-	if inner.called.Load() != 1 {
-		t.Fatalf("expected inner transport to be called once, got %d", inner.called.Load())
-	}
-}
+		if inner.called.Load() != 1 {
+			t.Fatalf("expected inner transport to be called once, got %d calls", inner.called.Load())
+		}
+	})
 
-func Test_throttler_RoundTrip_success_releases_on_body_close(t *testing.T) {
-	t.Parallel()
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
 
-	inner := &testRoundTripper{resp: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("ok"))}}
-	sema := semaphore.NewWeighted(1)
-	tr := &throttler{
-		sema:  sema,
-		inner: inner,
-	}
+		inner := &testRoundTripper{resp: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("ok"))}}
+		sema := semaphore.NewWeighted(1)
+		tr := &throttler{
+			sema:  sema,
+			inner: inner,
+		}
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com", nil)
-	if err != nil {
-		t.Fatalf("failed to create request: %v", err)
-	}
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com", nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %v", err)
+		}
 
-	resp, err := tr.RoundTrip(req)
-	if err != nil {
-		t.Fatalf("expected round trip to succeed, got error: %v", err)
-	}
+		resp, err := tr.RoundTrip(req)
+		if err != nil {
+			t.Fatalf("expected round trip to succeed, got error: %v", err)
+		}
 
-	blockedCtx, blockedCancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
-	defer blockedCancel()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status code 200 OK, got %d", resp.StatusCode)
+		}
 
-	if err := sema.Acquire(blockedCtx, 1); err == nil {
-		t.Fatal("expected acquire to block before response body is closed")
-	}
+		if inner.called.Load() != 1 {
+			t.Fatalf("expected inner transport to be called once, got %d calls", inner.called.Load())
+		}
 
-	if err := resp.Body.Close(); err != nil {
-		t.Fatalf("failed to close response body: %v", err)
-	}
+		if ok := sema.TryAcquire(1); ok {
+			t.Fatal("expected semaphore to be held until response body is closed")
+		}
 
-	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
-	defer cancel()
+		if err := resp.Body.Close(); err != nil {
+			t.Fatalf("failed to close response body: %v", err)
+		}
 
-	if err := sema.Acquire(ctx, 1); err != nil {
-		t.Fatalf("expected semaphore to be released after closing response body, got %v", err)
-	}
-
-	if inner.called.Load() != 1 {
-		t.Fatalf("expected inner transport to be called once, got %d", inner.called.Load())
-	}
+		if ok := sema.TryAcquire(1); !ok {
+			t.Fatal("expected semaphore to be released after closing response body")
+		}
+	})
 }

--- a/internal/ghclient/token.go
+++ b/internal/ghclient/token.go
@@ -2,34 +2,49 @@ package ghclient
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	"github.com/google/go-github/v88/github"
 	"github.com/shurcooL/githubv4"
+	"golang.org/x/sync/semaphore"
 )
 
 // tokenSource is a concrete implementation of a [Source] that uses the provided token credentials to create GitHub clients.
 type tokenSource struct {
-	token         string
 	restClient    *github.Client
 	graphQLClient *githubv4.Client
 }
 
 // NewTokenSource creates a new tokenSource that provides a GitHub client authenticated with the provided personal access token.
-func NewTokenSource(token string, options Options) (*tokenSource, error) {
-	options.cacheRef = new("token-rest")
-	client, err := NewTokenRESTClient(token, options)
+func NewTokenSource(token string, opts Options) (*tokenSource, error) {
+	if opts.CachePath == "" {
+		s, err := os.MkdirTemp("", "*")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create temporary cache directory: %w", err)
+		}
+		opts.CachePath = s
+	}
+
+	opts.sema = semaphore.NewWeighted(maxConcurrentRequests)
+
+	opts.maxIdleConns = maxIdleConnsREST
+	opts.idleConnTimeout = idleConnTimeoutREST
+	opts.cacheRef = "token-rest"
+	client, err := NewTokenRESTClient(token, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	options.cacheRef = new("token-graphql")
-	graphQLClient, err := NewTokenGraphQLClient(token, options)
+	opts.maxIdleConns = maxIdleConnsGraphQL
+	opts.idleConnTimeout = idleConnTimeoutGraphQL
+	opts.cacheRef = "token-graphql"
+	graphQLClient, err := NewTokenGraphQLClient(token, opts)
 	if err != nil {
 		return nil, err
 	}
 
 	return &tokenSource{
-		token:         token,
 		restClient:    client,
 		graphQLClient: graphQLClient,
 	}, nil

--- a/internal/ghclient/token_test.go
+++ b/internal/ghclient/token_test.go
@@ -1,130 +1,105 @@
 package ghclient
 
 import (
+	"os"
 	"testing"
 )
 
 func TestNewTokenSource(t *testing.T) {
 	t.Parallel()
 
-	source, err := NewTokenSource("test-token", testOptions(t))
-	if err != nil {
-		t.Fatalf("failed to create token source: %v", err)
-	}
+	cacheBasePath := mustMkdirTemp(t, "", "*")
+	t.Cleanup(func() {
+		_ = os.RemoveAll(cacheBasePath)
+	})
 
-	if source == nil {
-		t.Fatal("expected token source to be non-nil")
-	}
-}
+	for _, tt := range []struct {
+		name string
+		opts Options
+	}{
+		{
+			name: "default",
+			opts: Options{
+				RESTAPIURL: "https://api.github.com/",
+				GraphQLURL: "https://api.github.com/graphql",
+			},
+		},
+		{
+			name: "with_cache_path",
+			opts: Options{
+				RESTAPIURL: "https://api.github.com/",
+				GraphQLURL: "https://api.github.com/graphql",
+				CachePath:  mustMkdirTemp(t, cacheBasePath, "*"),
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-func TestNewTokenRESTClient(t *testing.T) {
-	t.Parallel()
+			source, err := NewTokenSource("test-token", tt.opts)
+			if err != nil {
+				t.Fatalf("failed to create token source: %v", err)
+			}
 
-	client, err := NewTokenRESTClient("test-token", testOptions(t))
-	if err != nil {
-		t.Fatalf("failed to create token rest client: %v", err)
-	}
-
-	if client == nil {
-		t.Fatal("expected token rest client to be non-nil")
-	}
-}
-
-func TestNewTokenGraphQLClient(t *testing.T) {
-	t.Parallel()
-
-	client, err := NewTokenGraphQLClient("test-token", testOptions(t))
-	if err != nil {
-		t.Fatalf("failed to create token graphql client: %v", err)
-	}
-
-	if client == nil {
-		t.Fatal("expected token graphql client to be non-nil")
+			if source == nil {
+				t.Fatal("expected token source to be non-nil")
+			}
+		})
 	}
 }
 
 func Test_tokenSource(t *testing.T) {
 	t.Parallel()
 
-	t.Run("RESTClient", func(t *testing.T) {
-		t.Parallel()
-
-		source, err := NewTokenSource("test-token", testOptions(t))
-		if err != nil {
-			t.Fatalf("failed to create token source: %v", err)
-		}
-
-		client, err := source.RESTClient()
-		if err != nil {
-			t.Fatalf("failed to get rest client: %v", err)
-		}
-
-		if client == nil {
-			t.Fatal("expected rest client to be non-nil")
-		}
+	cacheBasePath := mustMkdirTemp(t, "", "*")
+	t.Cleanup(func() {
+		_ = os.RemoveAll(cacheBasePath)
 	})
 
-	t.Run("OwnerRESTClient", func(t *testing.T) {
-		t.Parallel()
+	opts := Options{
+		RESTAPIURL: "https://api.github.com/",
+		GraphQLURL: "https://api.github.com/graphql",
+		CachePath:  mustMkdirTemp(t, cacheBasePath, "*"),
+	}
 
-		source, err := NewTokenSource("test-token", testOptions(t))
-		if err != nil {
-			t.Fatalf("failed to create token source: %v", err)
-		}
+	source, err := NewTokenSource("test-token", opts)
+	if err != nil {
+		t.Fatalf("failed to create token source: %v", err)
+	}
 
-		defaultClient, err := source.RESTClient()
-		if err != nil {
-			t.Fatalf("failed to get default rest client: %v", err)
-		}
+	restClient, err := source.RESTClient()
+	if err != nil {
+		t.Fatalf("failed to get rest client: %v", err)
+	}
 
-		ownerClient, err := source.OwnerRESTClient(t.Context(), "octocat")
-		if err != nil {
-			t.Fatalf("failed to get owner rest client: %v", err)
-		}
+	if restClient == nil {
+		t.Fatal("expected rest client to be non-nil")
+	}
 
-		if ownerClient != defaultClient {
-			t.Fatal("expected owner rest client to be the same client as default rest client")
-		}
-	})
+	ownerRESTClient, err := source.OwnerRESTClient(t.Context(), "octocat")
+	if err != nil {
+		t.Fatalf("failed to get owner rest client: %v", err)
+	}
 
-	t.Run("GraphQLClient", func(t *testing.T) {
-		t.Parallel()
+	if ownerRESTClient != restClient {
+		t.Fatal("expected owner rest client to be the same client as default rest client")
+	}
 
-		source, err := NewTokenSource("test-token", testOptions(t))
-		if err != nil {
-			t.Fatalf("failed to create token source: %v", err)
-		}
+	graphQLClient, err := source.GraphQLClient()
+	if err != nil {
+		t.Fatalf("failed to get graphql client: %v", err)
+	}
 
-		client, err := source.GraphQLClient()
-		if err != nil {
-			t.Fatalf("failed to get graphql client: %v", err)
-		}
+	if graphQLClient == nil {
+		t.Fatal("expected graphql client to be non-nil")
+	}
 
-		if client == nil {
-			t.Fatal("expected graphql client to be non-nil")
-		}
-	})
+	ownerGraphQLClient, err := source.OwnerGraphQLClient(t.Context(), "octocat")
+	if err != nil {
+		t.Fatalf("failed to get owner graphql client: %v", err)
+	}
 
-	t.Run("OwnerGraphQLClient", func(t *testing.T) {
-		t.Parallel()
-
-		source, err := NewTokenSource("test-token", testOptions(t))
-		if err != nil {
-			t.Fatalf("failed to create token source: %v", err)
-		}
-
-		defaultClient, err := source.GraphQLClient()
-		if err != nil {
-			t.Fatalf("failed to get default graphql client: %v", err)
-		}
-
-		ownerClient, err := source.OwnerGraphQLClient(t.Context(), "octocat")
-		if err != nil {
-			t.Fatalf("failed to get owner graphql client: %v", err)
-		}
-
-		if ownerClient != defaultClient {
-			t.Fatal("expected owner graphql client to be the same client as default graphql client")
-		}
-	})
+	if ownerGraphQLClient != graphQLClient {
+		t.Fatal("expected owner graphql client to be the same client as default graphql client")
+	}
 }

--- a/internal/ghclient/token_test.go
+++ b/internal/ghclient/token_test.go
@@ -7,7 +7,7 @@ import (
 func TestNewTokenSource(t *testing.T) {
 	t.Parallel()
 
-	source, err := NewTokenSource("test-token", Options{})
+	source, err := NewTokenSource("test-token", testOptions(t))
 	if err != nil {
 		t.Fatalf("failed to create token source: %v", err)
 	}
@@ -20,7 +20,7 @@ func TestNewTokenSource(t *testing.T) {
 func TestNewTokenRESTClient(t *testing.T) {
 	t.Parallel()
 
-	client, err := NewTokenRESTClient("test-token", Options{})
+	client, err := NewTokenRESTClient("test-token", testOptions(t))
 	if err != nil {
 		t.Fatalf("failed to create token rest client: %v", err)
 	}
@@ -33,7 +33,7 @@ func TestNewTokenRESTClient(t *testing.T) {
 func TestNewTokenGraphQLClient(t *testing.T) {
 	t.Parallel()
 
-	client, err := NewTokenGraphQLClient("test-token", Options{})
+	client, err := NewTokenGraphQLClient("test-token", testOptions(t))
 	if err != nil {
 		t.Fatalf("failed to create token graphql client: %v", err)
 	}
@@ -49,7 +49,7 @@ func Test_tokenSource(t *testing.T) {
 	t.Run("RESTClient", func(t *testing.T) {
 		t.Parallel()
 
-		source, err := NewTokenSource("test-token", Options{})
+		source, err := NewTokenSource("test-token", testOptions(t))
 		if err != nil {
 			t.Fatalf("failed to create token source: %v", err)
 		}
@@ -67,7 +67,7 @@ func Test_tokenSource(t *testing.T) {
 	t.Run("OwnerRESTClient", func(t *testing.T) {
 		t.Parallel()
 
-		source, err := NewTokenSource("test-token", Options{})
+		source, err := NewTokenSource("test-token", testOptions(t))
 		if err != nil {
 			t.Fatalf("failed to create token source: %v", err)
 		}
@@ -90,7 +90,7 @@ func Test_tokenSource(t *testing.T) {
 	t.Run("GraphQLClient", func(t *testing.T) {
 		t.Parallel()
 
-		source, err := NewTokenSource("test-token", Options{})
+		source, err := NewTokenSource("test-token", testOptions(t))
 		if err != nil {
 			t.Fatalf("failed to create token source: %v", err)
 		}
@@ -108,7 +108,7 @@ func Test_tokenSource(t *testing.T) {
 	t.Run("OwnerGraphQLClient", func(t *testing.T) {
 		t.Parallel()
 
-		source, err := NewTokenSource("test-token", Options{})
+		source, err := NewTokenSource("test-token", testOptions(t))
 		if err != nil {
 			t.Fatalf("failed to create token source: %v", err)
 		}

--- a/internal/ghclient/transport.go
+++ b/internal/ghclient/transport.go
@@ -16,9 +16,14 @@ import (
 )
 
 // cloneTransport attempts to clone the given http.RoundTripper if it is an *http.Transport, otherwise it returns the original RoundTripper. Cloning the transport is important to avoid sharing state (such as idle connections) between different clients that use the same base transport.
-func cloneTransport(tr http.RoundTripper) http.RoundTripper {
+func cloneTransport(tr http.RoundTripper, opts Options) http.RoundTripper {
 	if dtr, ok := tr.(*http.Transport); ok {
-		return dtr.Clone()
+		htr := dtr.Clone()
+		htr.ForceAttemptHTTP2 = true
+		htr.MaxIdleConns = opts.maxIdleConns
+		htr.MaxIdleConnsPerHost = opts.maxIdleConns
+		htr.IdleConnTimeout = opts.idleConnTimeout
+		return htr
 	}
 
 	return tr
@@ -26,7 +31,7 @@ func cloneTransport(tr http.RoundTripper) http.RoundTripper {
 
 // newTransport creates a new HTTP RoundTripper that wraps the provided token source with OAuth2 authentication, adds conditional request caching, logging, and retry logic based on the provided options. The resulting RoundTripper is designed to be used with GitHub API clients to handle authentication, caching, rate limiting, and retries in a consistent manner.
 func newTransport(tokenSource oauth2.TokenSource, opts Options) (http.RoundTripper, error) {
-	tr := cloneTransport(http.DefaultTransport)
+	tr := cloneTransport(http.DefaultTransport, opts)
 
 	if tokenSource != nil {
 		tr = &oauth2.Transport{
@@ -35,18 +40,9 @@ func newTransport(tokenSource oauth2.TokenSource, opts Options) (http.RoundTripp
 		}
 	}
 
-	// Create a cache store.
-	store, err := createCacheStore(opts.CachePath, opts.cacheRef)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create cache store: %w", err)
-	}
-	tr = ghct.NewTransport(store, tr)
-
-	// Log each actual HTTP round-trip (including retries)
 	tr = logging.NewLoggingHTTPTransport(tr)
 
 	if opts.RetryMax > 0 {
-		// Wrap with retry transport
 		retryClient := retryablehttp.NewClient()
 		retryClient.Logger = nil
 		retryClient.HTTPClient = &http.Client{Transport: tr, Timeout: clientTimeout}
@@ -63,12 +59,23 @@ func newTransport(tokenSource oauth2.TokenSource, opts Options) (http.RoundTripp
 			return false, nil
 		}
 
-		// Use the RoundTripper adapter so it composes with other transports
 		tr = &retryablehttp.RoundTripper{Client: retryClient}
 	}
 
-	// Wrap with rate limit transport
+	if opts.sema != nil {
+		tr = &throttler{sema: opts.sema, inner: tr}
+	}
+
 	tr = ratelimit.New(tr, ratelimitp.WithLimitDetectedCallback(primaryRateLimitCallback), ratelimits.WithLimitDetectedCallback(secondaryRateLimitCallback))
+
+	if opts.CachePath != "" {
+		store, err := createCacheStore(opts.CachePath, opts.cacheRef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create cache store: %w", err)
+		}
+
+		tr = ghct.NewTransport(store, tr)
+	}
 
 	return tr, nil
 }

--- a/internal/ghclient/transport.go
+++ b/internal/ghclient/transport.go
@@ -1,7 +1,6 @@
 package ghclient
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
@@ -49,15 +48,6 @@ func newTransport(tokenSource oauth2.TokenSource, opts Options) (http.RoundTripp
 		retryClient.RetryMax = opts.RetryMax
 		retryClient.RetryWaitMin = opts.RetryWaitMin
 		retryClient.RetryWaitMax = opts.RetryWaitMax
-		retryClient.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
-			if err != nil {
-				return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
-			}
-			if resp.StatusCode == 0 || (resp.StatusCode >= 500 && resp.StatusCode != http.StatusNotImplemented) {
-				return true, nil
-			}
-			return false, nil
-		}
 
 		tr = &retryablehttp.RoundTripper{Client: retryClient}
 	}

--- a/internal/ghclient/transport_test.go
+++ b/internal/ghclient/transport_test.go
@@ -2,10 +2,11 @@ package ghclient
 
 import (
 	"net/http"
-	"net/http/httptest"
-	"sync/atomic"
 	"testing"
 	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/sync/semaphore"
 )
 
 func Test_cloneTransport(t *testing.T) {
@@ -33,7 +34,7 @@ func Test_cloneTransport(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cloned := cloneTransport(tt.original)
+			cloned := cloneTransport(tt.original, Options{maxIdleConns: 10, idleConnTimeout: 30 * time.Second})
 
 			if tt.expectSamePointer && cloned != tt.original {
 				t.Fatal("expected cloned transport to match original pointer")
@@ -55,63 +56,65 @@ func Test_newTransport(t *testing.T) {
 	t.Parallel()
 
 	for _, tt := range []struct {
-		name                 string
-		opts                 Options
-		firstStatusCode      int
-		retryStatusCode      int
-		expectedStatusCode   int
-		expectedRequestCount int32
+		name            string
+		withTokenSource bool
+		retryMax        int
+		withSemaphore   bool
 	}{
 		{
-			name:                 "retry_disabled",
-			opts:                 Options{},
-			firstStatusCode:      http.StatusInternalServerError,
-			retryStatusCode:      http.StatusOK,
-			expectedStatusCode:   http.StatusInternalServerError,
-			expectedRequestCount: 1,
+			name:            "base_transport",
+			withTokenSource: false,
+			retryMax:        0,
+			withSemaphore:   false,
 		},
 		{
-			name:                 "retry_enabled",
-			opts:                 Options{RetryMax: 1, RetryWaitMin: time.Millisecond, RetryWaitMax: time.Millisecond},
-			firstStatusCode:      http.StatusInternalServerError,
-			retryStatusCode:      http.StatusOK,
-			expectedStatusCode:   http.StatusOK,
-			expectedRequestCount: 2,
+			name:            "with_retry",
+			withTokenSource: false,
+			retryMax:        1,
+			withSemaphore:   false,
+		},
+		{
+			name:            "with_token_source",
+			withTokenSource: true,
+			retryMax:        0,
+			withSemaphore:   false,
+		},
+		{
+			name:            "with_throttler",
+			withTokenSource: false,
+			retryMax:        0,
+			withSemaphore:   true,
+		},
+		{
+			name:            "with_all_wrappers",
+			withTokenSource: true,
+			retryMax:        1,
+			withSemaphore:   true,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			var requestCount atomic.Int32
-			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				count := requestCount.Add(1)
-				if count == 1 {
-					w.WriteHeader(tt.firstStatusCode)
-					return
-				}
+			testOpts := testOptions(t)
+			testOpts.RetryMax = tt.retryMax
+			testOpts.RetryWaitMin = time.Millisecond
+			testOpts.RetryWaitMax = time.Millisecond
+			if tt.withSemaphore {
+				testOpts.sema = semaphore.NewWeighted(1)
+			}
 
-				w.WriteHeader(tt.retryStatusCode)
-			}))
-			defer ts.Close()
+			var tokenSource oauth2.TokenSource
+			if tt.withTokenSource {
+				tokenSource = oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"})
+			}
 
-			tr, err := newTransport(nil, tt.opts)
+			tr, err := newTransport(tokenSource, testOpts)
 			if err != nil {
 				t.Fatalf("failed to create transport: %v", err)
 			}
 
-			client := &http.Client{Transport: tr, Timeout: 10 * time.Second}
-			resp, err := client.Get(ts.URL)
-			if err != nil {
-				t.Fatalf("failed to perform request: %v", err)
-			}
-			defer resp.Body.Close()
-
-			if resp.StatusCode != tt.expectedStatusCode {
-				t.Fatalf("expected status code %d, got %d", tt.expectedStatusCode, resp.StatusCode)
-			}
-
-			if requestCount.Load() != tt.expectedRequestCount {
-				t.Fatalf("expected %d requests, got %d", tt.expectedRequestCount, requestCount.Load())
+			if tr == nil {
+				t.Fatal("expected transport to be non-nil")
 			}
 		})
 	}

--- a/internal/ghclient/transport_test.go
+++ b/internal/ghclient/transport_test.go
@@ -2,9 +2,13 @@ package ghclient
 
 import (
 	"errors"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"regexp"
+	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -93,32 +97,32 @@ func Test_newTransport(t *testing.T) {
 		wantErr     string
 	}{
 		{
-			name:        "empty_options",
+			name:        "succeeds_with_empty_options",
 			tokenSource: nil,
 			opts:        Options{},
 		},
 		{
-			name:        "with_token",
+			name:        "succeeds_with_token",
 			tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
 			opts:        Options{},
 		},
 		{
-			name:        "with_retry",
+			name:        "succeeds_with_retry",
 			tokenSource: nil,
 			opts:        Options{RetryMax: 1, RetryWaitMin: time.Millisecond, RetryWaitMax: time.Millisecond},
 		},
 		{
-			name:        "with_throttler",
+			name:        "succeeds_with_throttler",
 			tokenSource: nil,
 			opts:        Options{sema: semaphore.NewWeighted(1)},
 		},
 		{
-			name:        "with_cache",
+			name:        "succeeds_with_cache",
 			tokenSource: nil,
 			opts:        Options{CachePath: mustMkdirTemp(t, cacheBasePath, "*")},
 		},
 		{
-			name:        "all_options",
+			name:        "succeeds_with_all_options",
 			tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
 			opts:        Options{RetryMax: 1, RetryWaitMin: time.Millisecond, RetryWaitMax: time.Millisecond, sema: semaphore.NewWeighted(1), CachePath: mustMkdirTemp(t, cacheBasePath, "*")},
 		},
@@ -154,4 +158,239 @@ func Test_newTransport(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("transport_retries_requests", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tt := range []struct {
+			name               string
+			retryMax           int
+			failures           int
+			failStatusCode     int
+			wantFailStatusCode bool
+			wantError          string
+		}{
+			{
+				name:               "no_retries",
+				retryMax:           0,
+				failures:           1,
+				failStatusCode:     http.StatusInternalServerError,
+				wantFailStatusCode: true,
+			},
+			{
+				name:           "retries_until_success",
+				retryMax:       3,
+				failures:       2,
+				failStatusCode: http.StatusInternalServerError,
+			},
+			{
+				name:           "retries_until_failure",
+				retryMax:       2,
+				failures:       3,
+				failStatusCode: http.StatusInternalServerError,
+				wantError:      "giving up after",
+			},
+			{
+				name:               "does_not_retry_on_4xx",
+				retryMax:           3,
+				failures:           1,
+				failStatusCode:     http.StatusBadRequest,
+				wantFailStatusCode: true,
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				called := atomic.Int32{}
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					call := int(called.Add(1))
+
+					if call <= tt.failures {
+						w.WriteHeader(tt.failStatusCode)
+						return
+					}
+
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("PASS"))
+				}))
+				defer ts.Close()
+
+				opts := Options{RetryMax: tt.retryMax, RetryWaitMin: time.Millisecond, RetryWaitMax: time.Millisecond}
+				tr, err := newTransport(nil, opts)
+				if err != nil {
+					t.Fatalf("failed to create transport: %v", err)
+				}
+
+				if tr == nil {
+					t.Fatal("expected transport to be non-nil")
+				}
+
+				client := &http.Client{Transport: tr}
+
+				res, err := client.Get(ts.URL)
+				if err != nil {
+					if tt.wantError != "" {
+						if !regexp.MustCompile(regexp.QuoteMeta(tt.wantError)).MatchString(err.Error()) {
+							t.Fatalf("expected error to match %q, got %v", tt.wantError, err)
+						}
+
+						return
+					}
+
+					t.Fatalf("failed to make request: %v", err)
+				}
+				defer res.Body.Close()
+
+				if tt.wantError != "" {
+					t.Fatalf("expected error %q, got nil", tt.wantError)
+				}
+
+				if tt.wantFailStatusCode {
+					if res.StatusCode != tt.failStatusCode {
+						t.Fatalf("expected status code %d, got %d", tt.failStatusCode, res.StatusCode)
+					}
+
+					return
+				}
+
+				if res.StatusCode != http.StatusOK {
+					t.Fatalf("expected status code %d, got %d", http.StatusOK, res.StatusCode)
+				}
+
+				body, err := io.ReadAll(res.Body)
+				if err != nil {
+					t.Fatalf("failed to read response body: %v", err)
+				}
+
+				if string(body) != "PASS" {
+					t.Fatalf("expected response body to be %q, got %q", "PASS", string(body))
+				}
+			})
+		}
+	})
+
+	t.Run("transport_throttles_requests", func(t *testing.T) {
+		t.Parallel()
+
+		result := "FAIL"
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(result))
+		}))
+		defer ts.Close()
+
+		opts := Options{sema: semaphore.NewWeighted(1)}
+		tr, err := newTransport(nil, opts)
+		if err != nil {
+			t.Fatalf("failed to create transport: %v", err)
+		}
+
+		if tr == nil {
+			t.Fatal("expected transport to be non-nil")
+		}
+
+		client := &http.Client{Transport: tr}
+
+		if err := opts.sema.Acquire(t.Context(), 1); err != nil {
+			t.Fatalf("failed to acquire semaphore: %v", err)
+		}
+
+		go func() {
+			time.Sleep(1 * time.Second)
+			result = "PASS"
+			opts.sema.Release(1)
+		}()
+
+		res, err := client.Get(ts.URL)
+		if err != nil {
+			t.Fatalf("failed to make request: %v", err)
+		}
+		defer res.Body.Close()
+
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			t.Fatalf("failed to read response body: %v", err)
+		}
+
+		if string(body) != "PASS" {
+			t.Fatalf("expected response body to be %q, got %q", "PASS", string(body))
+		}
+	})
+
+	t.Run("transport_caches_requests", func(t *testing.T) {
+		t.Parallel()
+
+		etag := "test-etag"
+
+		called := atomic.Int32{}
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called.Add(1)
+			call := int(called.Load())
+
+			if call <= 2 && r.Header.Get("If-None-Match") == etag {
+				w.Header().Set("Etag", etag)
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+
+			w.Header().Set("Etag", etag)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(strconv.Itoa(call)))
+		}))
+		defer ts.Close()
+
+		opts := Options{CachePath: mustMkdirTemp(t, cacheBasePath, "*")}
+		tr, err := newTransport(nil, opts)
+		if err != nil {
+			t.Fatalf("failed to create transport: %v", err)
+		}
+
+		if tr == nil {
+			t.Fatal("expected transport to be non-nil")
+		}
+
+		client := &http.Client{Transport: tr}
+
+		res1, err := client.Get(ts.URL)
+		if err != nil {
+			t.Fatalf("failed to make first request: %v", err)
+		}
+
+		b1, err := io.ReadAll(res1.Body)
+		if err != nil {
+			t.Fatalf("failed to read first response body: %v", err)
+		}
+		res1.Body.Close()
+
+		res2, err := client.Get(ts.URL)
+		if err != nil {
+			t.Fatalf("failed to make second request: %v", err)
+		}
+
+		b2, err := io.ReadAll(res2.Body)
+		if err != nil {
+			t.Fatalf("failed to read second response body: %v", err)
+		}
+		res2.Body.Close()
+
+		if string(b2) != string(b1) {
+			t.Fatalf("expected cached response to match first response, got %q and %q", string(b2), string(b1))
+		}
+
+		res3, err := client.Get(ts.URL)
+		if err != nil {
+			t.Fatalf("failed to make third request: %v", err)
+		}
+
+		b3, err := io.ReadAll(res3.Body)
+		if err != nil {
+			t.Fatalf("failed to read third response body: %v", err)
+		}
+		res3.Body.Close()
+
+		if string(b3) == string(b2) {
+			t.Fatalf("expected cached response to not match last response, got %q and %q", string(b3), string(b2))
+		}
+	})
 }

--- a/internal/ghclient/transport_test.go
+++ b/internal/ghclient/transport_test.go
@@ -1,7 +1,10 @@
 package ghclient
 
 import (
+	"errors"
 	"net/http"
+	"os"
+	"regexp"
 	"testing"
 	"time"
 
@@ -13,40 +16,63 @@ func Test_cloneTransport(t *testing.T) {
 	t.Parallel()
 
 	for _, tt := range []struct {
-		name                string
-		original            http.RoundTripper
-		expectSamePointer   bool
-		expectHTTPTransport bool
+		name          string
+		source        http.RoundTripper
+		httpTransport bool
 	}{
 		{
-			name:                "http_transport",
-			original:            &http.Transport{},
-			expectSamePointer:   false,
-			expectHTTPTransport: true,
+			name:          "http_transport",
+			source:        &http.Transport{},
+			httpTransport: true,
 		},
 		{
-			name:                "non_http_transport",
-			original:            &staticRoundTripper{},
-			expectSamePointer:   true,
-			expectHTTPTransport: false,
+			name:          "non_http_transport",
+			source:        &testRoundTripper{err: errors.New("not used")},
+			httpTransport: false,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cloned := cloneTransport(tt.original, Options{maxIdleConns: 10, idleConnTimeout: 30 * time.Second})
+			opts := Options{maxIdleConns: 10, idleConnTimeout: 30 * time.Second}
+			cloned := cloneTransport(tt.source, opts)
 
-			if tt.expectSamePointer && cloned != tt.original {
+			if !tt.httpTransport && cloned != tt.source {
 				t.Fatal("expected cloned transport to match original pointer")
 			}
 
-			if !tt.expectSamePointer && cloned == tt.original {
+			if tt.httpTransport && cloned == tt.source {
 				t.Fatal("expected cloned transport to have a different pointer")
 			}
 
-			_, ok := cloned.(*http.Transport)
-			if ok != tt.expectHTTPTransport {
-				t.Fatalf("unexpected transport type: got %T", cloned)
+			htr, ok := cloned.(*http.Transport)
+
+			if !tt.httpTransport && ok {
+				t.Fatalf("expected cloned transport to not be an *http.Transport")
+			}
+
+			if tt.httpTransport && !ok {
+				t.Fatalf("expected cloned transport to be an *http.Transport, got %T", cloned)
+			}
+
+			if !tt.httpTransport {
+				return
+			}
+
+			if htr.ForceAttemptHTTP2 != true {
+				t.Fatal("expected ForceAttemptHTTP2 to be true")
+			}
+
+			if htr.MaxIdleConns != opts.maxIdleConns {
+				t.Fatalf("expected MaxIdleConns to be %d, got %d", opts.maxIdleConns, htr.MaxIdleConns)
+			}
+
+			if htr.MaxIdleConnsPerHost != opts.maxIdleConns {
+				t.Fatalf("expected MaxIdleConnsPerHost to be %d, got %d", opts.maxIdleConns, htr.MaxIdleConnsPerHost)
+			}
+
+			if htr.IdleConnTimeout != opts.idleConnTimeout {
+				t.Fatalf("expected IdleConnTimeout to be %v, got %v", opts.idleConnTimeout, htr.IdleConnTimeout)
 			}
 		})
 	}
@@ -55,62 +81,72 @@ func Test_cloneTransport(t *testing.T) {
 func Test_newTransport(t *testing.T) {
 	t.Parallel()
 
+	cacheBasePath := mustMkdirTemp(t, "", "*")
+	t.Cleanup(func() {
+		_ = os.RemoveAll(cacheBasePath)
+	})
+
 	for _, tt := range []struct {
-		name            string
-		withTokenSource bool
-		retryMax        int
-		withSemaphore   bool
+		name        string
+		tokenSource oauth2.TokenSource
+		opts        Options
+		wantErr     string
 	}{
 		{
-			name:            "base_transport",
-			withTokenSource: false,
-			retryMax:        0,
-			withSemaphore:   false,
+			name:        "empty_options",
+			tokenSource: nil,
+			opts:        Options{},
 		},
 		{
-			name:            "with_retry",
-			withTokenSource: false,
-			retryMax:        1,
-			withSemaphore:   false,
+			name:        "with_token",
+			tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
+			opts:        Options{},
 		},
 		{
-			name:            "with_token_source",
-			withTokenSource: true,
-			retryMax:        0,
-			withSemaphore:   false,
+			name:        "with_retry",
+			tokenSource: nil,
+			opts:        Options{RetryMax: 1, RetryWaitMin: time.Millisecond, RetryWaitMax: time.Millisecond},
 		},
 		{
-			name:            "with_throttler",
-			withTokenSource: false,
-			retryMax:        0,
-			withSemaphore:   true,
+			name:        "with_throttler",
+			tokenSource: nil,
+			opts:        Options{sema: semaphore.NewWeighted(1)},
 		},
 		{
-			name:            "with_all_wrappers",
-			withTokenSource: true,
-			retryMax:        1,
-			withSemaphore:   true,
+			name:        "with_cache",
+			tokenSource: nil,
+			opts:        Options{CachePath: mustMkdirTemp(t, cacheBasePath, "*")},
+		},
+		{
+			name:        "all_options",
+			tokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
+			opts:        Options{RetryMax: 1, RetryWaitMin: time.Millisecond, RetryWaitMax: time.Millisecond, sema: semaphore.NewWeighted(1), CachePath: mustMkdirTemp(t, cacheBasePath, "*")},
+		},
+		{
+			name:        "errors_with_invalid_cache_path",
+			tokenSource: nil,
+			opts:        Options{CachePath: "\x00c"},
+			wantErr:     "failed to create cache store",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			testOpts := testOptions(t)
-			testOpts.RetryMax = tt.retryMax
-			testOpts.RetryWaitMin = time.Millisecond
-			testOpts.RetryWaitMax = time.Millisecond
-			if tt.withSemaphore {
-				testOpts.sema = semaphore.NewWeighted(1)
-			}
-
-			var tokenSource oauth2.TokenSource
-			if tt.withTokenSource {
-				tokenSource = oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"})
-			}
-
-			tr, err := newTransport(tokenSource, testOpts)
+			tr, err := newTransport(tt.tokenSource, tt.opts)
 			if err != nil {
-				t.Fatalf("failed to create transport: %v", err)
+				if tt.wantErr == "" {
+					t.Fatalf("failed to create transport: %v", err)
+				}
+
+				if !regexp.MustCompile(regexp.QuoteMeta(tt.wantErr)).MatchString(err.Error()) {
+					t.Fatalf("expected error to match %q, got %v", tt.wantErr, err)
+				}
+
+				return
+			}
+
+			if tt.wantErr != "" {
+				t.Fatalf("expected error %q, got nil", tt.wantErr)
 			}
 
 			if tr == nil {

--- a/main.go
+++ b/main.go
@@ -6,10 +6,16 @@ import (
 	"github.com/integrations/terraform-provider-github/v6/github"
 )
 
+var (
+	// These will be set by GoReleaser.
+	version string = "dev"
+	commit  string = "none"
+)
+
 func main() {
 	opts := &plugin.ServeOpts{
 		ProviderAddr: "registry.terraform.io/integrations/github",
-		ProviderFunc: github.NewProvider(),
+		ProviderFunc: github.NewProvider(version, commit),
 	}
 
 	plugin.Serve(opts)


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

-

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The new client has explicit concurrency control to limit cross client request concurrency to the secondary rate limit
- The new client has improved default transport options
- The new client has a user agent with the provider version
- The `ghclient` package has improved unit tests

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
