### PR TITLE
[DOCS] Add deprecation notice to `GitHub CLI Authentication`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -99,6 +99,8 @@ provider "github" {
 
 ### GitHub CLI Authentication
 
+~> The GitHub CLI authentication fallback is only available when using the legacy client implementation and will be removed in a future major release. To use the legacy client implementation, set `legacy_client = true` in the provider configuration or set the `GITHUB_LEGACY_CLIENT` environment variable to `true`.
+
 When using the GitHub CLI authentication fallback, you can optionally specify the path to the `gh` executable using the `GH_PATH` environment variable. This is useful when the provider cannot properly determine the path to GitHub CLI, such as in cygwin terminals. If not specified, the provider looks for `gh` in your system PATH.
 
 #### .env

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -63,6 +63,8 @@ Some API operations may not be available when using a GitHub App installation co
 
 ### GitHub CLI Authentication
 
+~> The GitHub CLI authentication fallback is only available when using the legacy client implementation and will be removed in a future major release. To use the legacy client implementation, set `legacy_client = true` in the provider configuration or set the `GITHUB_LEGACY_CLIENT` environment variable to `true`.
+
 When using the GitHub CLI authentication fallback, you can optionally specify the path to the `gh` executable using the `GH_PATH` environment variable. This is useful when the provider cannot properly determine the path to GitHub CLI, such as in cygwin terminals. If not specified, the provider looks for `gh` in your system PATH.
 
 #### .env


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #3536

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- Unclear why `gh` CLI authentication doesn't work in new client

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds deprecation notice to `gh` CLI authentication

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
