### PR TITLE
feat: Check owner as part of provider configuration

### DIFF
--- a/github/provider.go
+++ b/github/provider.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -13,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v88/github"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -615,16 +613,14 @@ func configureProviderMeta(ctx context.Context, version string, c *Config) (*Own
 	}
 
 	if owner.name != "" {
-		org, _, err := owner.v3client.Organizations.Get(ctx, owner.name)
+		o, _, err := owner.v3client.Users.Get(ctx, owner.name)
 		if err != nil {
-			if ghErr, ok := errors.AsType[*github.ErrorResponse](err); !ok || ghErr.Response.StatusCode != http.StatusNotFound {
-				return nil, fmt.Errorf("failed to lookup organization %q: %w", owner.name, err)
-			}
+			return nil, fmt.Errorf("failed to lookup owner %q: %w", owner.name, err)
 		}
 
-		if org != nil {
-			owner.id = org.GetID()
+		if o.GetType() == "Organization" {
 			owner.IsOrganization = true
+			owner.id = o.GetID()
 		}
 	}
 

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -23,15 +23,15 @@ func Test_configureProviderMeta(t *testing.T) {
 	t.Parallel()
 
 	for _, tt := range []struct {
-		name        string
-		installResp *string
-		userResp    *string
-		orgResp     *string
-		conf        *Config
-		wantName    string
-		wantIsOrg   bool
-		wantOrgId   int64
-		wantErr     string
+		name          string
+		installResp   *string
+		tokenUserResp *string
+		userResp      *string
+		conf          *Config
+		wantName      string
+		wantIsOrg     bool
+		wantOrgId     int64
+		wantErr       string
 	}{
 		{
 			name: "anonymous",
@@ -40,7 +40,7 @@ func Test_configureProviderMeta(t *testing.T) {
 		{
 			name:        "app_auth_organization",
 			installResp: new(`{"id": 999999}`),
-			orgResp:     new(`{"id": 123456}`),
+			userResp:    new(`{"id": 123456, "type": "Organization"}`),
 			conf: &Config{
 				AppID:             new("111111"),
 				AppInstallationID: new("999999"),
@@ -54,6 +54,7 @@ func Test_configureProviderMeta(t *testing.T) {
 		{
 			name:        "app_auth_user",
 			installResp: new(`{"id": 999999}`),
+			userResp:    new(`{"id": 123456, "type": "User"}`),
 			conf: &Config{
 				AppID:             new("111111"),
 				AppInstallationID: new("999999"),
@@ -63,8 +64,8 @@ func Test_configureProviderMeta(t *testing.T) {
 			wantName: "test-user",
 		},
 		{
-			name:    "token_auth_organization",
-			orgResp: new(`{"id": 123456}`),
+			name:     "token_auth_organization",
+			userResp: new(`{"id": 123456, "type": "Organization"}`),
 			conf: &Config{
 				Owner: "test-org",
 				Token: "test-token",
@@ -74,7 +75,8 @@ func Test_configureProviderMeta(t *testing.T) {
 			wantOrgId: 123456,
 		},
 		{
-			name: "token_auth_user",
+			name:     "token_auth_user",
+			userResp: new(`{"id": 123456, "type": "User"}`),
 			conf: &Config{
 				Owner: "test-user",
 				Token: "test-token",
@@ -89,6 +91,14 @@ func Test_configureProviderMeta(t *testing.T) {
 			wantErr: "owner must be set when authenticating using the new client implementation",
 		},
 		{
+			name: "errors_on_non_existent_owner",
+			conf: &Config{
+				Owner: "test-user",
+				Token: "test-token",
+			},
+			wantErr: "failed to lookup owner",
+		},
+		{
 			name: "legacy_client_anonymous",
 			conf: &Config{
 				LegacyClient: true,
@@ -97,7 +107,7 @@ func Test_configureProviderMeta(t *testing.T) {
 		{
 			name:        "legacy_client_app_auth_organization",
 			installResp: new(`{"id": 999999}`),
-			orgResp:     new(`{"id": 123456}`),
+			userResp:    new(`{"id": 123456, "type": "Organization"}`),
 			conf: &Config{
 				LegacyClient:      true,
 				AppID:             new("111111"),
@@ -112,6 +122,7 @@ func Test_configureProviderMeta(t *testing.T) {
 		{
 			name:        "legacy_client_app_auth_user",
 			installResp: new(`{"id": 999999}`),
+			userResp:    new(`{"id": 123456, "type": "User"}`),
 			conf: &Config{
 				LegacyClient:      true,
 				AppID:             new("111111"),
@@ -122,7 +133,20 @@ func Test_configureProviderMeta(t *testing.T) {
 			wantName: "test-user",
 		},
 		{
-			name: "legacy_client_token_auth_user",
+			name:     "legacy_client_token_auth_organization",
+			userResp: new(`{"id": 123456, "type": "Organization"}`),
+			conf: &Config{
+				LegacyClient: true,
+				Owner:        "test-org",
+				Token:        "test-token",
+			},
+			wantName:  "test-org",
+			wantIsOrg: true,
+			wantOrgId: 123456,
+		},
+		{
+			name:     "legacy_client_token_auth_user",
+			userResp: new(`{"id": 123456, "type": "User"}`),
 			conf: &Config{
 				LegacyClient: true,
 				Owner:        "test-user",
@@ -131,8 +155,9 @@ func Test_configureProviderMeta(t *testing.T) {
 			wantName: "test-user",
 		},
 		{
-			name:     "legacy_client_token_auth_no_owner",
-			userResp: new(`{"login": "test-user"}`),
+			name:          "legacy_client_token_auth_no_owner",
+			tokenUserResp: new(`{"login": "test-user"}`),
+			userResp:      new(`{"id": 123456, "type": "User"}`),
 			conf: &Config{
 				LegacyClient: true,
 				Token:        "test-token",
@@ -140,12 +165,21 @@ func Test_configureProviderMeta(t *testing.T) {
 			wantName: "test-user",
 		},
 		{
-			name: "legacy_client_token_auth_no_owner_found",
+			name: "legacy_client_token_auth_errors_if_no_owner_found",
 			conf: &Config{
 				LegacyClient: true,
 				Token:        "test-token",
 			},
 			wantErr: "owner cannot be found by token",
+		},
+		{
+			name: "legacy_client_errors_on_non_existent_owner",
+			conf: &Config{
+				LegacyClient: true,
+				Owner:        "test-user",
+				Token:        "test-token",
+			},
+			wantErr: "failed to lookup owner",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -170,6 +204,17 @@ func Test_configureProviderMeta(t *testing.T) {
 				}
 
 				if regexp.MustCompile(`/user$`).MatchString(r.URL.Path) {
+					if tt.tokenUserResp == nil {
+						w.WriteHeader(http.StatusNotFound)
+						return
+					}
+
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(*tt.tokenUserResp))
+					return
+				}
+
+				if regexp.MustCompile(`/users/[^/]+$`).MatchString(r.URL.Path) {
 					if tt.userResp == nil {
 						w.WriteHeader(http.StatusNotFound)
 						return
@@ -177,17 +222,6 @@ func Test_configureProviderMeta(t *testing.T) {
 
 					w.WriteHeader(http.StatusOK)
 					_, _ = w.Write([]byte(*tt.userResp))
-					return
-				}
-
-				if regexp.MustCompile(`/orgs/[^/]+$`).MatchString(r.URL.Path) {
-					if tt.orgResp == nil {
-						w.WriteHeader(http.StatusNotFound)
-						return
-					}
-
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write([]byte(*tt.orgResp))
 					return
 				}
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- The owner was assumed to be valid with a check if it was an organization

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Owners are checked for validity (exists and can be accessed by the client) and if they're an organization

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
