### PR TITLE
Add cooldown config for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 
 updates:
   - package-ecosystem: github-actions
+    cooldown:
+      default-days: 7
     directories:
       - /
     groups:
@@ -23,6 +25,8 @@ updates:
       interval: weekly
 
   - package-ecosystem: gomod
+    cooldown:
+      default-days: 7
     directories:
       - /
       - /tools


### PR DESCRIPTION
Enable waiting for 7 days before offering updates, to reduce the risk of supply-chain attacks 
