### PR TITLE
fix: Avoid merge_commit_* drift when merge/squash strategies are disabled

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v89/github"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -255,28 +256,32 @@ func resourceGithubRepository() *schema.Resource {
 				Description: "Set to 'true' to allow private forking on the repository; this is only relevant if the repository is owned by an organization and is private or internal.",
 			},
 			"squash_merge_commit_title": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "COMMIT_OR_PR_TITLE",
-				Description: "Can be 'PR_TITLE' or 'COMMIT_OR_PR_TITLE' for a default squash merge commit title.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          "COMMIT_OR_PR_TITLE",
+				DiffSuppressFunc: suppressDiffIfSquashMergeDisabled,
+				Description:      "Can be 'PR_TITLE' or 'COMMIT_OR_PR_TITLE' for a default squash merge commit title.",
 			},
 			"squash_merge_commit_message": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "COMMIT_MESSAGES",
-				Description: "Can be 'PR_BODY', 'COMMIT_MESSAGES', or 'BLANK' for a default squash merge commit message.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          "COMMIT_MESSAGES",
+				DiffSuppressFunc: suppressDiffIfSquashMergeDisabled,
+				Description:      "Can be 'PR_BODY', 'COMMIT_MESSAGES', or 'BLANK' for a default squash merge commit message.",
 			},
 			"merge_commit_title": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "MERGE_MESSAGE",
-				Description: "Can be 'PR_TITLE' or 'MERGE_MESSAGE' for a default merge commit title.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          "MERGE_MESSAGE",
+				DiffSuppressFunc: suppressDiffIfMergeCommitDisabled,
+				Description:      "Can be 'PR_TITLE' or 'MERGE_MESSAGE' for a default merge commit title.",
 			},
 			"merge_commit_message": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "PR_TITLE",
-				Description: "Can be 'PR_BODY', 'PR_TITLE', or 'BLANK' for a default merge commit message.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          "PR_TITLE",
+				DiffSuppressFunc: suppressDiffIfMergeCommitDisabled,
+				Description:      "Can be 'PR_BODY', 'PR_TITLE', or 'BLANK' for a default merge commit message.",
 			},
 			"delete_branch_on_merge": {
 				Type:        schema.TypeBool,
@@ -509,6 +514,75 @@ func valueChangedButNotEmpty(ctx context.Context, oldVal, newVal, meta any) bool
 	oldValStr := oldVal.(string)
 	newValStr := newVal.(string)
 	return oldValStr != "" && oldValStr != newValStr
+}
+
+// suppressDiffIfMergeCommitDisabled suppresses diffs on merge_commit_title /
+// merge_commit_message while allow_merge_commit is false. GitHub rejects any
+// attempt to change these values while the merge commit strategy is disabled
+// (HTTP 422 "no_merge_strategy"), so a change to them can never be applied and
+// would otherwise produce a permanent, non-convergent plan. See issue #3554.
+func suppressDiffIfMergeCommitDisabled(_, _, _ string, d *schema.ResourceData) bool {
+	return !d.Get("allow_merge_commit").(bool)
+}
+
+// suppressDiffIfSquashMergeDisabled is the squash-merge counterpart of
+// suppressDiffIfMergeCommitDisabled: GitHub likewise rejects changes to
+// squash_merge_commit_title / squash_merge_commit_message while
+// allow_squash_merge is false.
+func suppressDiffIfSquashMergeDisabled(_, _, _ string, d *schema.ResourceData) bool {
+	return !d.Get("allow_squash_merge").(bool)
+}
+
+// warnIgnoredMergeCommitSettings returns warning diagnostics when the user has
+// explicitly configured merge_commit_* or squash_merge_commit_* values while
+// the corresponding merge strategy is disabled. GitHub refuses to change these
+// values while the strategy is off (HTTP 422 "no_merge_strategy"), so the
+// provider does not send them and the configured values have no effect. We
+// surface that as a warning rather than a silent no-op. See issue #3554.
+func warnIgnoredMergeCommitSettings(d *schema.ResourceData) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	rawConfig := d.GetRawConfig()
+	// During delete or when config is unavailable, rawConfig is null; nothing
+	// to warn about.
+	if rawConfig.IsNull() {
+		return diags
+	}
+
+	// configured reports whether the user explicitly set a (non-null) value for
+	// the given attribute in the configuration.
+	configured := func(attr string) bool {
+		v := rawConfig.GetAttr(attr)
+		return !v.IsNull()
+	}
+
+	if !d.Get("allow_merge_commit").(bool) {
+		for _, attr := range []string{"merge_commit_title", "merge_commit_message"} {
+			if configured(attr) {
+				diags = append(diags, diag.Diagnostic{
+					Severity:      diag.Warning,
+					Summary:       "merge commit setting ignored",
+					Detail:        fmt.Sprintf("%q is ignored because allow_merge_commit is false; GitHub does not allow changing it while merge commits are disabled.", attr),
+					AttributePath: cty.GetAttrPath(attr),
+				})
+			}
+		}
+	}
+
+	if !d.Get("allow_squash_merge").(bool) {
+		for _, attr := range []string{"squash_merge_commit_title", "squash_merge_commit_message"} {
+			if configured(attr) {
+				diags = append(diags, diag.Diagnostic{
+					Severity:      diag.Warning,
+					Summary:       "squash merge setting ignored",
+					Detail:        fmt.Sprintf("%q is ignored because allow_squash_merge is false; GitHub does not allow changing it while squash merges are disabled.", attr),
+					AttributePath: cty.GetAttrPath(attr),
+				})
+			}
+		}
+	}
+
+	return diags
 }
 
 func customDiffFunction(_ context.Context, diff *schema.ResourceDiff, v any) error {
@@ -1021,7 +1095,11 @@ func resourceGithubRepositoryUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
-	return resourceGithubRepositoryRead(ctx, d, meta)
+	// Warn if the user configured merge/squash commit title/message values that
+	// are ignored because the corresponding strategy is disabled (see #3554).
+	diags := warnIgnoredMergeCommitSettings(d)
+	diags = append(diags, resourceGithubRepositoryRead(ctx, d, meta)...)
+	return diags
 }
 
 func resourceGithubRepositoryDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -848,6 +848,117 @@ resource "github_repository" "test" {
 		})
 	})
 
+	t.Run("does not drift merge commit settings when merge commits are disabled", func(t *testing.T) {
+		t.Parallel()
+
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		testRepoName := fmt.Sprintf("%sno-drift-co-str-%s", testResourcePrefix, randomID)
+
+		// See https://github.com/integrations/terraform-provider-github/issues/3554
+		// GitHub rejects any change to merge_commit_title/message while merge
+		// commits are disabled (HTTP 422 "no_merge_strategy"), so the provider
+		// does not send them. Without a diff suppression, a config that both
+		// disables merge commits and specifies different merge_commit_* values
+		// produces a plan that can never converge. The DiffSuppressFunc must
+		// suppress that diff so the plan stays empty.
+		config := `
+resource "github_repository" "test" {
+		name                 = "%[1]s"
+		allow_merge_commit   = %[2]t
+		merge_commit_title   = "%[3]s"
+		merge_commit_message = "%[4]s"
+		visibility           = "%[5]s"
+}
+`
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					// Start with merge commits enabled and a valid combination.
+					Config: fmt.Sprintf(config, testRepoName, true, "PR_TITLE", "PR_BODY", testAccConf.testRepositoryVisibility),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("github_repository.test", "merge_commit_title", "PR_TITLE"),
+						resource.TestCheckResourceAttr("github_repository.test", "merge_commit_message", "PR_BODY"),
+					),
+				},
+				{
+					// Disable merge commits AND change the merge_commit_* values.
+					// GitHub will not apply the change, but the diff must be
+					// suppressed so the apply converges without perpetual drift.
+					Config: fmt.Sprintf(config, testRepoName, false, "MERGE_MESSAGE", "PR_TITLE", testAccConf.testRepositoryVisibility),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("github_repository.test", "allow_merge_commit", "false"),
+					),
+				},
+				{
+					// A follow-up plan with the same (disabled) config must be
+					// empty: no drift on merge_commit_title/message.
+					Config:             fmt.Sprintf(config, testRepoName, false, "MERGE_MESSAGE", "PR_TITLE", testAccConf.testRepositoryVisibility),
+					PlanOnly:           true,
+					ExpectNonEmptyPlan: false,
+				},
+			},
+		})
+	})
+
+	t.Run("does not drift squash merge commit settings when squash merges are disabled", func(t *testing.T) {
+		t.Parallel()
+
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		testRepoName := fmt.Sprintf("%sno-drift-sq-str-%s", testResourcePrefix, randomID)
+
+		// See https://github.com/integrations/terraform-provider-github/issues/3554
+		// GitHub rejects any change to squash_merge_commit_title/message while
+		// squash merges are disabled (HTTP 422 "no_merge_strategy"), so the
+		// provider does not send them. The DiffSuppressFunc must suppress the
+		// resulting diff so a config that both disables squash merges and
+		// specifies different values still converges.
+		// allow_merge_commit defaults to true, so the repo still has a valid
+		// merge strategy while squash merges are disabled.
+		config := `
+resource "github_repository" "test" {
+		name                        = "%[1]s"
+		allow_squash_merge          = %[2]t
+		squash_merge_commit_title   = "%[3]s"
+		squash_merge_commit_message = "%[4]s"
+		visibility                  = "%[5]s"
+}
+`
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					// Start with squash merges enabled and a valid combination.
+					Config: fmt.Sprintf(config, testRepoName, true, "PR_TITLE", "PR_BODY", testAccConf.testRepositoryVisibility),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("github_repository.test", "squash_merge_commit_title", "PR_TITLE"),
+						resource.TestCheckResourceAttr("github_repository.test", "squash_merge_commit_message", "PR_BODY"),
+					),
+				},
+				{
+					// Disable squash merges AND change the squash_merge_commit_*
+					// values. GitHub will not apply the change, but the diff must
+					// be suppressed so the apply converges without perpetual drift.
+					Config: fmt.Sprintf(config, testRepoName, false, "COMMIT_OR_PR_TITLE", "COMMIT_MESSAGES", testAccConf.testRepositoryVisibility),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("github_repository.test", "allow_squash_merge", "false"),
+					),
+				},
+				{
+					// A follow-up plan with the same (disabled) config must be
+					// empty: no drift on squash_merge_commit_title/message.
+					Config:             fmt.Sprintf(config, testRepoName, false, "COMMIT_OR_PR_TITLE", "COMMIT_MESSAGES", testAccConf.testRepositoryVisibility),
+					PlanOnly:           true,
+					ExpectNonEmptyPlan: false,
+				},
+			},
+		})
+	})
+
 	t.Run("create and modify squash merge commit strategy without error", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Resolves #3554

----

## Summary

`merge_commit_title` / `merge_commit_message` (and the `squash_merge_commit_*` equivalents) **cannot be set on GitHub while the corresponding merge strategy is disabled**. If `allow_merge_commit = false`, GitHub ignores/refuses these fields — the REST API returns:

```
HTTP 422 Validation Failed
Sorry, you need to allow the merge commit strategy in order to set the default
merge commit message title and message. (no_merge_strategy)
```

Because of this, a config that sets `allow_merge_commit = false` **and** specifies `merge_commit_title` / `merge_commit_message` produces a plan that can never converge.

## Behaviour: v6.13.0 vs this PR

### terraform-provider-github v6.13.0 (current)

To avoid the 422 above, the provider **already skips setting** these fields when the strategy is disabled — it simply never puts them in the API request:

```go
// only configure merge commit if we are in commit merge strategy
allowMergeCommit, ok := d.Get("allow_merge_commit").(bool)
if ok {
	if allowMergeCommit {                     // <-- only when true
		repository.MergeCommitTitle = new(d.Get("merge_commit_title").(string))
		repository.MergeCommitMessage = new(d.Get("merge_commit_message").(string))
	}
}
```

The problem: nothing tells Terraform the fields are being ignored. The values still appear in the plan as a pending change, the apply silently does not send them, GitHub keeps its existing values, and the **next plan shows the same change again** — perpetual, non-convergent drift:

```
~ merge_commit_message = "PR_BODY" -> "BLANK"
~ merge_commit_title   = "PR_TITLE" -> "MERGE_MESSAGE"
Plan: 0 to add, 1 to change, 0 to destroy.   # ...forever, apply never fixes it
```

### This PR

The fix keeps the "don't send them" behaviour (still correct — GitHub would 422), but makes the provider **honest and convergent** about it:

1. **The `merge_commit_*` / `squash_merge_commit_*` values are ignored from plan onwards** while the strategy is disabled. A `DiffSuppressFunc` suppresses the diff on these fields whenever `allow_merge_commit` / `allow_squash_merge` is `false`, so the plan converges (no more perpetual drift) and re-applies are no-ops.
2. **The ignored setting is surfaced as a warning** (emitted on create/apply, when an update runs) instead of silently having no effect:

```
Warning: merge commit setting ignored

  with github_repository.test,
  on main.tf line 31, in resource "github_repository" "test":
  31:   merge_commit_title   = var.merge_commit_title

"merge_commit_title" is ignored because allow_merge_commit is false; GitHub
does not allow changing it while merge commits are disabled.
```

When the strategy is enabled again, diffs on these fields work exactly as before.

### Why the warning is emitted at apply time, not plan time

Ideally this warning would also appear during `terraform plan`. Unfortunately the Terraform Plugin SDK v2 (which this provider uses) has no hook that can emit a **warning** at plan time conditioned on another attribute:

- **`CustomizeDiff`** is the only plan-time hook that can see sibling attributes (e.g. read `allow_merge_commit` while deciding about `merge_commit_title`). But its signature returns `error` only — it can *fail* the plan, not attach a warning. Turning this into a plan-time signal would mean erroring out and blocking `apply`, which is stricter than the ignored-setting deserves.
- **`ValidateDiagFunc`** does run at plan/validate time and *can* return `diag.Diagnostics` (including warnings), but its signature is `func(interface{}, cty.Path)` — it only receives the single attribute's own value and path, with **no access to sibling attributes**. So a validator on `merge_commit_title` cannot know whether `allow_merge_commit` is `false`, which is exactly the condition we need to warn about.

There is therefore no way in SDK v2 to emit a *conditional* plan-time warning here. The warning is instead emitted from the create/update path, so it surfaces at **apply** time via `diag.Diagnostics`.

Consequence: if the *only* change in a plan is an ignored `merge_commit_*` value, that plan is a no-op, no update runs, and no warning is shown for that specific run — but the `DiffSuppressFunc` still suppresses the diff, which is what prevents the drift. The warning reliably appears whenever an update actually runs (e.g. on create, or when `allow_merge_commit` itself flips to `false`).

## Verification

Verified end-to-end against a real repository, running the same sequence on both providers:

| Step | v6.13.0 | This PR |
|---|---|---|
| apply `allow_merge_commit=false` + changed `merge_commit_*` | applies "OK" silently | applies OK, **warning** shown |
| gh API: did the values change on GitHub? | **No** (ignored) | **No** (ignored) |
| `terraform plan` again | **drift** (never converges) | **No changes** (fixed) |

## Pull request checklist

- [ ] Schema migrations have been created if needed
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (docs already state these fields are "Applicable only if allow_merge_commit / allow_squash_merge is true")

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

