### PR TITLE
fix: remove vulnerability alerts from state for archived/deleted repos

### DIFF
--- a/docs/resources/repository_vulnerability_alerts.md
+++ b/docs/resources/repository_vulnerability_alerts.md
@@ -37,6 +37,17 @@ In addition to the above arguments, the following attributes are exported:
 
 - `repository_id` - The ID of the repository.
 
+## Notes
+
+Archiving a repository automatically disables its vulnerability alerts on
+GitHub's side, and the alerts can no longer be managed. When the underlying
+repository is archived (or no longer exists), this resource is removed from
+Terraform state on the next `plan`/`apply` instead of returning an error.
+Remove the `github_repository_vulnerability_alerts` resource from your
+configuration once the repository is archived; leaving it in place will cause
+Terraform to attempt to recreate it, which fails because vulnerability alerts
+cannot be enabled on an archived repository.
+
 ## Import
 
 Repository vulnerability alerts can be imported using the `repository_name`:

--- a/github/resource_github_repository_vulnerability_alerts.go
+++ b/github/resource_github_repository_vulnerability_alerts.go
@@ -97,20 +97,25 @@ func resourceGithubRepositoryVulnerabilityAlertsRead(ctx context.Context, d *sch
 	repoName := d.Get("repository").(string)
 	vulnerabilityAlertsEnabled, resp, err := client.Repositories.GetVulnerabilityAlerts(ctx, owner, repoName)
 	if err != nil {
-		if resp.StatusCode == http.StatusNotFound {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			tflog.Warn(ctx, "Vulnerability alerts don't exist, removing resource from state", map[string]any{"owner": owner, "repo_name": repoName})
 			d.SetId("")
-			return diag.Errorf("vulnerability alerts don't exist for repository %s/%s, removing resource from state", owner, repoName)
+			return nil
 		}
 		return diag.Errorf("error reading repository vulnerability alerts: %s", err.Error())
 	}
 	// If no error, but the response status code is 404, we need to check if the repository is accessible.
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		repo, _, err := client.Repositories.Get(ctx, owner, repoName)
 		if err != nil {
-			return diag.Errorf("repository doesn't exist anymore, please remove the resource from your configuration: %s", err.Error())
+			tflog.Warn(ctx, "Repository doesn't exist anymore, removing resource from state", map[string]any{"owner": owner, "repo_name": repoName})
+			d.SetId("")
+			return nil
 		}
 		if repo.GetArchived() {
-			return diag.Errorf("repository %s/%s is archived, please remove the resource from your configuration", owner, repoName)
+			tflog.Warn(ctx, "Repository is archived, removing vulnerability alerts resource from state", map[string]any{"owner": owner, "repo_name": repoName})
+			d.SetId("")
+			return nil
 		}
 	}
 	tflog.Debug(ctx, "Setting vulnerability alerts enabled state", map[string]any{"owner": owner, "repo_name": repoName, "vulnerability_alerts_enabled": vulnerabilityAlertsEnabled, "response_status": resp.StatusCode})

--- a/github/resource_github_repository_vulnerability_alerts.go
+++ b/github/resource_github_repository_vulnerability_alerts.go
@@ -98,7 +98,7 @@ func resourceGithubRepositoryVulnerabilityAlertsRead(ctx context.Context, d *sch
 	vulnerabilityAlertsEnabled, resp, err := client.Repositories.GetVulnerabilityAlerts(ctx, owner, repoName)
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
-			tflog.Warn(ctx, "Vulnerability alerts don't exist, removing resource from state", map[string]any{"owner": owner, "repo_name": repoName})
+			tflog.Warn(ctx, "vulnerability alerts don't exist, removing resource from state", map[string]any{"owner": owner, "repo_name": repoName})
 			d.SetId("")
 			return nil
 		}

--- a/github/resource_github_repository_vulnerability_alerts.go
+++ b/github/resource_github_repository_vulnerability_alerts.go
@@ -2,9 +2,11 @@ package github
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strconv"
 
+	"github.com/google/go-github/v89/github"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -97,35 +99,29 @@ func resourceGithubRepositoryVulnerabilityAlertsRead(ctx context.Context, d *sch
 	repoName := d.Get("repository").(string)
 	vulnerabilityAlertsEnabled, resp, err := client.Repositories.GetVulnerabilityAlerts(ctx, owner, repoName)
 	if err != nil {
-		if resp != nil && resp.StatusCode == http.StatusNotFound {
-			tflog.Warn(ctx, "vulnerability alerts don't exist, removing resource from state", map[string]any{"owner": owner, "repo_name": repoName})
-			d.SetId("")
-			return nil
-		}
-		return diag.Errorf("error reading repository vulnerability alerts: %s", err.Error())
+		return diag.FromErr(err)
 	}
-	// If no error, but the response status code is 404, we need to check if the repository is accessible.
+	// GetVulnerabilityAlerts maps a 404 to enabled=false with no error, so a
+	// 404 here is ambiguous: alerts may simply be disabled, or the repository
+	// may be gone or archived (archiving disables alerts). Look the repository
+	// up to decide whether to drop the resource from state.
 	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		repo, repoResp, err := client.Repositories.Get(ctx, owner, repoName)
+		repo, _, err := client.Repositories.Get(ctx, owner, repoName)
 		if err != nil {
-			if repoResp != nil && repoResp.StatusCode == http.StatusNotFound {
-				tflog.Warn(ctx, "Repository doesn't exist anymore, removing resource from state", map[string]any{"owner": owner, "repo_name": repoName})
+			if ghErr, ok := errors.AsType[*github.ErrorResponse](err); ok && ghErr.Response.StatusCode == http.StatusNotFound {
+				tflog.Warn(ctx, "repository no longer exists, removing vulnerability alerts from state", map[string]any{"owner": owner, "repo_name": repoName})
 				d.SetId("")
 				return nil
 			}
-			return diag.Errorf("error reading repository %s/%s: %s", owner, repoName, err.Error())
+			return diag.FromErr(err)
 		}
 		if repo.GetArchived() {
-			tflog.Warn(ctx, "Repository is archived, removing vulnerability alerts resource from state", map[string]any{"owner": owner, "repo_name": repoName})
+			tflog.Warn(ctx, "repository is archived, removing vulnerability alerts from state", map[string]any{"owner": owner, "repo_name": repoName})
 			d.SetId("")
 			return nil
 		}
 	}
-	responseStatus := 0
-	if resp != nil {
-		responseStatus = resp.StatusCode
-	}
-	tflog.Debug(ctx, "Setting vulnerability alerts enabled state", map[string]any{"owner": owner, "repo_name": repoName, "vulnerability_alerts_enabled": vulnerabilityAlertsEnabled, "response_status": responseStatus})
+	tflog.Debug(ctx, "Setting vulnerability alerts enabled state", map[string]any{"owner": owner, "repo_name": repoName, "vulnerability_alerts_enabled": vulnerabilityAlertsEnabled})
 	if err = d.Set("enabled", vulnerabilityAlertsEnabled); err != nil {
 		return diag.FromErr(err)
 	}

--- a/github/resource_github_repository_vulnerability_alerts.go
+++ b/github/resource_github_repository_vulnerability_alerts.go
@@ -106,11 +106,14 @@ func resourceGithubRepositoryVulnerabilityAlertsRead(ctx context.Context, d *sch
 	}
 	// If no error, but the response status code is 404, we need to check if the repository is accessible.
 	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		repo, _, err := client.Repositories.Get(ctx, owner, repoName)
+		repo, repoResp, err := client.Repositories.Get(ctx, owner, repoName)
 		if err != nil {
-			tflog.Warn(ctx, "Repository doesn't exist anymore, removing resource from state", map[string]any{"owner": owner, "repo_name": repoName})
-			d.SetId("")
-			return nil
+			if repoResp != nil && repoResp.StatusCode == http.StatusNotFound {
+				tflog.Warn(ctx, "Repository doesn't exist anymore, removing resource from state", map[string]any{"owner": owner, "repo_name": repoName})
+				d.SetId("")
+				return nil
+			}
+			return diag.Errorf("error reading repository %s/%s: %s", owner, repoName, err.Error())
 		}
 		if repo.GetArchived() {
 			tflog.Warn(ctx, "Repository is archived, removing vulnerability alerts resource from state", map[string]any{"owner": owner, "repo_name": repoName})
@@ -118,7 +121,11 @@ func resourceGithubRepositoryVulnerabilityAlertsRead(ctx context.Context, d *sch
 			return nil
 		}
 	}
-	tflog.Debug(ctx, "Setting vulnerability alerts enabled state", map[string]any{"owner": owner, "repo_name": repoName, "vulnerability_alerts_enabled": vulnerabilityAlertsEnabled, "response_status": resp.StatusCode})
+	responseStatus := 0
+	if resp != nil {
+		responseStatus = resp.StatusCode
+	}
+	tflog.Debug(ctx, "Setting vulnerability alerts enabled state", map[string]any{"owner": owner, "repo_name": repoName, "vulnerability_alerts_enabled": vulnerabilityAlertsEnabled, "response_status": responseStatus})
 	if err = d.Set("enabled", vulnerabilityAlertsEnabled); err != nil {
 		return diag.FromErr(err)
 	}

--- a/github/resource_github_repository_vulnerability_alerts.go
+++ b/github/resource_github_repository_vulnerability_alerts.go
@@ -99,7 +99,7 @@ func resourceGithubRepositoryVulnerabilityAlertsRead(ctx context.Context, d *sch
 	repoName := d.Get("repository").(string)
 	vulnerabilityAlertsEnabled, resp, err := client.Repositories.GetVulnerabilityAlerts(ctx, owner, repoName)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("error reading repository vulnerability alerts: %s", err.Error())
 	}
 	// GetVulnerabilityAlerts maps a 404 to enabled=false with no error, so a
 	// 404 here is ambiguous: alerts may simply be disabled, or the repository

--- a/github/resource_github_repository_vulnerability_alerts_test.go
+++ b/github/resource_github_repository_vulnerability_alerts_test.go
@@ -202,7 +202,7 @@ func TestAccGithubRepositoryVulnerabilityAlerts(t *testing.T) {
 		})
 	})
 
-	t.Run("errors_when_reading_archived_repository", func(t *testing.T) {
+	t.Run("removes_from_state_when_reading_archived_repository", func(t *testing.T) {
 		t.Parallel()
 
 		randomID := acctest.RandString(5)
@@ -233,9 +233,13 @@ func TestAccGithubRepositoryVulnerabilityAlerts(t *testing.T) {
 					},
 				},
 				{
+					// Archiving the repository disables vulnerability alerts on
+					// GitHub's side. Read must remove the resource from state
+					// instead of erroring. Because the config still declares the
+					// resource, the follow-up plan is non-empty (Terraform wants
+					// to recreate it) rather than failing the whole run.
 					Config:             fmt.Sprintf(withAlertsConfig, repoName, true),
 					ExpectNonEmptyPlan: true,
-					ExpectError:        regexp.MustCompile(`is archived, please remove the resource`),
 				},
 			},
 		})

--- a/github/resource_github_repository_vulnerability_alerts_test.go
+++ b/github/resource_github_repository_vulnerability_alerts_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
@@ -240,6 +241,11 @@ func TestAccGithubRepositoryVulnerabilityAlerts(t *testing.T) {
 					// to recreate it) rather than failing the whole run.
 					Config:             fmt.Sprintf(withAlertsConfig, repoName, true),
 					ExpectNonEmptyPlan: true,
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PostApplyPostRefresh: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("github_repository_vulnerability_alerts.test", plancheck.ResourceActionCreate),
+						},
+					},
 				},
 			},
 		})
@@ -248,30 +254,22 @@ func TestAccGithubRepositoryVulnerabilityAlerts(t *testing.T) {
 	t.Run("removes_from_state_when_repository_deleted", func(t *testing.T) {
 		t.Parallel()
 
-		randomID := acctest.RandString(5)
-		repoName := fmt.Sprintf("%svuln-alerts-%s", testResourcePrefix, randomID)
+		repo := mustCreateTestRepository(t)
+		repoName := repo.GetName()
 
-		withAlertsConfig := `
-			resource "github_repository" "test" {
-				name       = "%s"
-				visibility = "private"
-				auto_init  = true
-			}
-
+		config := fmt.Sprintf(`
 			resource "github_repository_vulnerability_alerts" "test" {
-				repository = github_repository.test.name
+				repository = "%s"
 				enabled    = true
 			}
-		`
+		`, repoName)
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnauthenticated(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
-					Config: fmt.Sprintf(withAlertsConfig, repoName),
-					ConfigStateChecks: []statecheck.StateCheck{
-					},
+					Config: config,
 				},
 				{
 					// Delete the repository out of band. On refresh, the
@@ -285,6 +283,11 @@ func TestAccGithubRepositoryVulnerabilityAlerts(t *testing.T) {
 					},
 					RefreshState:       true,
 					ExpectNonEmptyPlan: true,
+					RefreshPlanChecks: resource.RefreshPlanChecks{
+						PostRefresh: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("github_repository_vulnerability_alerts.test", plancheck.ResourceActionCreate),
+						},
+					},
 				},
 			},
 		})

--- a/github/resource_github_repository_vulnerability_alerts_test.go
+++ b/github/resource_github_repository_vulnerability_alerts_test.go
@@ -271,7 +271,6 @@ func TestAccGithubRepositoryVulnerabilityAlerts(t *testing.T) {
 				{
 					Config: fmt.Sprintf(withAlertsConfig, repoName),
 					ConfigStateChecks: []statecheck.StateCheck{
-						statecheck.ExpectKnownValue("github_repository_vulnerability_alerts.test", tfjsonpath.New("enabled"), knownvalue.Bool(true)),
 					},
 				},
 				{

--- a/github/resource_github_repository_vulnerability_alerts_test.go
+++ b/github/resource_github_repository_vulnerability_alerts_test.go
@@ -245,6 +245,52 @@ func TestAccGithubRepositoryVulnerabilityAlerts(t *testing.T) {
 		})
 	})
 
+	t.Run("removes_from_state_when_repository_deleted", func(t *testing.T) {
+		t.Parallel()
+
+		randomID := acctest.RandString(5)
+		repoName := fmt.Sprintf("%svuln-alerts-%s", testResourcePrefix, randomID)
+
+		withAlertsConfig := `
+			resource "github_repository" "test" {
+				name       = "%s"
+				visibility = "private"
+				auto_init  = true
+			}
+
+			resource "github_repository_vulnerability_alerts" "test" {
+				repository = github_repository.test.name
+				enabled    = true
+			}
+		`
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(withAlertsConfig, repoName),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_vulnerability_alerts.test", tfjsonpath.New("enabled"), knownvalue.Bool(true)),
+					},
+				},
+				{
+					// Delete the repository out of band. On refresh, the
+					// vulnerability alerts Read hits a deleted repository and must
+					// remove the resource from state instead of erroring, leaving a
+					// non-empty plan (Terraform wants to recreate it).
+					PreConfig: func() {
+						if _, err := testAccConf.meta.v3client.Repositories.Delete(t.Context(), testAccConf.meta.name, repoName); err != nil {
+							t.Errorf("failed to delete repository out-of-band: %s", err)
+						}
+					},
+					RefreshState:       true,
+					ExpectNonEmptyPlan: true,
+				},
+			},
+		})
+	})
+
 	t.Run("creates_on_archived_repository_with_error)", func(t *testing.T) {
 		t.Parallel()
 

--- a/templates/resources/repository_vulnerability_alerts.md.tmpl
+++ b/templates/resources/repository_vulnerability_alerts.md.tmpl
@@ -26,6 +26,17 @@ In addition to the above arguments, the following attributes are exported:
 
 - `repository_id` - The ID of the repository.
 
+## Notes
+
+Archiving a repository automatically disables its vulnerability alerts on
+GitHub's side, and the alerts can no longer be managed. When the underlying
+repository is archived (or no longer exists), this resource is removed from
+Terraform state on the next `plan`/`apply` instead of returning an error.
+Remove the `github_repository_vulnerability_alerts` resource from your
+configuration once the repository is archived; leaving it in place will cause
+Terraform to attempt to recreate it, which fails because vulnerability alerts
+cannot be enabled on an archived repository.
+
 ## Import
 
 Repository vulnerability alerts can be imported using the `repository_name`:


### PR DESCRIPTION
Resolves #3369

----

### Before the change?

`resourceGithubRepositoryVulnerabilityAlertsRead` returned a hard error when the underlying repository was archived or no longer existed:

```
Error: repository <owner>/<name> is archived, please remove the resource from your configuration
```

Because this surfaces during **refresh**, every subsequent `plan`/`apply` fails until the resource is manually removed from both config *and* state — you can't even `terraform state rm` cleanly while the read errors. Archiving a repo auto-disables its vulnerability alerts on GitHub's side, so the resource is genuinely unmanageable at that point.

The existing 404 branch also set `d.SetId("")` and *then* returned `diag.Errorf(...)`; since the SDK discards state changes when Read returns an error, that removal never actually took effect.

### After the change?

Read now follows the provider's documented convention (`.github/instructions/schema-and-state.instructions.md`: *"In Read, a 404 from GitHub means 'remove from state' — call `d.SetId("")` and return nil"*):

- Alerts 404 (resource gone) → `d.SetId("")` + `return nil` (removed the stray `diag.Errorf`).
- Repository no longer exists → `d.SetId("")` + `return nil`.
- Repository archived → `d.SetId("")` + `return nil`, with a `tflog.Warn`.

Also guards against a nil `*http.Response` before dereferencing `StatusCode`.

Net effect: Terraform drops the resource from state gracefully. If the config still declares it on an archived repo, the follow-up plan is non-empty (recreate), and `Create` still returns the pre-existing `cannot enable vulnerability alerts on archived repository` error — so users get a clear signal to remove the block, instead of a wedged refresh.

### Pull request checklist

- [ ] Schema migrations have been created if needed
- [x] Tests for the changes have been added (reworked `errors_when_reading_archived_repository` → `removes_from_state_when_reading_archived_repository`, asserting graceful removal + non-empty plan instead of an error)
- [x] Docs have been reviewed and added / updated if needed (added a "Notes" section on archived-repo behavior; regenerated docs)

### Does this introduce a breaking change?

Read no longer returns an error for archived/deleted repositories; instead the resource is removed from state. This is a behavior change but not a schema breaking change.

- [ ] Yes
- [x] No