### PR TITLE
fix: prevent panic in expandConditions when ref_name is nil or empty

### DIFF
--- a/github/util_rules.go
+++ b/github/util_rules.go
@@ -194,26 +194,34 @@ func expandConditions(input []any, org bool) *github.RepositoryRulesetConditions
 	inputConditions := input[0].(map[string]any)
 
 	// ref_name is available for both repo and org rulesets
-	if v, ok := inputConditions["ref_name"].([]any); ok && v != nil && len(v) != 0 {
-		inputRefName := v[0].(map[string]any)
-		include := make([]string, 0)
-		exclude := make([]string, 0)
+	if v, ok := inputConditions["ref_name"].([]any); ok && len(v) != 0 {
+		// A present-but-empty ref_name block (e.g. `ref_name {}`) can yield a nil
+		// element or a map without include/exclude keys; guard both so we fail
+		// gracefully instead of panicking (#3299).
+		if inputRefName, ok := v[0].(map[string]any); ok {
+			include := make([]string, 0)
+			exclude := make([]string, 0)
 
-		for _, v := range inputRefName["include"].([]any) {
-			if v != nil {
-				include = append(include, v.(string))
+			if raw, ok := inputRefName["include"].([]any); ok {
+				for _, v := range raw {
+					if v != nil {
+						include = append(include, v.(string))
+					}
+				}
 			}
-		}
 
-		for _, v := range inputRefName["exclude"].([]any) {
-			if v != nil {
-				exclude = append(exclude, v.(string))
+			if raw, ok := inputRefName["exclude"].([]any); ok {
+				for _, v := range raw {
+					if v != nil {
+						exclude = append(exclude, v.(string))
+					}
+				}
 			}
-		}
 
-		rulesetConditions.RefName = &github.RepositoryRulesetRefConditionParameters{
-			Include: include,
-			Exclude: exclude,
+			rulesetConditions.RefName = &github.RepositoryRulesetRefConditionParameters{
+				Include: include,
+				Exclude: exclude,
+			}
 		}
 	}
 

--- a/github/util_rules_test.go
+++ b/github/util_rules_test.go
@@ -1365,3 +1365,113 @@ func TestFlattenRulesetRepositoryPropertyTargetParameters_NilPropertyValues(t *t
 		}
 	}
 }
+
+// Regression tests for #3299: expandConditions must not panic when a
+// conditions.ref_name block is present but nil/empty (e.g. `ref_name {}` with
+// no include/exclude, or a nil element in the ref_name list).
+
+func TestExpandConditions_RefNameNilElement(t *testing.T) {
+	t.Parallel()
+
+	// A ref_name list holding a nil element (as produced by an empty/typeless
+	// block) previously panicked on v[0].(map[string]any).
+	input := []any{
+		map[string]any{
+			"ref_name": []any{nil},
+		},
+	}
+
+	result := expandConditions(input, false)
+
+	if result == nil {
+		t.Fatal("Expected result to not be nil")
+	}
+	if result.RefName != nil {
+		t.Errorf("Expected RefName to be nil for a nil ref_name element, got %+v", result.RefName)
+	}
+}
+
+func TestExpandConditions_RefNameMissingIncludeExclude(t *testing.T) {
+	t.Parallel()
+
+	// An empty `ref_name {}` block yields a map without include/exclude keys;
+	// asserting the absent values as []any previously panicked.
+	input := []any{
+		map[string]any{
+			"ref_name": []any{
+				map[string]any{},
+			},
+		},
+	}
+
+	result := expandConditions(input, false)
+
+	if result == nil {
+		t.Fatal("Expected result to not be nil")
+	}
+	if result.RefName == nil {
+		t.Fatal("Expected RefName to be set for a present ref_name block")
+	}
+	if len(result.RefName.Include) != 0 {
+		t.Errorf("Expected 0 include refs, got %d", len(result.RefName.Include))
+	}
+	if len(result.RefName.Exclude) != 0 {
+		t.Errorf("Expected 0 exclude refs, got %d", len(result.RefName.Exclude))
+	}
+}
+
+func TestExpandConditions_RefNameEmptyIncludeExclude(t *testing.T) {
+	t.Parallel()
+
+	// The common empty-array case must keep working: RefName set, no entries.
+	input := []any{
+		map[string]any{
+			"ref_name": []any{
+				map[string]any{
+					"include": []any{},
+					"exclude": []any{},
+				},
+			},
+		},
+	}
+
+	result := expandConditions(input, false)
+
+	if result == nil || result.RefName == nil {
+		t.Fatal("Expected result and RefName to be set")
+	}
+	if len(result.RefName.Include) != 0 || len(result.RefName.Exclude) != 0 {
+		t.Errorf("Expected empty include/exclude, got include=%v exclude=%v", result.RefName.Include, result.RefName.Exclude)
+	}
+}
+
+func TestExpandConditions_RefNamePopulated(t *testing.T) {
+	t.Parallel()
+
+	// Populated include/exclude (with a nil entry to skip) must still expand.
+	input := []any{
+		map[string]any{
+			"ref_name": []any{
+				map[string]any{
+					"include": []any{"~DEFAULT_BRANCH", nil, "refs/heads/release/*"},
+					"exclude": []any{"refs/heads/wip/*"},
+				},
+			},
+		},
+	}
+
+	result := expandConditions(input, false)
+
+	if result == nil || result.RefName == nil {
+		t.Fatal("Expected result and RefName to be set")
+	}
+	if len(result.RefName.Include) != 2 {
+		t.Fatalf("Expected 2 include refs (nil skipped), got %d", len(result.RefName.Include))
+	}
+	if result.RefName.Include[0] != "~DEFAULT_BRANCH" || result.RefName.Include[1] != "refs/heads/release/*" {
+		t.Errorf("Unexpected include refs: %v", result.RefName.Include)
+	}
+	if len(result.RefName.Exclude) != 1 || result.RefName.Exclude[0] != "refs/heads/wip/*" {
+		t.Errorf("Unexpected exclude refs: %v", result.RefName.Exclude)
+	}
+}


### PR DESCRIPTION
Resolves #3299

----

### Before the change?

Applying a `github_repository_ruleset` whose `conditions.ref_name` block is present but empty crashed the provider:

```
panic: interface conversion: interface {} is nil, not map[string]interface {}
```

`expandConditions` asserted `ref_name[0].(map[string]any)` and `include`/`exclude` `.([]any)` without checking them, so a nil list element (or a `ref_name {}` block with no include/exclude keys) panicked instead of being handled.

### After the change?

The `ref_name` element and the `include`/`exclude` lookups now use comma-ok assertions. An empty/nil `ref_name` block is treated as no ref-name condition (no panic); populated and empty-array blocks behave exactly as before. This mirrors the existing nil-tolerant handling in `expandRepositoryPropertyConditions`.

### Pull request checklist

- [ ] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go)) — n/a, no schema change
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features) — n/a, no schema/behavior surface change

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

----

<sub>AI assistance: implemented with Claude Code. I directed the fix, reviewed the diff, and verified it: the added regression tests panic on `main` at `util_rules.go:198` and pass after the change (`go test -run TestExpandConditions_ ./github/`), with `go vet`/`gofmt`/`go build` clean.</sub>
