### PR TITLE
docs: update GitHub App env-var auth guidance for v6.13.0 blockless behavior

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,10 @@ To authenticate using a GitHub App installation, ensure that arguments in the `a
 
 Some API operations may not be available when using a GitHub App installation configuration. For more information, refer to the list of [supported endpoints](https://docs.github.com/en/rest/overview/endpoints-available-for-github-apps).
 
+~> The `app_auth` block is optional: the provider reads the `GITHUB_APP_XXX` environment variables directly. When you deliberately want GitHub App auth, keeping the block is recommended: its required arguments make `terraform validate` fail fast if a value is missing, and it lets you set non-secret values such as the App `id` directly. Drive auth from the environment without a block when the same configuration must also validate without the variables set, such as CI linting. The three patterns below cover each case.
+
+#### Block with values
+
 ```terraform
 provider "github" {
   owner = var.github_organization
@@ -78,9 +82,7 @@ provider "github" {
 }
 ```
 
-~> No `app_auth` block is needed when authenticating through the `GITHUB_APP_XXX` environment variables; the provider reads them directly. The previously documented empty `app_auth {}` block is no longer required and should be removed: its arguments are schema-required, so it fails `terraform validate` in environments where the variables are not set.
-
-#### .env
+#### Environment variables only
 
 ```shell
 export GITHUB_APP_ID="12332432" # Required: The GitHub App ID for authentication
@@ -88,12 +90,24 @@ export GITHUB_APP_INSTALLATION_ID="12435523" # Required: The GitHub App Installa
 export GITHUB_APP_PEM_FILE="..." # Required: Contents of the PEM file for the GitHub App, not the path to the PEM file
 ```
 
-#### main.tf
-
 ```terraform
 provider "github" {
   owner = var.github_organization
   # Credentials come from the `GITHUB_APP_XXX` environment variables.
+}
+```
+
+#### Non-secret values in configuration, secret from the environment
+
+```terraform
+provider "github" {
+  owner = var.github_organization
+  app_auth {
+    id              = "123456"   # the App ID and installation ID are not secret,
+    installation_id = "78901234" # so they can be set directly in configuration
+    # pem_file is omitted; it falls back to the GITHUB_APP_PEM_FILE variable,
+    # keeping the secret out of configuration
+  }
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,7 +78,7 @@ provider "github" {
 }
 ```
 
-~> When using environment variables, an empty `app_auth` block is required to allow provider configurations from environment variables to be specified. See: <https://github.com/hashicorp/terraform-plugin-sdk/issues/142>
+~> As of v6.13.0, no `app_auth` block is needed when authenticating through the `GITHUB_APP_XXX` environment variables; the provider reads them directly. On earlier versions, an empty `app_auth {}` block is required to allow provider configuration from environment variables (see: <https://github.com/hashicorp/terraform-plugin-sdk/issues/142>), but be aware that it fails `terraform validate` in environments where the variables are not set, because the block's arguments are schema-required.
 
 #### .env
 
@@ -93,7 +93,8 @@ export GITHUB_APP_PEM_FILE="..." # Required: Contents of the PEM file for the Gi
 ```terraform
 provider "github" {
   owner = var.github_organization
-  app_auth {} # When using `GITHUB_APP_XXX` environment variables
+  # Credentials come from the `GITHUB_APP_XXX` environment variables.
+  # On provider versions below v6.13.0, add: app_auth {}
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,7 +78,7 @@ provider "github" {
 }
 ```
 
-~> As of v6.13.0, no `app_auth` block is needed when authenticating through the `GITHUB_APP_XXX` environment variables; the provider reads them directly. On earlier versions, an empty `app_auth {}` block is required to allow provider configuration from environment variables (see: <https://github.com/hashicorp/terraform-plugin-sdk/issues/142>), but be aware that it fails `terraform validate` in environments where the variables are not set, because the block's arguments are schema-required.
+~> No `app_auth` block is needed when authenticating through the `GITHUB_APP_XXX` environment variables; the provider reads them directly. The previously documented empty `app_auth {}` block is no longer required and should be removed: its arguments are schema-required, so it fails `terraform validate` in environments where the variables are not set.
 
 #### .env
 
@@ -94,7 +94,6 @@ export GITHUB_APP_PEM_FILE="..." # Required: Contents of the PEM file for the Gi
 provider "github" {
   owner = var.github_organization
   # Credentials come from the `GITHUB_APP_XXX` environment variables.
-  # On provider versions below v6.13.0, add: app_auth {}
 }
 ```
 

--- a/examples/provider/app_auth_env/main.tf
+++ b/examples/provider/app_auth_env/main.tf
@@ -1,4 +1,4 @@
 provider "github" {
   owner = var.github_organization
-  app_auth {} # When using `GITHUB_APP_XXX` environment variables
+  # Credentials come from the `GITHUB_APP_XXX` environment variables.
 }

--- a/examples/provider/app_auth_mixed/main.tf
+++ b/examples/provider/app_auth_mixed/main.tf
@@ -1,0 +1,9 @@
+provider "github" {
+  owner = var.github_organization
+  app_auth {
+    id              = "123456"   # the App ID and installation ID are not secret,
+    installation_id = "78901234" # so they can be set directly in configuration
+    # pem_file is omitted; it falls back to the GITHUB_APP_PEM_FILE variable,
+    # keeping the secret out of configuration
+  }
+}

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -49,17 +49,21 @@ To authenticate using a GitHub App installation, ensure that arguments in the `a
 
 Some API operations may not be available when using a GitHub App installation configuration. For more information, refer to the list of [supported endpoints](https://docs.github.com/en/rest/overview/endpoints-available-for-github-apps).
 
+~> The `app_auth` block is optional: the provider reads the `GITHUB_APP_XXX` environment variables directly. When you deliberately want GitHub App auth, keeping the block is recommended: its required arguments make `terraform validate` fail fast if a value is missing, and it lets you set non-secret values such as the App `id` directly. Drive auth from the environment without a block when the same configuration must also validate without the variables set, such as CI linting. The three patterns below cover each case.
+
+#### Block with values
+
 {{ tffile "examples/provider/app_auth/main.tf" }}
 
-~> No `app_auth` block is needed when authenticating through the `GITHUB_APP_XXX` environment variables; the provider reads them directly. The previously documented empty `app_auth {}` block is no longer required and should be removed: its arguments are schema-required, so it fails `terraform validate` in environments where the variables are not set.
-
-#### .env
+#### Environment variables only
 
 {{ codefile "shell" "examples/provider/app_auth_env/.env" }}
 
-#### main.tf
-
 {{ tffile "examples/provider/app_auth_env/main.tf" }}
+
+#### Non-secret values in configuration, secret from the environment
+
+{{ tffile "examples/provider/app_auth_mixed/main.tf" }}
 
 ### GitHub CLI Authentication
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -51,7 +51,7 @@ Some API operations may not be available when using a GitHub App installation co
 
 {{ tffile "examples/provider/app_auth/main.tf" }}
 
-~> When using environment variables, an empty `app_auth` block is required to allow provider configurations from environment variables to be specified. See: <https://github.com/hashicorp/terraform-plugin-sdk/issues/142>
+~> No `app_auth` block is needed when authenticating through the `GITHUB_APP_XXX` environment variables; the provider reads them directly. The previously documented empty `app_auth {}` block is no longer required and should be removed: its arguments are schema-required, so it fails `terraform validate` in environments where the variables are not set.
 
 #### .env
 


### PR DESCRIPTION
Resolves #3550

----

### Before the change?

- The GitHub App Installation docs state that an empty `app_auth {}` block is required when authenticating through the `GITHUB_APP_XXX` environment variables, and the `main.tf` example shows that pattern.
- Since #3448 this is obsolete: `getAppAuth()` reads the environment variables directly, before consulting the block.
- The documented pattern also fails `terraform validate` / `tofu validate` in any environment where the variables are not set (CI linting, local pre-commit hooks), because the `app_auth` arguments are schema-required with `EnvDefaultFunc`. Details and reproduction in #3550.

### After the change?

- The note states that no `app_auth` block is needed for environment-variable auth, and that the previously documented empty block should be removed because it fails `validate` without the variables set.
- The `main.tf` example no longer shows an empty `app_auth {}` block.
- No per-version guidance included: registry docs are versioned, users on older provider versions see the matching older docs.

### Pull request checklist

- [ ] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
