### PR TITLE
Fix nil-pointer panic when deleting github_team_repository

### DIFF
--- a/github/resource_github_team_repository.go
+++ b/github/resource_github_team_repository.go
@@ -223,7 +223,7 @@ func resourceGithubTeamRepositoryDelete(ctx context.Context, d *schema.ResourceD
 
 	resp, err := client.Teams.RemoveTeamRepoByID(ctx, orgId, teamId, orgName, repoName)
 
-	if resp.StatusCode == 404 {
+	if resp != nil && resp.StatusCode == 404 {
 		log.Printf("[DEBUG] Failed to find team %s to delete for repo: %s.", teamIdString, repoName)
 		repo, _, err := client.Repositories.Get(ctx, orgName, repoName)
 		if err != nil {

--- a/github/resource_github_team_repository_test.go
+++ b/github/resource_github_team_repository_test.go
@@ -35,7 +35,7 @@ func Test_resourceGithubTeamRepositoryDelete_nilResponseDoesNotPanic(t *testing.
 
 	// A cancelled context makes the underlying HTTP call return before it
 	// reaches the server, so go-github yields a nil response with an error.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
 	diags := resourceGithubTeamRepositoryDelete(ctx, d, meta)

--- a/github/resource_github_team_repository_test.go
+++ b/github/resource_github_team_repository_test.go
@@ -1,13 +1,48 @@
 package github
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+// Test_resourceGithubTeamRepositoryDelete_nilResponseDoesNotPanic is a
+// regression test for a nil-pointer panic in the delete path. When the
+// RemoveTeamRepoByID call fails at the transport layer (for example a
+// cancelled context or an exceeded deadline), go-github returns a nil
+// *github.Response. Delete must surface that as an error diagnostic instead of
+// dereferencing resp.StatusCode and panicking.
+func Test_resourceGithubTeamRepositoryDelete_nilResponseDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	ts := githubApiMock(nil)
+	defer ts.Close()
+
+	meta := &Owner{
+		name:           "test-org",
+		id:             12345,
+		v3client:       mustCreateTestGitHubClient(t, ts.URL),
+		IsOrganization: true,
+	}
+
+	d := schema.TestResourceDataRaw(t, resourceGithubTeamRepository().Schema, map[string]any{})
+	d.SetId(buildTwoPartID("123", "test-repo"))
+
+	// A cancelled context makes the underlying HTTP call return before it
+	// reaches the server, so go-github yields a nil response with an error.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	diags := resourceGithubTeamRepositoryDelete(ctx, d, meta)
+	if !diags.HasError() {
+		t.Fatal("expected an error diagnostic when the API response is nil, got none")
+	}
+}
 
 func TestAccGithubTeamRepository(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Resolves #3517

----

### Before the change?

`resourceGithubTeamRepositoryDelete` read `resp.StatusCode` without checking whether `resp` was nil. When `Teams.RemoveTeamRepoByID` fails at the transport layer (for example a cancelled context or an exceeded deadline), `google/go-github` returns a nil `*github.Response` (in `bareDo`, a transport error yields `(nil, err)`), so the delete panicked with a nil-pointer dereference instead of returning the error:

```
panic: runtime error: invalid memory address or nil pointer dereference
    github/resource_github_team_repository.go:226
```

In a `terraform apply`/`destroy`, a transient network error while removing a team's repository access could crash the provider. This is the only unguarded `resp.StatusCode` dereference in the `github/` package; the other call sites already use `resp != nil && resp.StatusCode`.

### After the change?

- Guard the status check with `resp != nil`, matching the pattern already used elsewhere in the provider. When `resp` is nil, the underlying error now flows through `handleArchivedRepoDelete` and is returned as a diagnostic instead of panicking.
- Add a regression test (`Test_resourceGithubTeamRepositoryDelete_nilResponseDoesNotPanic`) that drives delete with a cancelled context so the API call returns a nil response, asserting delete returns an error diagnostic. It panics at line 226 without the fix and passes with it.

Verification:
- `go test ./github/ -run '^Test_resourceGithubTeamRepositoryDelete_nilResponseDoesNotPanic$'` panics before the change, passes after.
- Full unit suite green (`make test`, which skips `^TestAcc`).
- Happy path unchanged against a live org: `TestAccGithubTeamRepository` passes (create / read / import / update / destroy).

### Pull request checklist

- [ ] Schema migrations have been created if needed — N/A, no schema change
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed — N/A, no user-facing schema or behavior change beyond not panicking

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

----

> **AI-assisted disclosure:** this change was developed with AI assistance (GitHub Copilot). Per the repository's AI Use Policy I have reviewed and understand the change, verified the root cause in `google/go-github`'s `bareDo` (nil `*Response` on transport error), and tested it with a deterministic unit regression test plus a live acceptance run of `TestAccGithubTeamRepository`.
