### PR TITLE
chore: Refactor max per page to owner struct

### DIFF
--- a/github/config.go
+++ b/github/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	RetryDelay        time.Duration
 	Token             string
 	WriteDelay        time.Duration
+	MaxPerPage        int
 }
 
 type Owner struct {
@@ -41,6 +42,7 @@ type Owner struct {
 	v4client       *githubv4.Client
 	StopContext    context.Context
 	IsOrganization bool
+	maxPerPage     int
 }
 
 const (

--- a/github/data_source_github_actions_environment_secrets.go
+++ b/github/data_source_github_actions_environment_secrets.go
@@ -78,7 +78,7 @@ func dataSourceGithubActionsEnvironmentSecretsRead(ctx context.Context, d *schem
 	}
 
 	var all_secrets []map[string]string
-	for secret, err := range client.Actions.ListEnvSecretsIter(ctx, owner, repoName, url.PathEscape(envName), &github.ListOptions{PerPage: maxPerPage}) {
+	for secret, err := range client.Actions.ListEnvSecretsIter(ctx, owner, repoName, url.PathEscape(envName), &github.ListOptions{PerPage: meta.maxPerPage}) {
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/github/data_source_github_actions_environment_variables.go
+++ b/github/data_source_github_actions_environment_variables.go
@@ -59,9 +59,10 @@ func dataSourceGithubActionsEnvironmentVariables() *schema.Resource {
 	}
 }
 
-func dataSourceGithubActionsEnvironmentVariablesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*Owner).v3client
-	owner := meta.(*Owner).name
+func dataSourceGithubActionsEnvironmentVariablesRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
 	var repoName string
 
 	envName := d.Get("environment").(string)
@@ -83,7 +84,7 @@ func dataSourceGithubActionsEnvironmentVariablesRead(ctx context.Context, d *sch
 	}
 
 	options := github.ListOptions{
-		PerPage: maxPerPage,
+		PerPage: meta.maxPerPage,
 	}
 
 	var all_variables []map[string]string

--- a/github/data_source_github_actions_organization_secrets.go
+++ b/github/data_source_github_actions_organization_secrets.go
@@ -42,12 +42,13 @@ func dataSourceGithubActionsOrganizationSecrets() *schema.Resource {
 	}
 }
 
-func dataSourceGithubActionsOrganizationSecretsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*Owner).v3client
-	owner := meta.(*Owner).name
+func dataSourceGithubActionsOrganizationSecretsRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
 
 	options := github.ListOptions{
-		PerPage: 100,
+		PerPage: meta.maxPerPage,
 	}
 
 	var allSecrets []map[string]string

--- a/github/data_source_github_actions_organization_variables.go
+++ b/github/data_source_github_actions_organization_variables.go
@@ -46,12 +46,13 @@ func dataSourceGithubActionsOrganizationVariables() *schema.Resource {
 	}
 }
 
-func dataSourceGithubActionsOrganizationVariablesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*Owner).v3client
-	owner := meta.(*Owner).name
+func dataSourceGithubActionsOrganizationVariablesRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
 
 	options := github.ListOptions{
-		PerPage: 100,
+		PerPage: meta.maxPerPage,
 	}
 
 	var all_variables []map[string]string

--- a/github/data_source_github_actions_secrets.go
+++ b/github/data_source_github_actions_secrets.go
@@ -50,9 +50,10 @@ func dataSourceGithubActionsSecrets() *schema.Resource {
 	}
 }
 
-func dataSourceGithubActionsSecretsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*Owner).v3client
-	owner := meta.(*Owner).name
+func dataSourceGithubActionsSecretsRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
 	var repoName string
 
 	if fullName, ok := d.GetOk("full_name"); ok {
@@ -72,7 +73,7 @@ func dataSourceGithubActionsSecretsRead(ctx context.Context, d *schema.ResourceD
 	}
 
 	options := github.ListOptions{
-		PerPage: 100,
+		PerPage: meta.maxPerPage,
 	}
 
 	var all_secrets []map[string]string

--- a/github/data_source_github_actions_variables.go
+++ b/github/data_source_github_actions_variables.go
@@ -54,9 +54,10 @@ func dataSourceGithubActionsVariables() *schema.Resource {
 	}
 }
 
-func dataSourceGithubActionsVariablesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*Owner).v3client
-	owner := meta.(*Owner).name
+func dataSourceGithubActionsVariablesRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
 	var repoName string
 
 	if fullName, ok := d.GetOk("full_name"); ok {
@@ -76,7 +77,7 @@ func dataSourceGithubActionsVariablesRead(ctx context.Context, d *schema.Resourc
 	}
 
 	options := github.ListOptions{
-		PerPage: 100,
+		PerPage: meta.maxPerPage,
 	}
 
 	var all_variables []map[string]string

--- a/github/data_source_github_branch_protection_rules.go
+++ b/github/data_source_github_branch_protection_rules.go
@@ -33,9 +33,10 @@ func dataSourceGithubBranchProtectionRules() *schema.Resource {
 	}
 }
 
-func dataSourceGithubBranchProtectionRulesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*Owner).v4client
-	orgName := meta.(*Owner).name
+func dataSourceGithubBranchProtectionRulesRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+	client := meta.v4client
+	orgName := meta.name
 	repoName := d.Get("repository").(string)
 
 	var query struct {
@@ -50,7 +51,7 @@ func dataSourceGithubBranchProtectionRulesRead(ctx context.Context, d *schema.Re
 		} `graphql:"repository(name: $name, owner: $owner)"`
 	}
 	variables := map[string]any{
-		"first":  githubv4.Int(100),
+		"first":  githubv4.Int(meta.maxPerPage),
 		"name":   githubv4.String(repoName),
 		"owner":  githubv4.String(orgName),
 		"cursor": (*githubv4.String)(nil),

--- a/github/data_source_github_codespaces_organization_secrets.go
+++ b/github/data_source_github_codespaces_organization_secrets.go
@@ -42,12 +42,13 @@ func dataSourceGithubCodespacesOrganizationSecrets() *schema.Resource {
 	}
 }
 
-func dataSourceGithubCodespacesOrganizationSecretsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*Owner).v3client
-	owner := meta.(*Owner).name
+func dataSourceGithubCodespacesOrganizationSecretsRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
 
 	options := github.ListOptions{
-		PerPage: 100,
+		PerPage: meta.maxPerPage,
 	}
 
 	var all_secrets []map[string]string

--- a/github/data_source_github_codespaces_secrets.go
+++ b/github/data_source_github_codespaces_secrets.go
@@ -52,9 +52,10 @@ func dataSourceGithubCodespacesSecrets() *schema.Resource {
 	}
 }
 
-func dataSourceGithubCodespacesSecretsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*Owner).v3client
-	owner := meta.(*Owner).name
+func dataSourceGithubCodespacesSecretsRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
 
 	var repoName string
 
@@ -75,7 +76,7 @@ func dataSourceGithubCodespacesSecretsRead(ctx context.Context, d *schema.Resour
 	}
 
 	options := github.ListOptions{
-		PerPage: 100,
+		PerPage: meta.maxPerPage,
 	}
 
 	var all_secrets []map[string]string

--- a/github/data_source_github_codespaces_user_secrets.go
+++ b/github/data_source_github_codespaces_user_secrets.go
@@ -42,12 +42,13 @@ func dataSourceGithubCodespacesUserSecrets() *schema.Resource {
 	}
 }
 
-func dataSourceGithubCodespacesUserSecretsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*Owner).v3client
-	owner := meta.(*Owner).name
+func dataSourceGithubCodespacesUserSecretsRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
 
 	options := github.ListOptions{
-		PerPage: 100,
+		PerPage: meta.maxPerPage,
 	}
 
 	var all_secrets []map[string]string

--- a/github/data_source_github_collaborators.go
+++ b/github/data_source_github_collaborators.go
@@ -121,8 +121,9 @@ func dataSourceGithubCollaborators() *schema.Resource {
 	}
 }
 
-func dataSourceGithubCollaboratorsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*Owner).v3client
+func dataSourceGithubCollaboratorsRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
 
 	owner := d.Get("owner").(string)
 	repo := d.Get("repository").(string)
@@ -133,7 +134,7 @@ func dataSourceGithubCollaboratorsRead(ctx context.Context, d *schema.ResourceDa
 		Affiliation: affiliation,
 		Permission:  permission,
 		ListOptions: github.ListOptions{
-			PerPage: maxPerPage,
+			PerPage: meta.maxPerPage,
 		},
 	}
 

--- a/github/data_source_github_dependabot_organization_secrets.go
+++ b/github/data_source_github_dependabot_organization_secrets.go
@@ -42,12 +42,13 @@ func dataSourceGithubDependabotOrganizationSecrets() *schema.Resource {
 	}
 }
 
-func dataSourceGithubDependabotOrganizationSecretsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*Owner).v3client
-	owner := meta.(*Owner).name
+func dataSourceGithubDependabotOrganizationSecretsRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
 
 	options := github.ListOptions{
-		PerPage: 100,
+		PerPage: meta.maxPerPage,
 	}
 
 	var all_secrets []map[string]string

--- a/github/data_source_github_dependabot_secrets.go
+++ b/github/data_source_github_dependabot_secrets.go
@@ -50,9 +50,10 @@ func dataSourceGithubDependabotSecrets() *schema.Resource {
 	}
 }
 
-func dataSourceGithubDependabotSecretsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*Owner).v3client
-	owner := meta.(*Owner).name
+func dataSourceGithubDependabotSecretsRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
 	var repoName string
 
 	if fullName, ok := d.GetOk("full_name"); ok {
@@ -72,7 +73,7 @@ func dataSourceGithubDependabotSecretsRead(ctx context.Context, d *schema.Resour
 	}
 
 	options := github.ListOptions{
-		PerPage: 100,
+		PerPage: meta.maxPerPage,
 	}
 
 	var all_secrets []map[string]string

--- a/github/data_source_github_issue_labels.go
+++ b/github/data_source_github_issue_labels.go
@@ -44,14 +44,14 @@ func dataSourceGithubIssueLabels() *schema.Resource {
 	}
 }
 
-func dataSourceGithubIssueLabelsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*Owner).v3client
-	owner := meta.(*Owner).name
+func dataSourceGithubIssueLabelsRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+	owner := meta.name
 	repository := d.Get("repository").(string)
 
 	d.SetId(repository)
 
-	labels, err := listLabels(client, ctx, owner, repository)
+	labels, err := listLabels(meta, ctx, owner, repository)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/github/data_source_github_organization.go
+++ b/github/data_source_github_organization.go
@@ -150,11 +150,12 @@ func dataSourceGithubOrganization() *schema.Resource {
 	}
 }
 
-func dataSourceGithubOrganizationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	name := d.Get("name").(string)
+func dataSourceGithubOrganizationRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+	client4 := meta.v4client
+	client3 := meta.v3client
 
-	client4 := meta.(*Owner).v4client
-	client3 := meta.(*Owner).v3client
+	name, _ := d.Get("name").(string)
 
 	organization, _, err := client3.Organizations.Get(ctx, name)
 	if err != nil {
@@ -168,7 +169,7 @@ func dataSourceGithubOrganizationRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	opts := &github.RepositoryListByOrgOptions{
-		ListOptions: github.ListOptions{PerPage: 100, Page: 1},
+		ListOptions: github.ListOptions{PerPage: meta.maxPerPage, Page: 1},
 	}
 
 	summaryOnly := d.Get("summary_only").(bool)
@@ -215,11 +216,12 @@ func dataSourceGithubOrganizationRead(ctx context.Context, d *schema.ResourceDat
 						EndCursor   githubv4.String
 						HasNextPage bool
 					}
-				} `graphql:"membersWithRole(first: 100, after: $after)"`
+				} `graphql:"membersWithRole(first: $first, after: $after)"`
 			} `graphql:"organization(login: $login)"`
 		}
 		variables := map[string]any{
 			"login": githubv4.String(name),
+			"first": githubv4.Int(meta.maxPerPage),
 			"after": (*githubv4.String)(nil),
 		}
 		var members []string

--- a/github/data_source_github_organization_app_installations.go
+++ b/github/data_source_github_organization_app_installations.go
@@ -101,7 +101,7 @@ func dataSourceGithubOrganizationAppInstallationsRead(ctx context.Context, d *sc
 	client := meta.v3client
 
 	options := &github.ListOptions{
-		PerPage: maxPerPage,
+		PerPage: meta.maxPerPage,
 	}
 
 	results := make([]map[string]any, 0)

--- a/github/data_source_github_organization_external_identities.go
+++ b/github/data_source_github_organization_external_identities.go
@@ -68,20 +68,22 @@ func dataSourceGithubOrganizationExternalIdentities() *schema.Resource {
 	}
 }
 
-func dataSourceGithubOrganizationExternalIdentitiesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	name := meta.(*Owner).name
+func dataSourceGithubOrganizationExternalIdentitiesRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+	name := meta.name
 
-	client4 := meta.(*Owner).v4client
+	client4 := meta.v4client
 
 	var query struct {
 		Organization struct {
 			SamlIdentityProvider struct {
-				ExternalIdentities `graphql:"externalIdentities(first: 100, after: $after)"`
+				ExternalIdentities `graphql:"externalIdentities(first: $first, after: $after)"`
 			}
 		} `graphql:"organization(login: $login)"`
 	}
 	variables := map[string]any{
 		"login": githubv4.String(name),
+		"first": githubv4.Int(meta.maxPerPage),
 		"after": (*githubv4.String)(nil),
 	}
 

--- a/github/data_source_github_organization_ip_allow_list.go
+++ b/github/data_source_github_organization_ip_allow_list.go
@@ -49,14 +49,15 @@ func dataSourceGithubOrganizationIpAllowList() *schema.Resource {
 	}
 }
 
-func dataSourceGithubOrganizationIpAllowListRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func dataSourceGithubOrganizationIpAllowListRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
 	err := checkOrganization(meta)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	client := meta.(*Owner).v4client
-	orgName := meta.(*Owner).name
+	client := meta.v4client
+	orgName := meta.name
 
 	type IpAllowListEntry struct {
 		ID             githubv4.String
@@ -76,12 +77,13 @@ func dataSourceGithubOrganizationIpAllowListRead(ctx context.Context, d *schema.
 	var query struct {
 		Organization struct {
 			ID                 githubv4.String
-			IpAllowListEntries IpAllowListEntries `graphql:"ipAllowListEntries(first: 100, after: $entriesCursor)"`
+			IpAllowListEntries IpAllowListEntries `graphql:"ipAllowListEntries(first: $first, after: $entriesCursor)"`
 		} `graphql:"organization(login: $login)"`
 	}
 
 	variables := map[string]any{
 		"login":         githubv4.String(orgName),
+		"first":         githubv4.Int(meta.maxPerPage),
 		"entriesCursor": (*githubv4.String)(nil),
 	}
 

--- a/github/data_source_github_organization_role_teams.go
+++ b/github/data_source_github_organization_role_teams.go
@@ -113,7 +113,7 @@ func dataSourceGithubOrganizationRoleTeamsRead(ctx context.Context, d *schema.Re
 	roleID := int64(roleIdInt)
 
 	teams := make([]any, 0)
-	for team, err := range meta.v3client.Organizations.ListTeamsAssignedToOrgRoleIter(ctx, meta.name, roleID, &github.ListOptions{PerPage: maxPerPage}) {
+	for team, err := range meta.v3client.Organizations.ListTeamsAssignedToOrgRoleIter(ctx, meta.name, roleID, &github.ListOptions{PerPage: meta.maxPerPage}) {
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/github/data_source_github_organization_role_users.go
+++ b/github/data_source_github_organization_role_users.go
@@ -63,7 +63,7 @@ func dataSourceGithubOrganizationRoleUsersRead(ctx context.Context, d *schema.Re
 	roleID := int64(roleIdInt)
 
 	users := make([]any, 0)
-	for user, err := range meta.v3client.Organizations.ListUsersAssignedToOrgRoleIter(ctx, meta.name, roleID, &github.ListOptions{PerPage: maxPerPage}) {
+	for user, err := range meta.v3client.Organizations.ListUsersAssignedToOrgRoleIter(ctx, meta.name, roleID, &github.ListOptions{PerPage: meta.maxPerPage}) {
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/github/data_source_github_organization_team_sync_groups.go
+++ b/github/data_source_github_organization_team_sync_groups.go
@@ -38,13 +38,14 @@ func dataSourceGithubOrganizationTeamSyncGroups() *schema.Resource {
 	}
 }
 
-func dataSourceGithubOrganizationTeamSyncGroupsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*Owner).v3client
+func dataSourceGithubOrganizationTeamSyncGroupsRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
 
-	orgName := meta.(*Owner).name
+	orgName := meta.name
 	options := &github.ListIDPGroupsOptions{
 		ListCursorOptions: github.ListCursorOptions{
-			PerPage: maxPerPage,
+			PerPage: meta.maxPerPage,
 		},
 	}
 

--- a/github/data_source_github_organization_teams.go
+++ b/github/data_source_github_organization_teams.go
@@ -159,7 +159,7 @@ func dataSourceGithubOrganizationTeamsRead(ctx context.Context, d *schema.Resour
 	summaryOnly, _ := d.Get("summary_only").(bool)
 
 	teams := make([]map[string]any, 0)
-	for team, err := range meta.v3client.Teams.ListTeamsIter(ctx, meta.name, &github.ListOptions{PerPage: maxPerPage}) {
+	for team, err := range meta.v3client.Teams.ListTeamsIter(ctx, meta.name, &github.ListOptions{PerPage: meta.maxPerPage}) {
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -212,7 +212,7 @@ func dataSourceGithubOrganizationTeamsRead(ctx context.Context, d *schema.Resour
 		if !summaryOnly {
 			var members, repositories []string
 
-			for member, err := range meta.v3client.Teams.ListTeamMembersBySlugIter(ctx, meta.name, team.GetSlug(), &github.TeamListTeamMembersOptions{ListOptions: github.ListOptions{PerPage: maxPerPage}}) {
+			for member, err := range meta.v3client.Teams.ListTeamMembersBySlugIter(ctx, meta.name, team.GetSlug(), &github.TeamListTeamMembersOptions{ListOptions: github.ListOptions{PerPage: meta.maxPerPage}}) {
 				if err != nil {
 					if ghErr, ok := errors.AsType[*github.ErrorResponse](err); ok && ghErr.Response.StatusCode == http.StatusNotFound {
 						tflog.Warn(ctx, "Team members are not accessible, this is likely because the team has been deleted.", map[string]any{"team": team.GetSlug()})
@@ -228,7 +228,7 @@ func dataSourceGithubOrganizationTeamsRead(ctx context.Context, d *schema.Resour
 				members = append(members, member.GetLogin())
 			}
 
-			for repo, err := range meta.v3client.Teams.ListTeamReposBySlugIter(ctx, meta.name, team.GetSlug(), &github.ListOptions{PerPage: maxPerPage}) {
+			for repo, err := range meta.v3client.Teams.ListTeamReposBySlugIter(ctx, meta.name, team.GetSlug(), &github.ListOptions{PerPage: meta.maxPerPage}) {
 				if err != nil {
 					if ghErr, ok := errors.AsType[*github.ErrorResponse](err); ok && ghErr.Response.StatusCode == http.StatusNotFound {
 						tflog.Warn(ctx, "Team repositories are not accessible, this is likely because the team has been deleted.", map[string]any{"team": team.GetSlug()})

--- a/github/data_source_github_organization_webhooks.go
+++ b/github/data_source_github_organization_webhooks.go
@@ -45,13 +45,13 @@ func dataSourceGithubOrganizationWebhooks() *schema.Resource {
 	}
 }
 
-func dataSourceGithubOrganizationWebhooksRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	owner := meta.(*Owner).name
-
-	client := meta.(*Owner).v3client
+func dataSourceGithubOrganizationWebhooksRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+	owner := meta.name
+	client := meta.v3client
 
 	options := &github.ListOptions{
-		PerPage: 100,
+		PerPage: meta.maxPerPage,
 	}
 
 	results := make([]map[string]any, 0)

--- a/github/data_source_github_repository_deploy_keys.go
+++ b/github/data_source_github_repository_deploy_keys.go
@@ -46,14 +46,15 @@ func dataSourceGithubRepositoryDeployKeys() *schema.Resource {
 	}
 }
 
-func dataSourceGithubRepositoryDeployKeysRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	repository := d.Get("repository").(string)
-	owner := meta.(*Owner).name
+func dataSourceGithubRepositoryDeployKeysRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+	owner := meta.name
+	client := meta.v3client
 
-	client := meta.(*Owner).v3client
+	repository, _ := d.Get("repository").(string)
 
 	options := &github.ListOptions{
-		PerPage: 100,
+		PerPage: meta.maxPerPage,
 	}
 
 	results := make([]map[string]any, 0)

--- a/github/data_source_github_repository_deployment_branch_policies.go
+++ b/github/data_source_github_repository_deployment_branch_policies.go
@@ -57,7 +57,7 @@ func dataSourceGithubRepositoryDeploymentBranchPoliciesRead(ctx context.Context,
 	environmentName := d.Get("environment_name").(string)
 
 	results := make([]map[string]any, 0)
-	listOptions := &github.ListOptions{PerPage: maxPerPage}
+	listOptions := &github.ListOptions{PerPage: meta.maxPerPage}
 	for {
 		policies, resp, err := client.Repositories.ListDeploymentBranchPolicies(ctx, owner, repoName, environmentName, listOptions)
 		if err != nil {

--- a/github/data_source_github_repository_environment_deployment_policies.go
+++ b/github/data_source_github_repository_environment_deployment_policies.go
@@ -46,14 +46,15 @@ func dataSourceGithubRepositoryEnvironmentDeploymentPolicies() *schema.Resource 
 	}
 }
 
-func dataSourceGithubRepositoryEnvironmentDeploymentPoliciesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*Owner).v3client
-	owner := meta.(*Owner).name
+func dataSourceGithubRepositoryEnvironmentDeploymentPoliciesRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
 	repoName := d.Get("repository").(string)
 	envName := d.Get("environment").(string)
 
 	results := make([]map[string]any, 0)
-	listOptions := &github.ListOptions{PerPage: maxPerPage}
+	listOptions := &github.ListOptions{PerPage: meta.maxPerPage}
 	for {
 		policies, resp, err := client.Repositories.ListDeploymentBranchPolicies(ctx, owner, repoName, url.PathEscape(envName), listOptions)
 		if err != nil {

--- a/github/data_source_github_repository_pull_requests.go
+++ b/github/data_source_github_repository_pull_requests.go
@@ -129,10 +129,11 @@ func dataSourceGithubRepositoryPullRequests() *schema.Resource {
 	}
 }
 
-func dataSourceGithubRepositoryPullRequestsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	client := meta.(*Owner).v3client
+func dataSourceGithubRepositoryPullRequestsRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
 
-	owner := meta.(*Owner).name
 	if explicitOwner, ok := d.GetOk("owner"); ok {
 		owner = explicitOwner.(string)
 	}
@@ -145,7 +146,7 @@ func dataSourceGithubRepositoryPullRequestsRead(ctx context.Context, d *schema.R
 	direction := d.Get("sort_direction").(string)
 
 	options := &github.PullRequestListOptions{
-		ListOptions: github.ListOptions{PerPage: 100},
+		ListOptions: github.ListOptions{PerPage: meta.maxPerPage},
 		State:       state,
 		Head:        head,
 		Base:        base,

--- a/github/data_source_github_repository_teams.go
+++ b/github/data_source_github_repository_teams.go
@@ -112,7 +112,7 @@ func dataSourceGithubRepositoryTeamsRead(ctx context.Context, d *schema.Resource
 	}
 
 	var teams []map[string]any
-	for team, err := range meta.v3client.Repositories.ListTeamsIter(ctx, owner, repoName, &github.ListOptions{PerPage: maxPerPage}) {
+	for team, err := range meta.v3client.Repositories.ListTeamsIter(ctx, owner, repoName, &github.ListOptions{PerPage: meta.maxPerPage}) {
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/github/data_source_github_repository_webhooks.go
+++ b/github/data_source_github_repository_webhooks.go
@@ -50,14 +50,15 @@ func dataSourceGithubRepositoryWebhooks() *schema.Resource {
 	}
 }
 
-func dataSourceGithubRepositoryWebhooksRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	repository := d.Get("repository").(string)
-	owner := meta.(*Owner).name
+func dataSourceGithubRepositoryWebhooksRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
+	owner := meta.name
+	client := meta.v3client
 
-	client := meta.(*Owner).v3client
+	repository, _ := d.Get("repository").(string)
 
 	options := &github.ListOptions{
-		PerPage: 100,
+		PerPage: meta.maxPerPage,
 	}
 
 	results := make([]map[string]any, 0)

--- a/github/data_source_github_team.go
+++ b/github/data_source_github_team.go
@@ -205,7 +205,7 @@ func dataSourceGithubTeamRead(ctx context.Context, d *schema.ResourceData, m any
 	if !summaryOnly {
 		membershipType, _ := d.Get("membership_type").(string)
 
-		for member, err := range client.Teams.ListTeamMembersBySlugIter(ctx, meta.name, team.GetSlug(), &github.TeamListTeamMembersOptions{ListOptions: github.ListOptions{PerPage: maxPerPage}}) {
+		for member, err := range client.Teams.ListTeamMembersBySlugIter(ctx, meta.name, team.GetSlug(), &github.TeamListTeamMembersOptions{ListOptions: github.ListOptions{PerPage: meta.maxPerPage}}) {
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -217,7 +217,7 @@ func dataSourceGithubTeamRead(ctx context.Context, d *schema.ResourceData, m any
 			members = append(members, member.GetLogin())
 		}
 
-		for repo, err := range client.Teams.ListTeamReposBySlugIter(ctx, meta.name, team.GetSlug(), &github.ListOptions{PerPage: maxPerPage}) {
+		for repo, err := range client.Teams.ListTeamReposBySlugIter(ctx, meta.name, team.GetSlug(), &github.ListOptions{PerPage: meta.maxPerPage}) {
 			if err != nil {
 				return diag.FromErr(err)
 			}

--- a/github/provider.go
+++ b/github/provider.go
@@ -488,8 +488,7 @@ func configureProvider(version, commit string) func(context.Context, *schema.Res
 		if v, ok := d.GetOk("max_per_page"); ok {
 			if i, ok := v.(int); ok {
 				tflog.Debug(ctx, "Using max per page from provider configuration.", map[string]any{"max_per_page": i})
-				// TODO: Move max per page to the provider metadata and remove the global variable.
-				maxPerPage = i
+				config.MaxPerPage = i
 			}
 		}
 
@@ -526,7 +525,8 @@ func configureProvider(version, commit string) func(context.Context, *schema.Res
 // configureProviderMeta initializes the provider metadata, including setting up the GitHub API clients based on the provided configuration. It returns the initialized metadata or an error if the configuration is invalid or if there are issues initializing the clients.
 func configureProviderMeta(ctx context.Context, version string, c *Config) (*Owner, error) {
 	owner := &Owner{
-		name: c.Owner,
+		name:       c.Owner,
+		maxPerPage: c.MaxPerPage,
 	}
 
 	if c.LegacyClient {

--- a/github/resource_github_actions_organization_permissions.go
+++ b/github/resource_github_actions_organization_permissions.go
@@ -137,9 +137,10 @@ func resourceGithubActionsEnabledRepositoriesObject(d *schema.ResourceData) ([]i
 	return enabled, nil
 }
 
-func resourceGithubActionsOrganizationPermissionsCreateOrUpdate(d *schema.ResourceData, meta any) error {
-	client := meta.(*Owner).v3client
-	orgName := meta.(*Owner).name
+func resourceGithubActionsOrganizationPermissionsCreateOrUpdate(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+	orgName := meta.name
 	ctx := context.Background()
 	if !d.IsNewResource() {
 		ctx = context.WithValue(ctx, ctxId, d.Id())
@@ -201,8 +202,9 @@ func resourceGithubActionsOrganizationPermissionsCreateOrUpdate(d *schema.Resour
 	return resourceGithubActionsOrganizationPermissionsRead(d, meta)
 }
 
-func resourceGithubActionsOrganizationPermissionsRead(d *schema.ResourceData, meta any) error {
-	client := meta.(*Owner).v3client
+func resourceGithubActionsOrganizationPermissionsRead(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
 	ctx := context.Background()
 
 	err := checkOrganization(meta)
@@ -250,7 +252,7 @@ func resourceGithubActionsOrganizationPermissionsRead(d *schema.ResourceData, me
 	}
 
 	if actionsPermissions.GetEnabledRepositories() == "selected" {
-		opts := github.ListOptions{PerPage: maxPerPage}
+		opts := github.ListOptions{PerPage: meta.maxPerPage}
 		var repoList []int64
 		var allRepos []*github.Repository
 
@@ -303,9 +305,10 @@ func resourceGithubActionsOrganizationPermissionsRead(d *schema.ResourceData, me
 	return nil
 }
 
-func resourceGithubActionsOrganizationPermissionsDelete(d *schema.ResourceData, meta any) error {
-	client := meta.(*Owner).v3client
-	orgName := meta.(*Owner).name
+func resourceGithubActionsOrganizationPermissionsDelete(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+	orgName := meta.name
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
 	err := checkOrganization(meta)

--- a/github/resource_github_actions_organization_secret.go
+++ b/github/resource_github_actions_organization_secret.go
@@ -248,7 +248,7 @@ func resourceGithubActionsOrganizationSecretRead(ctx context.Context, d *schema.
 	if secret.Visibility == "selected" {
 		if _, ok := d.GetOk("selected_repository_ids"); ok {
 			var repoIDs []int64
-			for repo, err := range client.Actions.ListSelectedReposForOrgSecretIter(ctx, owner, secretName, &github.ListOptions{PerPage: maxPerPage}) {
+			for repo, err := range client.Actions.ListSelectedReposForOrgSecretIter(ctx, owner, secretName, &github.ListOptions{PerPage: meta.maxPerPage}) {
 				if err != nil {
 					return diag.FromErr(err)
 				}

--- a/github/resource_github_actions_organization_secret_repositories.go
+++ b/github/resource_github_actions_organization_secret_repositories.go
@@ -79,7 +79,7 @@ func resourceGithubActionsOrganizationSecretRepositoriesRead(ctx context.Context
 
 	repoIDs := []int64{}
 	opt := &github.ListOptions{
-		PerPage: maxPerPage,
+		PerPage: meta.maxPerPage,
 	}
 	for {
 		results, resp, err := client.Actions.ListSelectedReposForOrgSecret(ctx, owner, secretName, opt)
@@ -134,7 +134,7 @@ func resourceGithubActionsOrganizationSecretRepositoriesImport(ctx context.Conte
 
 	repoIDs := []int64{}
 	opt := &github.ListOptions{
-		PerPage: maxPerPage,
+		PerPage: meta.maxPerPage,
 	}
 	for {
 		results, resp, err := client.Actions.ListSelectedReposForOrgSecret(ctx, owner, secretName, opt)

--- a/github/resource_github_actions_organization_secret_repository.go
+++ b/github/resource_github_actions_organization_secret_repository.go
@@ -76,7 +76,7 @@ func resourceGithubActionsOrganizationSecretRepositoryRead(ctx context.Context, 
 	repoIDInt, _ := d.Get("repository_id").(int)
 	repoID := int64(repoIDInt)
 
-	for repo, err := range client.Actions.ListSelectedReposForOrgSecretIter(ctx, owner, secretName, &github.ListOptions{PerPage: maxPerPage}) {
+	for repo, err := range client.Actions.ListSelectedReposForOrgSecretIter(ctx, owner, secretName, &github.ListOptions{PerPage: meta.maxPerPage}) {
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/github/resource_github_actions_organization_variable.go
+++ b/github/resource_github_actions_organization_variable.go
@@ -149,7 +149,7 @@ func resourceGithubActionsOrganizationVariableRead(ctx context.Context, d *schem
 	if variable.GetVisibility() == "selected" {
 		if _, ok := d.GetOk("selected_repository_ids"); ok {
 			var repoIDs []int64
-			for repo, err := range client.Actions.ListSelectedReposForOrgVariableIter(ctx, owner, varName, &github.ListOptions{PerPage: maxPerPage}) {
+			for repo, err := range client.Actions.ListSelectedReposForOrgVariableIter(ctx, owner, varName, &github.ListOptions{PerPage: meta.maxPerPage}) {
 				if err != nil {
 					return diag.FromErr(err)
 				}

--- a/github/resource_github_actions_organization_variable_repositories.go
+++ b/github/resource_github_actions_organization_variable_repositories.go
@@ -79,7 +79,7 @@ func resourceGithubActionsOrganizationVariableRepositoriesRead(ctx context.Conte
 
 	repoIDs := []int64{}
 	opt := &github.ListOptions{
-		PerPage: maxPerPage,
+		PerPage: meta.maxPerPage,
 	}
 	for {
 		results, resp, err := client.Actions.ListSelectedReposForOrgVariable(ctx, owner, variableName, opt)
@@ -134,7 +134,7 @@ func resourceGithubActionsOrganizationVariableRepositoriesImport(ctx context.Con
 
 	repoIDs := []int64{}
 	opt := &github.ListOptions{
-		PerPage: maxPerPage,
+		PerPage: meta.maxPerPage,
 	}
 	for {
 		results, resp, err := client.Actions.ListSelectedReposForOrgVariable(ctx, owner, variableName, opt)

--- a/github/resource_github_actions_organization_variable_repository.go
+++ b/github/resource_github_actions_organization_variable_repository.go
@@ -80,7 +80,7 @@ func resourceGithubActionsOrganizationVariableRepositoryRead(ctx context.Context
 	repoID := int64(d.Get("repository_id").(int))
 
 	opt := &github.ListOptions{
-		PerPage: maxPerPage,
+		PerPage: meta.maxPerPage,
 	}
 
 	for {

--- a/github/resource_github_actions_runner_group.go
+++ b/github/resource_github_actions_runner_group.go
@@ -96,14 +96,16 @@ func resourceGithubActionsRunnerGroup() *schema.Resource {
 	}
 }
 
-func resourceGithubActionsRunnerGroupCreate(d *schema.ResourceData, meta any) error {
+func resourceGithubActionsRunnerGroupCreate(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
 	err := checkOrganization(meta)
 	if err != nil {
 		return err
 	}
 
-	client := meta.(*Owner).v3client
-	orgName := meta.(*Owner).name
+	client := meta.v3client
+	orgName := meta.name
+
 	name := d.Get("name").(string)
 	restrictedToWorkflows := d.Get("restricted_to_workflows").(bool)
 	visibility := d.Get("visibility").(string)
@@ -133,7 +135,8 @@ func resourceGithubActionsRunnerGroupCreate(d *schema.ResourceData, meta any) er
 
 	ctx := context.Background()
 
-	runnerGroup, resp, err := client.Actions.CreateOrganizationRunnerGroup(ctx,
+	runnerGroup, resp, err := client.Actions.CreateOrganizationRunnerGroup(
+		ctx,
 		orgName,
 		github.CreateRunnerGroupRequest{
 			Name:                     &name,
@@ -201,14 +204,15 @@ func getOrganizationRunnerGroup(client *github.Client, ctx context.Context, org 
 	return runnerGroup, resp, err
 }
 
-func resourceGithubActionsRunnerGroupRead(d *schema.ResourceData, meta any) error {
+func resourceGithubActionsRunnerGroupRead(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
 	err := checkOrganization(meta)
 	if err != nil {
 		return err
 	}
 
-	client := meta.(*Owner).v3client
-	orgName := meta.(*Owner).name
+	client := meta.v3client
+	orgName := meta.name
 
 	runnerGroupID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
@@ -274,7 +278,7 @@ func resourceGithubActionsRunnerGroupRead(d *schema.ResourceData, meta any) erro
 
 	selectedRepositoryIDs := []int64{}
 	options := github.ListOptions{
-		PerPage: maxPerPage,
+		PerPage: meta.maxPerPage,
 	}
 
 	for {
@@ -301,14 +305,15 @@ func resourceGithubActionsRunnerGroupRead(d *schema.ResourceData, meta any) erro
 	return nil
 }
 
-func resourceGithubActionsRunnerGroupUpdate(d *schema.ResourceData, meta any) error {
+func resourceGithubActionsRunnerGroupUpdate(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
 	err := checkOrganization(meta)
 	if err != nil {
 		return err
 	}
 
-	client := meta.(*Owner).v3client
-	orgName := meta.(*Owner).name
+	client := meta.v3client
+	orgName := meta.name
 
 	name := d.Get("name").(string)
 	visibility := d.Get("visibility").(string)
@@ -359,14 +364,15 @@ func resourceGithubActionsRunnerGroupUpdate(d *schema.ResourceData, meta any) er
 	return resourceGithubActionsRunnerGroupRead(d, meta)
 }
 
-func resourceGithubActionsRunnerGroupDelete(d *schema.ResourceData, meta any) error {
+func resourceGithubActionsRunnerGroupDelete(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
 	err := checkOrganization(meta)
 	if err != nil {
 		return err
 	}
 
-	client := meta.(*Owner).v3client
-	orgName := meta.(*Owner).name
+	client := meta.v3client
+	orgName := meta.name
 	runnerGroupID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
 		return err

--- a/github/resource_github_app_installation_repositories.go
+++ b/github/resource_github_app_installation_repositories.go
@@ -39,12 +39,14 @@ func resourceGithubAppInstallationRepositories() *schema.Resource {
 	}
 }
 
-func resourceGithubAppInstallationRepositoriesCreateOrUpdate(d *schema.ResourceData, meta any) error {
+func resourceGithubAppInstallationRepositoriesCreateOrUpdate(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
+
 	installationIDString := d.Get("installation_id").(string)
 	selectedRepositories := d.Get("selected_repositories")
 
-	client := meta.(*Owner).v3client
-	owner := meta.(*Owner).name
 	ctx := context.WithValue(context.Background(), ctxId, installationIDString)
 
 	selectedRepositoryNames := []string{}
@@ -96,7 +98,8 @@ func resourceGithubAppInstallationRepositoriesCreateOrUpdate(d *schema.ResourceD
 	return resourceGithubAppInstallationRepositoriesRead(d, meta)
 }
 
-func resourceGithubAppInstallationRepositoriesRead(d *schema.ResourceData, meta any) error {
+func resourceGithubAppInstallationRepositoriesRead(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
 	installationIDString := d.Id()
 
 	reposNameIDs, _, err := getAllAccessibleRepos(meta, installationIDString)
@@ -125,7 +128,9 @@ func resourceGithubAppInstallationRepositoriesRead(d *schema.ResourceData, meta 
 	return nil
 }
 
-func resourceGithubAppInstallationRepositoriesDelete(d *schema.ResourceData, meta any) error {
+func resourceGithubAppInstallationRepositoriesDelete(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+
 	installationIDString := d.Get("installation_id").(string)
 
 	reposNameIDs, instID, err := getAllAccessibleRepos(meta, installationIDString)
@@ -133,7 +138,7 @@ func resourceGithubAppInstallationRepositoriesDelete(d *schema.ResourceData, met
 		return err
 	}
 
-	client := meta.(*Owner).v3client
+	client := meta.v3client
 	ctx := context.WithValue(context.Background(), ctxId, installationIDString)
 
 	// There is a github limitation that means we can't remove the last repository from an installation.
@@ -156,15 +161,15 @@ func resourceGithubAppInstallationRepositoriesDelete(d *schema.ResourceData, met
 	return nil
 }
 
-func getAllAccessibleRepos(meta any, idString string) (map[string]int64, int64, error) {
+func getAllAccessibleRepos(meta *Owner, idString string) (map[string]int64, int64, error) {
 	installationID, err := strconv.ParseInt(idString, 10, 64)
 	if err != nil {
 		return nil, 0, unconvertibleIdErr(idString, err)
 	}
 
 	ctx := context.WithValue(context.Background(), ctxId, idString)
-	opt := &github.ListOptions{PerPage: maxPerPage}
-	client := meta.(*Owner).v3client
+	opt := &github.ListOptions{PerPage: meta.maxPerPage}
+	client := meta.v3client
 
 	allRepos := make(map[string]int64)
 

--- a/github/resource_github_app_installation_repository.go
+++ b/github/resource_github_app_installation_repository.go
@@ -39,15 +39,16 @@ func resourceGithubAppInstallationRepository() *schema.Resource {
 	}
 }
 
-func resourceGithubAppInstallationRepositoryCreate(d *schema.ResourceData, meta any) error {
+func resourceGithubAppInstallationRepositoryCreate(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
 	installationIDString := d.Get("installation_id").(string)
 	installationID, err := strconv.ParseInt(installationIDString, 10, 64)
 	if err != nil {
 		return unconvertibleIdErr(installationIDString, err)
 	}
 
-	client := meta.(*Owner).v3client
-	owner := meta.(*Owner).name
+	client := meta.v3client
+	owner := meta.name
 	ctx := context.Background()
 	repoName := d.Get("repository").(string)
 	repo, _, err := client.Repositories.Get(ctx, owner, repoName)
@@ -65,8 +66,9 @@ func resourceGithubAppInstallationRepositoryCreate(d *schema.ResourceData, meta 
 	return resourceGithubAppInstallationRepositoryRead(d, meta)
 }
 
-func resourceGithubAppInstallationRepositoryRead(d *schema.ResourceData, meta any) error {
-	client := meta.(*Owner).v3client
+func resourceGithubAppInstallationRepositoryRead(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
 	installationIDString, repoName, err := parseID2(d.Id())
 	if err != nil {
 		return err
@@ -78,7 +80,7 @@ func resourceGithubAppInstallationRepositoryRead(d *schema.ResourceData, meta an
 	}
 
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
-	opt := &github.ListOptions{PerPage: maxPerPage}
+	opt := &github.ListOptions{PerPage: meta.maxPerPage}
 
 	for {
 		repos, resp, err := client.Apps.ListUserRepos(ctx, installationID, opt)
@@ -113,14 +115,15 @@ func resourceGithubAppInstallationRepositoryRead(d *schema.ResourceData, meta an
 	return nil
 }
 
-func resourceGithubAppInstallationRepositoryDelete(d *schema.ResourceData, meta any) error {
+func resourceGithubAppInstallationRepositoryDelete(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
 	installationIDString := d.Get("installation_id").(string)
 	installationID, err := strconv.ParseInt(installationIDString, 10, 64)
 	if err != nil {
 		return unconvertibleIdErr(installationIDString, err)
 	}
 
-	client := meta.(*Owner).v3client
+	client := meta.v3client
 	ctx := context.Background()
 
 	repoID := d.Get("repo_id").(int)

--- a/github/resource_github_codespaces_organization_secret_repositories.go
+++ b/github/resource_github_codespaces_organization_secret_repositories.go
@@ -38,9 +38,10 @@ func resourceGithubCodespacesOrganizationSecretRepositories() *schema.Resource {
 	}
 }
 
-func resourceGithubCodespaceOrganizationSecretRepositoriesCreateOrUpdate(d *schema.ResourceData, meta any) error {
-	client := meta.(*Owner).v3client
-	owner := meta.(*Owner).name
+func resourceGithubCodespaceOrganizationSecretRepositoriesCreateOrUpdate(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
 	ctx := context.Background()
 
 	err := checkOrganization(meta)
@@ -67,9 +68,10 @@ func resourceGithubCodespaceOrganizationSecretRepositoriesCreateOrUpdate(d *sche
 	return resourceGithubCodespaceOrganizationSecretRepositoriesRead(d, meta)
 }
 
-func resourceGithubCodespaceOrganizationSecretRepositoriesRead(d *schema.ResourceData, meta any) error {
-	client := meta.(*Owner).v3client
-	owner := meta.(*Owner).name
+func resourceGithubCodespaceOrganizationSecretRepositoriesRead(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
 	ctx := context.Background()
 
 	err := checkOrganization(meta)
@@ -79,7 +81,7 @@ func resourceGithubCodespaceOrganizationSecretRepositoriesRead(d *schema.Resourc
 
 	selectedRepositoryIDs := github.SelectedRepoIDs{}
 	opt := &github.ListOptions{
-		PerPage: maxPerPage,
+		PerPage: meta.maxPerPage,
 	}
 	for {
 		results, resp, err := client.Codespaces.ListSelectedReposForOrgSecret(ctx, owner, d.Id(), opt)
@@ -102,9 +104,10 @@ func resourceGithubCodespaceOrganizationSecretRepositoriesRead(d *schema.Resourc
 	return nil
 }
 
-func resourceGithubCodespaceOrganizationSecretRepositoriesDelete(d *schema.ResourceData, meta any) error {
-	client := meta.(*Owner).v3client
-	owner := meta.(*Owner).name
+func resourceGithubCodespaceOrganizationSecretRepositoriesDelete(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
 	err := checkOrganization(meta)

--- a/github/resource_github_dependabot_organization_secret.go
+++ b/github/resource_github_dependabot_organization_secret.go
@@ -236,7 +236,7 @@ func resourceGithubDependabotOrganizationSecretRead(ctx context.Context, d *sche
 		if _, ok := d.GetOk("selected_repository_ids"); ok {
 			repoIDs := []int64{}
 			opt := &github.ListOptions{
-				PerPage: maxPerPage,
+				PerPage: meta.maxPerPage,
 			}
 			for {
 				results, resp, err := client.Dependabot.ListSelectedReposForOrgSecret(ctx, owner, secretName, opt)
@@ -386,7 +386,7 @@ func resourceGithubDependabotOrganizationSecretImport(ctx context.Context, d *sc
 	selectedRepositoryIDs := []int64{}
 	if secret.Visibility == "selected" {
 		opt := &github.ListOptions{
-			PerPage: maxPerPage,
+			PerPage: meta.maxPerPage,
 		}
 		for {
 			results, resp, err := client.Dependabot.ListSelectedReposForOrgSecret(ctx, owner, secretName, opt)

--- a/github/resource_github_dependabot_organization_secret_repositories.go
+++ b/github/resource_github_dependabot_organization_secret_repositories.go
@@ -79,7 +79,7 @@ func resourceGithubDependabotOrganizationSecretRepositoriesRead(ctx context.Cont
 
 	repoIDs := []int64{}
 	opt := &github.ListOptions{
-		PerPage: maxPerPage,
+		PerPage: meta.maxPerPage,
 	}
 	for {
 		results, resp, err := client.Dependabot.ListSelectedReposForOrgSecret(ctx, owner, secretName, opt)
@@ -134,7 +134,7 @@ func resourceGithubDependabotOrganizationSecretRepositoriesImport(ctx context.Co
 
 	repoIDs := []int64{}
 	opt := &github.ListOptions{
-		PerPage: maxPerPage,
+		PerPage: meta.maxPerPage,
 	}
 	for {
 		results, resp, err := client.Dependabot.ListSelectedReposForOrgSecret(ctx, owner, secretName, opt)

--- a/github/resource_github_dependabot_organization_secret_repository.go
+++ b/github/resource_github_dependabot_organization_secret_repository.go
@@ -80,7 +80,7 @@ func resourceGithubDependabotOrganizationSecretRepositoryRead(ctx context.Contex
 	repoID := int64(d.Get("repository_id").(int))
 
 	opt := &github.ListOptions{
-		PerPage: maxPerPage,
+		PerPage: meta.maxPerPage,
 	}
 
 	for {

--- a/github/resource_github_enterprise_actions_runner_group.go
+++ b/github/resource_github_enterprise_actions_runner_group.go
@@ -125,7 +125,8 @@ func resourceGithubActionsEnterpriseRunnerGroupCreate(d *schema.ResourceData, me
 
 	ctx := context.Background()
 
-	enterpriseRunnerGroup, resp, err := client.Enterprise.CreateEnterpriseRunnerGroup(ctx,
+	enterpriseRunnerGroup, resp, err := client.Enterprise.CreateEnterpriseRunnerGroup(
+		ctx,
 		enterpriseSlug,
 		github.CreateEnterpriseRunnerGroupRequest{
 			Name:                     &name,
@@ -189,8 +190,9 @@ func getEnterpriseRunnerGroup(client *github.Client, ctx context.Context, ent st
 	return enterpriseRunnerGroup, resp, err
 }
 
-func resourceGithubActionsEnterpriseRunnerGroupRead(d *schema.ResourceData, meta any) error {
-	client := meta.(*Owner).v3client
+func resourceGithubActionsEnterpriseRunnerGroupRead(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
 
 	enterpriseSlug := d.Get("enterprise_slug").(string)
 	runnerGroupID, err := strconv.ParseInt(d.Id(), 10, 64)
@@ -254,7 +256,7 @@ func resourceGithubActionsEnterpriseRunnerGroupRead(d *schema.ResourceData, meta
 
 	selectedOrganizationIDs := []int64{}
 	optionsOrgs := github.ListOptions{
-		PerPage: maxPerPage,
+		PerPage: meta.maxPerPage,
 	}
 
 	for {
@@ -281,8 +283,9 @@ func resourceGithubActionsEnterpriseRunnerGroupRead(d *schema.ResourceData, meta
 	return nil
 }
 
-func resourceGithubActionsEnterpriseRunnerGroupUpdate(d *schema.ResourceData, meta any) error {
-	client := meta.(*Owner).v3client
+func resourceGithubActionsEnterpriseRunnerGroupUpdate(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
 
 	name := d.Get("name").(string)
 	enterpriseSlug := d.Get("enterprise_slug").(string)
@@ -334,8 +337,9 @@ func resourceGithubActionsEnterpriseRunnerGroupUpdate(d *schema.ResourceData, me
 	return resourceGithubActionsEnterpriseRunnerGroupRead(d, meta)
 }
 
-func resourceGithubActionsEnterpriseRunnerGroupDelete(d *schema.ResourceData, meta any) error {
-	client := meta.(*Owner).v3client
+func resourceGithubActionsEnterpriseRunnerGroupDelete(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
 	enterpriseSlug := d.Get("enterprise_slug").(string)
 	enterpriseRunnerGroupID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
@@ -348,7 +352,7 @@ func resourceGithubActionsEnterpriseRunnerGroupDelete(d *schema.ResourceData, me
 	return err
 }
 
-func resourceGithubActionsEnterpriseRunnerGroupImport(d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+func resourceGithubActionsEnterpriseRunnerGroupImport(d *schema.ResourceData, _ any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("invalid import specified: supplied import must be written as <enterprise_slug>/<runner_group_id>")

--- a/github/resource_github_enterprise_organization.go
+++ b/github/resource_github_enterprise_organization.go
@@ -83,7 +83,8 @@ func resourceGithubEnterpriseOrganization() *schema.Resource {
 	}
 }
 
-func resourceGithubEnterpriseOrganizationCreate(data *schema.ResourceData, meta any) error {
+func resourceGithubEnterpriseOrganizationCreate(data *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
 	var mutate struct {
 		CreateEnterpriseOrganization struct {
 			Organization struct {
@@ -92,9 +93,8 @@ func resourceGithubEnterpriseOrganizationCreate(data *schema.ResourceData, meta 
 		} `graphql:"createEnterpriseOrganization(input:$input)"`
 	}
 
-	owner := meta.(*Owner)
-	v3 := owner.v3client
-	v4 := owner.v4client
+	v3 := meta.v3client
+	v4 := meta.v4client
 
 	var adminLogins []githubv4.String
 	for _, v := range data.Get("admin_logins").(*schema.Set).List() {
@@ -155,7 +155,9 @@ func resourceGithubEnterpriseOrganizationCreate(data *schema.ResourceData, meta 
 	return nil
 }
 
-func resourceGithubEnterpriseOrganizationRead(data *schema.ResourceData, meta any) error {
+func resourceGithubEnterpriseOrganizationRead(data *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+
 	var query struct {
 		Node struct {
 			Organization struct {
@@ -173,20 +175,21 @@ func resourceGithubEnterpriseOrganizationRead(data *schema.ResourceData, meta an
 						Role githubv4.String
 					} `graphql:"edges"`
 					PageInfo PageInfo
-				} `graphql:"membersWithRole(first:100, after:$cursor)"`
+				} `graphql:"membersWithRole(first:$first, after:$cursor)"`
 			} `graphql:"... on Organization"`
 		} `graphql:"node(id: $id)"`
 	}
 
 	variables := map[string]any{
 		"id":     data.Id(),
+		"first":  githubv4.Int(meta.maxPerPage),
 		"cursor": (*githubv4.String)(nil),
 	}
 
 	var adminLogins []any
 
 	for {
-		v4 := meta.(*Owner).v4client
+		v4 := meta.v4client
 		err := v4.Query(context.Background(), &query, variables)
 		if err != nil {
 			if strings.Contains(err.Error(), "Could not resolve to a node with the global id") {
@@ -241,9 +244,9 @@ func resourceGithubEnterpriseOrganizationRead(data *schema.ResourceData, meta an
 	return err
 }
 
-func resourceGithubEnterpriseOrganizationDelete(data *schema.ResourceData, meta any) error {
-	owner := meta.(*Owner)
-	v3 := owner.v3client
+func resourceGithubEnterpriseOrganizationDelete(data *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	v3 := meta.v3client
 
 	ctx := context.WithValue(context.Background(), ctxId, data.Id())
 
@@ -258,13 +261,14 @@ func resourceGithubEnterpriseOrganizationDelete(data *schema.ResourceData, meta 
 	return err
 }
 
-func resourceGithubEnterpriseOrganizationImport(data *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+func resourceGithubEnterpriseOrganizationImport(data *schema.ResourceData, m any) ([]*schema.ResourceData, error) {
+	meta, _ := m.(*Owner)
 	parts := strings.Split(data.Id(), "/")
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("invalid ID specified: supplied ID must be written as <enterprise_slug>/<org_name>")
 	}
 
-	v4 := meta.(*Owner).v4client
+	v4 := meta.v4client
 	ctx := context.Background()
 
 	enterpriseId, err := getEnterpriseID(ctx, v4, parts[0])
@@ -461,9 +465,10 @@ func updateBillingEmail(ctx context.Context, data *schema.ResourceData, orgName 
 	return nil
 }
 
-func resourceGithubEnterpriseOrganizationUpdate(data *schema.ResourceData, meta any) error {
-	v3 := meta.(*Owner).v3client
-	v4 := meta.(*Owner).v4client
+func resourceGithubEnterpriseOrganizationUpdate(data *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	v3 := meta.v3client
+	v4 := meta.v4client
 	ctx := context.Background()
 
 	err := updateDisplayName(ctx, data, v3)

--- a/github/resource_github_issue_labels.go
+++ b/github/resource_github_issue_labels.go
@@ -59,15 +59,15 @@ func resourceGithubIssueLabels() *schema.Resource {
 	}
 }
 
-func resourceGithubIssueLabelsRead(d *schema.ResourceData, meta any) error {
-	client := meta.(*Owner).v3client
-	owner := meta.(*Owner).name
+func resourceGithubIssueLabelsRead(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	owner := meta.name
 	repository := d.Id()
 	ctx := context.WithValue(context.Background(), ctxId, repository)
 
 	log.Printf("[DEBUG] Reading GitHub issue labels for %s/%s", owner, repository)
 
-	labels, err := listLabels(client, ctx, owner, repository)
+	labels, err := listLabels(meta, ctx, owner, repository)
 	if err != nil {
 		return err
 	}
@@ -85,9 +85,10 @@ func resourceGithubIssueLabelsRead(d *schema.ResourceData, meta any) error {
 	return nil
 }
 
-func resourceGithubIssueLabelsCreateOrUpdate(d *schema.ResourceData, meta any) error {
-	client := meta.(*Owner).v3client
-	owner := meta.(*Owner).name
+func resourceGithubIssueLabelsCreateOrUpdate(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
 	repository := d.Get("repository").(string)
 	ctx := context.WithValue(context.Background(), ctxId, repository)
 
@@ -102,7 +103,7 @@ func resourceGithubIssueLabelsCreateOrUpdate(d *schema.ResourceData, meta any) e
 		wantLabelsMap[name] = label
 	}
 
-	hasLabels, err := listLabels(client, ctx, owner, repository)
+	hasLabels, err := listLabels(meta, ctx, owner, repository)
 	if err != nil {
 		return err
 	}
@@ -170,9 +171,10 @@ func resourceGithubIssueLabelsCreateOrUpdate(d *schema.ResourceData, meta any) e
 	return nil
 }
 
-func resourceGithubIssueLabelsDelete(d *schema.ResourceData, meta any) error {
-	client := meta.(*Owner).v3client
-	owner := meta.(*Owner).name
+func resourceGithubIssueLabelsDelete(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+	owner := meta.name
 	repository := d.Get("repository").(string)
 	ctx := context.WithValue(context.Background(), ctxId, repository)
 

--- a/github/resource_github_organization_role_team.go
+++ b/github/resource_github_organization_role_team.go
@@ -39,14 +39,15 @@ func resourceGithubOrganizationRoleTeam() *schema.Resource {
 	}
 }
 
-func resourceGithubOrganizationRoleTeamCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceGithubOrganizationRoleTeamCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
 	err := checkOrganization(meta)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	client := meta.(*Owner).v3client
-	orgName := meta.(*Owner).name
+	client := meta.v3client
+	orgName := meta.name
 
 	roleId := int64(d.Get("role_id").(int))
 	teamSlug := d.Get("team_slug").(string)
@@ -61,14 +62,15 @@ func resourceGithubOrganizationRoleTeamCreate(ctx context.Context, d *schema.Res
 	return nil
 }
 
-func resourceGithubOrganizationRoleTeamRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceGithubOrganizationRoleTeamRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
 	err := checkOrganization(meta)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	client := meta.(*Owner).v3client
-	orgName := meta.(*Owner).name
+	client := meta.v3client
+	orgName := meta.name
 
 	roleIdString, teamSlug, err := parseID2(d.Id())
 	if err != nil {
@@ -80,7 +82,7 @@ func resourceGithubOrganizationRoleTeamRead(ctx context.Context, d *schema.Resou
 	}
 
 	opts := &github.ListOptions{
-		PerPage: maxPerPage,
+		PerPage: meta.maxPerPage,
 	}
 
 	var team *github.Team
@@ -120,14 +122,15 @@ func resourceGithubOrganizationRoleTeamRead(ctx context.Context, d *schema.Resou
 	return nil
 }
 
-func resourceGithubOrganizationRoleTeamDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceGithubOrganizationRoleTeamDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
 	err := checkOrganization(meta)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	client := meta.(*Owner).v3client
-	orgName := meta.(*Owner).name
+	client := meta.v3client
+	orgName := meta.name
 
 	roleId := int64(d.Get("role_id").(int))
 	teamSlug := d.Get("team_slug").(string)

--- a/github/resource_github_organization_role_team_assignment.go
+++ b/github/resource_github_organization_role_team_assignment.go
@@ -37,14 +37,15 @@ func resourceGithubOrganizationRoleTeamAssignment() *schema.Resource {
 	}
 }
 
-func resourceGithubOrganizationRoleTeamAssignmentCreate(d *schema.ResourceData, meta any) error {
+func resourceGithubOrganizationRoleTeamAssignmentCreate(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
 	err := checkOrganization(meta)
 	if err != nil {
 		return err
 	}
 
-	client := meta.(*Owner).v3client
-	orgName := meta.(*Owner).name
+	client := meta.v3client
+	orgName := meta.name
 	ctx := context.Background()
 
 	teamSlug := d.Get("team_slug").(string)
@@ -64,15 +65,17 @@ func resourceGithubOrganizationRoleTeamAssignmentCreate(d *schema.ResourceData, 
 	return resourceGithubOrganizationRoleTeamAssignmentRead(d, meta)
 }
 
-func resourceGithubOrganizationRoleTeamAssignmentRead(d *schema.ResourceData, meta any) error {
+func resourceGithubOrganizationRoleTeamAssignmentRead(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+	orgName := meta.name
+
 	err := checkOrganization(meta)
 	if err != nil {
 		return err
 	}
 
-	client := meta.(*Owner).v3client
 	ctx := context.Background()
-	orgName := meta.(*Owner).name
 
 	teamSlug, roleIDString, err := parseID2(d.Id())
 	if err != nil {
@@ -87,7 +90,7 @@ func resourceGithubOrganizationRoleTeamAssignmentRead(d *schema.ResourceData, me
 	// There is no api for checking a specific team role assignment, so instead we iterate over all teams assigned to the role
 	// go-github pagination (https://github.com/google/go-github?tab=readme-ov-file#pagination)
 	options := &github.ListOptions{
-		PerPage: 100,
+		PerPage: meta.maxPerPage,
 	}
 	var foundTeam *github.Team
 	for {
@@ -125,14 +128,15 @@ func resourceGithubOrganizationRoleTeamAssignmentRead(d *schema.ResourceData, me
 	return nil
 }
 
-func resourceGithubOrganizationRoleTeamAssignmentDelete(d *schema.ResourceData, meta any) error {
+func resourceGithubOrganizationRoleTeamAssignmentDelete(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
 	err := checkOrganization(meta)
 	if err != nil {
 		return err
 	}
 
-	client := meta.(*Owner).v3client
-	orgName := meta.(*Owner).name
+	client := meta.v3client
+	orgName := meta.name
 	ctx := context.Background()
 
 	teamSlug, roleIDString, err := parseID2(d.Id())

--- a/github/resource_github_organization_role_user.go
+++ b/github/resource_github_organization_role_user.go
@@ -39,14 +39,15 @@ func resourceGithubOrganizationRoleUser() *schema.Resource {
 	}
 }
 
-func resourceGithubOrganizationRoleUserCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceGithubOrganizationRoleUserCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
 	err := checkOrganization(meta)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	client := meta.(*Owner).v3client
-	orgName := meta.(*Owner).name
+	client := meta.v3client
+	orgName := meta.name
 
 	roleId := int64(d.Get("role_id").(int))
 	login := d.Get("login").(string)
@@ -61,14 +62,15 @@ func resourceGithubOrganizationRoleUserCreate(ctx context.Context, d *schema.Res
 	return nil
 }
 
-func resourceGithubOrganizationRoleUserRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceGithubOrganizationRoleUserRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
 	err := checkOrganization(meta)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	client := meta.(*Owner).v3client
-	orgName := meta.(*Owner).name
+	client := meta.v3client
+	orgName := meta.name
 
 	roleIdString, login, err := parseID2(d.Id())
 	if err != nil {
@@ -80,7 +82,7 @@ func resourceGithubOrganizationRoleUserRead(ctx context.Context, d *schema.Resou
 	}
 
 	opts := &github.ListOptions{
-		PerPage: maxPerPage,
+		PerPage: meta.maxPerPage,
 	}
 
 	var user *github.User
@@ -120,14 +122,15 @@ func resourceGithubOrganizationRoleUserRead(ctx context.Context, d *schema.Resou
 	return nil
 }
 
-func resourceGithubOrganizationRoleUserDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceGithubOrganizationRoleUserDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	meta, _ := m.(*Owner)
 	err := checkOrganization(meta)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	client := meta.(*Owner).v3client
-	orgName := meta.(*Owner).name
+	client := meta.v3client
+	orgName := meta.name
 
 	roleId := int64(d.Get("role_id").(int))
 	login := d.Get("login").(string)

--- a/github/resource_github_organization_security_manager.go
+++ b/github/resource_github_organization_security_manager.go
@@ -47,16 +47,17 @@ func getSecurityManagerRole(client *github.Client, ctx context.Context, orgName 
 	return nil, errors.New("security manager role not found")
 }
 
-func resourceGithubOrganizationSecurityManagerCreate(d *schema.ResourceData, meta any) error {
+func resourceGithubOrganizationSecurityManagerCreate(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
 	err := checkOrganization(meta)
 	if err != nil {
 		return err
 	}
 
-	orgName := meta.(*Owner).name
+	orgName := meta.name
 	teamSlug := d.Get("team_slug").(string)
 
-	client := meta.(*Owner).v3client
+	client := meta.v3client
 	ctx := context.Background()
 
 	team, _, err := client.Teams.GetTeamBySlug(ctx, orgName, teamSlug)
@@ -79,19 +80,21 @@ func resourceGithubOrganizationSecurityManagerCreate(d *schema.ResourceData, met
 	return resourceGithubOrganizationSecurityManagerRead(d, meta)
 }
 
-func resourceGithubOrganizationSecurityManagerRead(d *schema.ResourceData, meta any) error {
+func resourceGithubOrganizationSecurityManagerRead(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	orgName := meta.name
+	client := meta.v3client
+
 	err := checkOrganization(meta)
 	if err != nil {
 		return err
 	}
 
-	orgName := meta.(*Owner).name
 	teamId, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
 		return err
 	}
 
-	client := meta.(*Owner).v3client
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
 	smRole, err := getSecurityManagerRole(client, ctx, orgName)
@@ -100,7 +103,7 @@ func resourceGithubOrganizationSecurityManagerRead(d *schema.ResourceData, meta 
 	}
 
 	// There is no endpoint for getting a single security manager team, so get the list and filter.
-	options := &github.ListOptions{PerPage: 100}
+	options := &github.ListOptions{PerPage: meta.maxPerPage}
 	var smTeam *github.Team = nil
 	for {
 		smTeams, resp, err := client.Organizations.ListTeamsAssignedToOrgRole(ctx, orgName, smRole.GetID(), options)
@@ -136,20 +139,21 @@ func resourceGithubOrganizationSecurityManagerRead(d *schema.ResourceData, meta 
 	return nil
 }
 
-func resourceGithubOrganizationSecurityManagerUpdate(d *schema.ResourceData, meta any) error {
+func resourceGithubOrganizationSecurityManagerUpdate(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
 	err := checkOrganization(meta)
 	if err != nil {
 		return err
 	}
 
-	orgId := meta.(*Owner).id
-	orgName := meta.(*Owner).name
+	orgId := meta.id
+	orgName := meta.name
 	teamId, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
 		return err
 	}
 
-	client := meta.(*Owner).v3client
+	client := meta.v3client
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
 	team, _, err := client.Teams.GetTeamByID(ctx, orgId, teamId)
@@ -171,16 +175,17 @@ func resourceGithubOrganizationSecurityManagerUpdate(d *schema.ResourceData, met
 	return resourceGithubOrganizationSecurityManagerRead(d, meta)
 }
 
-func resourceGithubOrganizationSecurityManagerDelete(d *schema.ResourceData, meta any) error {
+func resourceGithubOrganizationSecurityManagerDelete(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
 	err := checkOrganization(meta)
 	if err != nil {
 		return err
 	}
 
-	orgName := meta.(*Owner).name
+	orgName := meta.name
 	teamSlug := d.Get("team_slug").(string)
 
-	client := meta.(*Owner).v3client
+	client := meta.v3client
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
 	smRole, err := getSecurityManagerRole(client, ctx, orgName)

--- a/github/resource_github_repository_collaborator.go
+++ b/github/resource_github_repository_collaborator.go
@@ -67,13 +67,14 @@ func resourceGithubRepositoryCollaborator() *schema.Resource {
 	}
 }
 
-func resourceGithubRepositoryCollaboratorCreate(d *schema.ResourceData, meta any) error {
-	client := meta.(*Owner).v3client
+func resourceGithubRepositoryCollaboratorCreate(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
 
 	username := d.Get("username").(string)
 	repoName := d.Get("repository").(string)
 
-	owner, repoNameWithoutOwner := parseRepoName(repoName, meta.(*Owner).name)
+	owner, repoNameWithoutOwner := parseRepoName(repoName, meta.name)
 
 	ctx := context.Background()
 
@@ -93,18 +94,19 @@ func resourceGithubRepositoryCollaboratorCreate(d *schema.ResourceData, meta any
 	return resourceGithubRepositoryCollaboratorRead(d, meta)
 }
 
-func resourceGithubRepositoryCollaboratorRead(d *schema.ResourceData, meta any) error {
-	client := meta.(*Owner).v3client
+func resourceGithubRepositoryCollaboratorRead(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
 
 	repoName, username, err := parseID2(d.Id())
-	owner, repoNameWithoutOwner := parseRepoName(repoName, meta.(*Owner).name)
+	owner, repoNameWithoutOwner := parseRepoName(repoName, meta.name)
 	if err != nil {
 		return err
 	}
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
 	// First, check if the user has been invited but has not yet accepted
-	invitation, err := findRepoInvitation(client, ctx, owner, repoNameWithoutOwner, username)
+	invitation, err := findRepoInvitation(meta, ctx, owner, repoNameWithoutOwner, username)
 	if err != nil {
 		var ghErr *github.ErrorResponse
 		if errors.As(err, &ghErr) {
@@ -141,7 +143,7 @@ func resourceGithubRepositoryCollaboratorRead(d *schema.ResourceData, meta any) 
 
 	// Next, check if the user has accepted the invite and is a full collaborator
 	opt := &github.ListCollaboratorsOptions{ListOptions: github.ListOptions{
-		PerPage: maxPerPage,
+		PerPage: meta.maxPerPage,
 	}}
 
 	for {
@@ -180,22 +182,23 @@ func resourceGithubRepositoryCollaboratorRead(d *schema.ResourceData, meta any) 
 	return nil
 }
 
-func resourceGithubRepositoryCollaboratorUpdate(d *schema.ResourceData, meta any) error {
-	return resourceGithubRepositoryCollaboratorRead(d, meta)
+func resourceGithubRepositoryCollaboratorUpdate(d *schema.ResourceData, m any) error {
+	return resourceGithubRepositoryCollaboratorRead(d, m)
 }
 
-func resourceGithubRepositoryCollaboratorDelete(d *schema.ResourceData, meta any) error {
-	client := meta.(*Owner).v3client
+func resourceGithubRepositoryCollaboratorDelete(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
 
 	username := d.Get("username").(string)
 	repoName := d.Get("repository").(string)
 
-	owner, repoNameWithoutOwner := parseRepoName(repoName, meta.(*Owner).name)
+	owner, repoNameWithoutOwner := parseRepoName(repoName, meta.name)
 
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
 	// Delete any pending invitations
-	invitation, err := findRepoInvitation(client, ctx, owner, repoNameWithoutOwner, username)
+	invitation, err := findRepoInvitation(meta, ctx, owner, repoNameWithoutOwner, username)
 	if err != nil {
 		return handleArchivedRepoDelete(err, "repository collaborator invitation", username, owner, repoNameWithoutOwner)
 	} else if invitation != nil {
@@ -207,10 +210,10 @@ func resourceGithubRepositoryCollaboratorDelete(d *schema.ResourceData, meta any
 	return handleArchivedRepoDelete(err, "repository collaborator", username, owner, repoNameWithoutOwner)
 }
 
-func findRepoInvitation(client *github.Client, ctx context.Context, owner, repo, collaborator string) (*github.RepositoryInvitation, error) {
-	opt := &github.ListOptions{PerPage: maxPerPage}
+func findRepoInvitation(meta *Owner, ctx context.Context, owner, repo, collaborator string) (*github.RepositoryInvitation, error) {
+	opt := &github.ListOptions{PerPage: meta.maxPerPage}
 	for {
-		invitations, resp, err := client.Repositories.ListInvitations(ctx, owner, repo, opt)
+		invitations, resp, err := meta.v3client.Repositories.ListInvitations(ctx, owner, repo, opt)
 		if err != nil {
 			return nil, err
 		}

--- a/github/resource_github_repository_collaborators.go
+++ b/github/resource_github_repository_collaborators.go
@@ -311,13 +311,13 @@ func resourceGithubRepositoryCollaboratorsCreate(ctx context.Context, d *schema.
 		return diag.FromErr(err)
 	}
 
-	invitations, err := updateUserCollaboratorsAndInvites(ctx, client, owner, repoName, inUsers, inIgnoreUsers)
+	invitations, err := updateUserCollaboratorsAndInvites(ctx, meta, owner, repoName, inUsers, inIgnoreUsers)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	if isOrg {
-		err = updateTeamCollaborators(ctx, client, meta.id, owner, repoName, inTeams, inIgnoreTeams)
+		err = updateTeamCollaborators(ctx, meta, meta.id, owner, repoName, inTeams, inIgnoreTeams)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -343,7 +343,6 @@ func resourceGithubRepositoryCollaboratorsCreate(ctx context.Context, d *schema.
 func resourceGithubRepositoryCollaboratorsRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	tflog.Debug(ctx, "Reading repository collaborators")
 	meta, _ := m.(*Owner)
-	client := meta.v3client
 	owner := meta.name
 	isOrg := meta.IsOrganization
 
@@ -367,7 +366,7 @@ func resourceGithubRepositoryCollaboratorsRead(ctx context.Context, d *schema.Re
 		return diag.FromErr(err)
 	}
 
-	ghUsers, err := listUserCollaborators(ctx, client, owner, repoName, inIgnoreUsers)
+	ghUsers, err := listUserCollaborators(ctx, meta, owner, repoName, inIgnoreUsers)
 	if err != nil {
 		if err, ok := errors.AsType[*github.ErrorResponse](err); ok && err.Response.StatusCode == 404 {
 			tflog.Debug(ctx, fmt.Sprintf("Repository %s not found when listing users, removing from state.", repoName))
@@ -378,7 +377,7 @@ func resourceGithubRepositoryCollaboratorsRead(ctx context.Context, d *schema.Re
 	}
 
 	if isOrg {
-		ghTeams, err := listTeamCollaborators(ctx, client, owner, repoName, inTeams, inIgnoreTeams)
+		ghTeams, err := listTeamCollaborators(ctx, meta, owner, repoName, inTeams, inIgnoreTeams)
 		if err != nil {
 			if err, ok := errors.AsType[*github.ErrorResponse](err); ok && err.Response.StatusCode == 404 {
 				tflog.Debug(ctx, fmt.Sprintf("Repository %s not found when listing teams, removing from state.", repoName))
@@ -393,7 +392,7 @@ func resourceGithubRepositoryCollaboratorsRead(ctx context.Context, d *schema.Re
 		}
 	}
 
-	ghInvitations, err := listInvitations(ctx, client, owner, repoName)
+	ghInvitations, err := listInvitations(ctx, meta, owner, repoName)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -413,7 +412,6 @@ func resourceGithubRepositoryCollaboratorsRead(ctx context.Context, d *schema.Re
 func resourceGithubRepositoryCollaboratorsUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	tflog.Debug(ctx, "Updating repository collaborators")
 	meta, _ := m.(*Owner)
-	client := meta.v3client
 	owner := meta.name
 	isOrg := meta.IsOrganization
 
@@ -460,13 +458,13 @@ func resourceGithubRepositoryCollaboratorsUpdate(ctx context.Context, d *schema.
 		return diag.FromErr(err)
 	}
 
-	invitations, err := updateUserCollaboratorsAndInvites(ctx, client, owner, repoName, inUsers, inIgnoreUsers)
+	invitations, err := updateUserCollaboratorsAndInvites(ctx, meta, owner, repoName, inUsers, inIgnoreUsers)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	if isOrg {
-		err := updateTeamCollaborators(ctx, client, meta.id, owner, repoName, inTeams, inIgnoreTeams)
+		err := updateTeamCollaborators(ctx, meta, meta.id, owner, repoName, inTeams, inIgnoreTeams)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -482,7 +480,6 @@ func resourceGithubRepositoryCollaboratorsUpdate(ctx context.Context, d *schema.
 func resourceGithubRepositoryCollaboratorsDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	tflog.Debug(ctx, "Deleting repository collaborators")
 	meta, _ := m.(*Owner)
-	client := meta.v3client
 	owner := meta.name
 	isOrg := meta.IsOrganization
 
@@ -496,12 +493,12 @@ func resourceGithubRepositoryCollaboratorsDelete(ctx context.Context, d *schema.
 
 	tflog.Debug(ctx, fmt.Sprintf("Removing all collaborators from repository %s.", repoName))
 
-	if _, err := updateUserCollaboratorsAndInvites(ctx, client, owner, repoName, nil, nil); err != nil {
+	if _, err := updateUserCollaboratorsAndInvites(ctx, meta, owner, repoName, nil, nil); err != nil {
 		return diag.FromErr(err)
 	}
 
 	if isOrg {
-		if err := updateTeamCollaborators(ctx, client, meta.id, owner, repoName, nil, inIgnoreTeams); err != nil {
+		if err := updateTeamCollaborators(ctx, meta, meta.id, owner, repoName, nil, inIgnoreTeams); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -641,7 +638,7 @@ func getTeamIdentity(d any) (teamIdentity, error) {
 	return newLegacyTeamIdentity(id), nil
 }
 
-func listUserCollaborators(ctx context.Context, client *github.Client, owner, repoName string, ignoreUsers []string) (userCollaborators, error) {
+func listUserCollaborators(ctx context.Context, meta *Owner, owner, repoName string, ignoreUsers []string) (userCollaborators, error) {
 	col := make([]userCollaborator, 0)
 	tflog.Debug(ctx, "Listing user collaborators", map[string]any{
 		"owner":    owner,
@@ -651,13 +648,13 @@ func listUserCollaborators(ctx context.Context, client *github.Client, owner, re
 	for _, affiliation := range affiliations {
 		opt := &github.ListCollaboratorsOptions{
 			ListOptions: github.ListOptions{
-				PerPage: maxPerPage,
+				PerPage: meta.maxPerPage,
 			},
 			Affiliation: affiliation,
 		}
 
 		for {
-			collaborators, resp, err := client.Repositories.ListCollaborators(ctx, owner, repoName, opt)
+			collaborators, resp, err := meta.v3client.Repositories.ListCollaborators(ctx, owner, repoName, opt)
 			if err != nil {
 				return nil, err
 			}
@@ -684,12 +681,12 @@ func listUserCollaborators(ctx context.Context, client *github.Client, owner, re
 	return col, nil
 }
 
-func listInvitations(ctx context.Context, client *github.Client, owner, repoName string) (userCollaborators, error) {
+func listInvitations(ctx context.Context, meta *Owner, owner, repoName string) (userCollaborators, error) {
 	col := make([]userCollaborator, 0)
 
-	opt := &github.ListOptions{PerPage: maxPerPage}
+	opt := &github.ListOptions{PerPage: meta.maxPerPage}
 	for {
-		invitations, resp, err := client.Repositories.ListInvitations(ctx, owner, repoName, opt)
+		invitations, resp, err := meta.v3client.Repositories.ListInvitations(ctx, owner, repoName, opt)
 		if err != nil {
 			return nil, err
 		}
@@ -715,7 +712,7 @@ func listInvitations(ctx context.Context, client *github.Client, owner, repoName
 	return col, nil
 }
 
-func listTeamCollaborators(ctx context.Context, client *github.Client, orgName, repoName string, inTeams teamCollaborators, ignoreTeams []teamIdentity) (teamCollaborators, error) {
+func listTeamCollaborators(ctx context.Context, meta *Owner, orgName, repoName string, inTeams teamCollaborators, ignoreTeams []teamIdentity) (teamCollaborators, error) {
 	lookup := make(map[string]teamCollaborator)
 	ignore := len(ignoreTeams) > 0
 	col := make([]teamCollaborator, 0)
@@ -725,11 +722,11 @@ func listTeamCollaborators(ctx context.Context, client *github.Client, orgName, 
 	}
 
 	opt := &github.ListOptions{
-		PerPage: maxPerPage,
+		PerPage: meta.maxPerPage,
 	}
 
 	for {
-		repoTeams, resp, err := client.Repositories.ListTeams(ctx, orgName, repoName, opt)
+		repoTeams, resp, err := meta.v3client.Repositories.ListTeams(ctx, orgName, repoName, opt)
 		if err != nil {
 			return nil, err
 		}
@@ -778,7 +775,7 @@ func listTeamCollaborators(ctx context.Context, client *github.Client, orgName, 
 	return col, nil
 }
 
-func updateUserCollaboratorsAndInvites(ctx context.Context, client *github.Client, owner, repoName string, inUsers userCollaborators, ignoreUsers []string) (userCollaborators, error) {
+func updateUserCollaboratorsAndInvites(ctx context.Context, meta *Owner, owner, repoName string, inUsers userCollaborators, ignoreUsers []string) (userCollaborators, error) {
 	lookup := make(map[string]userCollaborator)
 	seen := make(map[string]any)
 	remove := make([]string, 0)
@@ -795,7 +792,7 @@ func updateUserCollaboratorsAndInvites(ctx context.Context, client *github.Clien
 		"remove":   remove,
 	})
 
-	ghUsers, err := listUserCollaborators(ctx, client, owner, repoName, ignoreUsers)
+	ghUsers, err := listUserCollaborators(ctx, meta, owner, repoName, ignoreUsers)
 	if err != nil {
 		return nil, err
 	}
@@ -807,7 +804,7 @@ func updateUserCollaboratorsAndInvites(ctx context.Context, client *github.Clien
 
 			if ghUser.permission != inUser.permission {
 				tflog.Info(ctx, fmt.Sprintf("Updating user %s permission from %s to %s for repo %s.", inUser.login, ghUser.permission, inUser.permission, repoName))
-				_, _, err := client.Repositories.AddCollaborator(ctx, owner, repoName, inUser.login, &github.RepositoryAddCollaboratorOptions{Permission: inUser.permission})
+				_, _, err := meta.v3client.Repositories.AddCollaborator(ctx, owner, repoName, inUser.login, &github.RepositoryAddCollaboratorOptions{Permission: inUser.permission})
 				if err != nil {
 					return nil, err
 				}
@@ -817,7 +814,7 @@ func updateUserCollaboratorsAndInvites(ctx context.Context, client *github.Clien
 		}
 	}
 
-	ghInvites, err := listInvitations(ctx, client, owner, repoName)
+	ghInvites, err := listInvitations(ctx, meta, owner, repoName)
 	if err != nil {
 		return nil, err
 	}
@@ -829,14 +826,14 @@ func updateUserCollaboratorsAndInvites(ctx context.Context, client *github.Clien
 
 			if ghInvite.permission != inInvite.permission {
 				tflog.Info(ctx, fmt.Sprintf("Updating invite for user %s permission from %s to %s for repo %s.", inInvite.login, ghInvite.permission, inInvite.permission, repoName))
-				_, _, err := client.Repositories.UpdateInvitation(ctx, owner, repoName, *ghInvite.invitationID, inInvite.permission)
+				_, _, err := meta.v3client.Repositories.UpdateInvitation(ctx, owner, repoName, *ghInvite.invitationID, inInvite.permission)
 				if err != nil {
 					return nil, err
 				}
 			}
 		} else {
 			tflog.Info(ctx, fmt.Sprintf("Deleting invite for user %s from repo %s.", ghInvite.login, repoName))
-			_, err := client.Repositories.DeleteInvitation(ctx, owner, repoName, *ghInvite.invitationID)
+			_, err := meta.v3client.Repositories.DeleteInvitation(ctx, owner, repoName, *ghInvite.invitationID)
 			if err != nil {
 				return nil, handleArchivedRepoDelete(err, "repository collaborator invitation", ghInvite.login, owner, repoName)
 			}
@@ -849,7 +846,7 @@ func updateUserCollaboratorsAndInvites(ctx context.Context, client *github.Clien
 		}
 
 		tflog.Info(ctx, fmt.Sprintf("Inviting user %s to repo %s with permission %s.", inUser.login, repoName, inUser.permission))
-		inv, _, err := client.Repositories.AddCollaborator(ctx, owner, repoName, inUser.login, &github.RepositoryAddCollaboratorOptions{Permission: inUser.permission})
+		inv, _, err := meta.v3client.Repositories.AddCollaborator(ctx, owner, repoName, inUser.login, &github.RepositoryAddCollaboratorOptions{Permission: inUser.permission})
 		if err != nil {
 			return nil, err
 		}
@@ -870,7 +867,7 @@ func updateUserCollaboratorsAndInvites(ctx context.Context, client *github.Clien
 		}
 
 		tflog.Info(ctx, fmt.Sprintf("Removing user %s from repo %s.", l, repoName))
-		_, err := client.Repositories.RemoveCollaborator(ctx, owner, repoName, l)
+		_, err := meta.v3client.Repositories.RemoveCollaborator(ctx, owner, repoName, l)
 		if err != nil {
 			return nil, handleArchivedRepoDelete(err, "repository collaborator", l, owner, repoName)
 		}
@@ -879,7 +876,7 @@ func updateUserCollaboratorsAndInvites(ctx context.Context, client *github.Clien
 	return ghInvites, nil
 }
 
-func updateTeamCollaborators(ctx context.Context, client *github.Client, orgID int64, orgName, repoName string, inTeams teamCollaborators, ignoreTeams []teamIdentity) error {
+func updateTeamCollaborators(ctx context.Context, meta *Owner, orgID int64, orgName, repoName string, inTeams teamCollaborators, ignoreTeams []teamIdentity) error {
 	lookup := make(map[string]teamCollaborator)
 	seen := make(map[string]any)
 	remove := make([]string, 0)
@@ -888,7 +885,7 @@ func updateTeamCollaborators(ctx context.Context, client *github.Client, orgID i
 		lookup[inTeam.getTeamID()] = inTeam
 	}
 
-	ghTeams, err := listTeamCollaborators(ctx, client, orgName, repoName, inTeams, ignoreTeams)
+	ghTeams, err := listTeamCollaborators(ctx, meta, orgName, repoName, inTeams, ignoreTeams)
 	if err != nil {
 		return err
 	}
@@ -904,7 +901,7 @@ func updateTeamCollaborators(ctx context.Context, client *github.Client, orgID i
 
 			if ghTeam.permission != inTeam.permission {
 				tflog.Info(ctx, fmt.Sprintf("Updating team %s permission from %s to %s for repo %s.", slug, ghTeam.permission, inTeam.permission, repoName))
-				_, err := client.Teams.AddTeamRepoBySlug(ctx, orgName, slug, orgName, repoName, &github.TeamAddTeamRepoOptions{
+				_, err := meta.v3client.Teams.AddTeamRepoBySlug(ctx, orgName, slug, orgName, repoName, &github.TeamAddTeamRepoOptions{
 					Permission: inTeam.permission,
 				})
 				if err != nil {
@@ -924,12 +921,12 @@ func updateTeamCollaborators(ctx context.Context, client *github.Client, orgID i
 
 		tflog.Info(ctx, fmt.Sprintf("Adding team %s to repo %s with permission %s.", teamID, repoName, inTeam.permission))
 		if slug, ok := inTeam.getSlugOK(); ok {
-			_, err := client.Teams.AddTeamRepoBySlug(ctx, orgName, slug, orgName, repoName, &github.TeamAddTeamRepoOptions{Permission: inTeam.permission})
+			_, err := meta.v3client.Teams.AddTeamRepoBySlug(ctx, orgName, slug, orgName, repoName, &github.TeamAddTeamRepoOptions{Permission: inTeam.permission})
 			if err != nil {
 				return err
 			}
 		} else {
-			_, err := client.Teams.AddTeamRepoByID(ctx, orgID, inTeam.getID(), orgName, repoName, &github.TeamAddTeamRepoOptions{Permission: inTeam.permission})
+			_, err := meta.v3client.Teams.AddTeamRepoByID(ctx, orgID, inTeam.getID(), orgName, repoName, &github.TeamAddTeamRepoOptions{Permission: inTeam.permission})
 			if err != nil {
 				return err
 			}
@@ -938,7 +935,7 @@ func updateTeamCollaborators(ctx context.Context, client *github.Client, orgID i
 
 	for _, s := range remove {
 		tflog.Info(ctx, fmt.Sprintf("Removing team %s from repo %s.", s, repoName))
-		_, err := client.Teams.RemoveTeamRepoBySlug(ctx, orgName, s, orgName, repoName)
+		_, err := meta.v3client.Teams.RemoveTeamRepoBySlug(ctx, orgName, s, orgName, repoName)
 		if err != nil {
 			return handleArchivedRepoDelete(err, "team repository access", fmt.Sprintf("team %s", s), orgName, repoName)
 		}

--- a/github/resource_github_repository_topics.go
+++ b/github/resource_github_repository_topics.go
@@ -19,7 +19,7 @@ func resourceGithubRepositoryTopics() *schema.Resource {
 		Update: resourceGithubRepositoryTopicsCreateOrUpdate,
 		Delete: resourceGithubRepositoryTopicsDelete,
 		Importer: &schema.ResourceImporter{
-			State: func(d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+			State: func(d *schema.ResourceData, _ any) ([]*schema.ResourceData, error) {
 				_ = d.Set("repository", d.Id())
 				return []*schema.ResourceData{d}, nil
 			},
@@ -44,11 +44,12 @@ func resourceGithubRepositoryTopics() *schema.Resource {
 	}
 }
 
-func resourceGithubRepositoryTopicsCreateOrUpdate(d *schema.ResourceData, meta any) error {
-	client := meta.(*Owner).v3client
+func resourceGithubRepositoryTopicsCreateOrUpdate(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
 	ctx := context.Background()
 
-	owner := meta.(*Owner).name
+	owner := meta.name
 	repoName := d.Get("repository").(string)
 	topics := expandStringList(d.Get("topics").(*schema.Set).List())
 
@@ -63,15 +64,16 @@ func resourceGithubRepositoryTopicsCreateOrUpdate(d *schema.ResourceData, meta a
 	return resourceGithubRepositoryTopicsRead(d, meta)
 }
 
-func resourceGithubRepositoryTopicsRead(d *schema.ResourceData, meta any) error {
-	client := meta.(*Owner).v3client
+func resourceGithubRepositoryTopicsRead(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
-	owner := meta.(*Owner).name
+	owner := meta.name
 	repoName := d.Get("repository").(string)
 
 	results := make([]string, 0)
-	listOptions := &github.ListOptions{PerPage: maxPerPage}
+	listOptions := &github.ListOptions{PerPage: meta.maxPerPage}
 	for {
 		topics, resp, err := client.Repositories.ListAllTopics(ctx, owner, repoName, listOptions)
 		if err != nil {
@@ -106,11 +108,12 @@ func resourceGithubRepositoryTopicsRead(d *schema.ResourceData, meta any) error 
 	return nil
 }
 
-func resourceGithubRepositoryTopicsDelete(d *schema.ResourceData, meta any) error {
-	client := meta.(*Owner).v3client
+func resourceGithubRepositoryTopicsDelete(d *schema.ResourceData, m any) error {
+	meta, _ := m.(*Owner)
+	client := meta.v3client
 	ctx := context.WithValue(context.Background(), ctxId, d.Id())
 
-	owner := meta.(*Owner).name
+	owner := meta.name
 	repoName := d.Get("repository").(string)
 
 	_, _, err := client.Repositories.ReplaceAllTopics(ctx, owner, repoName, []string{})

--- a/github/util.go
+++ b/github/util.go
@@ -22,9 +22,6 @@ const (
 	idSeparatorEscaped = `??`
 )
 
-// https://developer.github.com/guides/traversing-with-pagination/#basics-of-pagination
-var maxPerPage = 100
-
 // escapeIDPart escapes any idSeparator characters in a string.
 func escapeIDPart(part string) string {
 	return strings.ReplaceAll(part, idSeparator, idSeparatorEscaped)

--- a/github/util_labels.go
+++ b/github/util_labels.go
@@ -27,15 +27,15 @@ func flattenLabels(labels []*github.Label) []any {
 	return results
 }
 
-func listLabels(client *github.Client, ctx context.Context, owner, repository string) ([]*github.Label, error) {
+func listLabels(meta *Owner, ctx context.Context, owner, repository string) ([]*github.Label, error) {
 	options := &github.ListOptions{
-		PerPage: maxPerPage,
+		PerPage: meta.maxPerPage,
 	}
 
 	labels := make([]*github.Label, 0)
 
 	for {
-		ls, resp, err := client.Issues.ListLabels(ctx, owner, repository, options)
+		ls, resp, err := meta.v3client.Issues.ListLabels(ctx, owner, repository, options)
 		if err != nil {
 			return nil, err
 		}

--- a/github/util_v4_branch_protection.go
+++ b/github/util_v4_branch_protection.go
@@ -558,7 +558,8 @@ func setForcePushBypassers(protection BranchProtectionRule, data BranchProtectio
 	return bypassForcePushActors
 }
 
-func getBranchProtectionID(repoID githubv4.ID, pattern string, meta any) (githubv4.ID, error) {
+func getBranchProtectionID(repoID githubv4.ID, pattern string, m any) (githubv4.ID, error) {
+	meta, _ := m.(*Owner)
 	var query struct {
 		Node struct {
 			Repository struct {
@@ -575,12 +576,12 @@ func getBranchProtectionID(repoID githubv4.ID, pattern string, meta any) (github
 	}
 	variables := map[string]any{
 		"id":     repoID,
-		"first":  githubv4.Int(100),
+		"first":  githubv4.Int(meta.maxPerPage),
 		"cursor": (*githubv4.String)(nil),
 	}
 
 	ctx := context.Background()
-	client := meta.(*Owner).v4client
+	client := meta.v4client
 
 	var allRules []struct {
 		ID      string


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- The provider scoped input for `max_per_page` is set to a global package variable

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The provider metadata holds `maxPerPage` variable

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
