### PR TITLE
fix: Error at plan when merge/squash commit title/message set with strategy disabled (alt. to #3556)

### DIFF
--- a/github/resource_github_repository.go
+++ b/github/resource_github_repository.go
@@ -496,11 +496,65 @@ func resourceGithubRepository() *schema.Resource {
 		},
 		CustomizeDiff: customdiff.All(
 			customDiffFunction,
+			validateMergeCommitSettings,
 			customdiff.ForceNewIfChange("fork", valueChangedButNotEmpty),
 			customdiff.ForceNewIfChange("source_repo", valueChangedButNotEmpty),
 			customdiff.ForceNewIfChange("source_owner", valueChangedButNotEmpty),
 		),
 	}
+}
+
+// validateMergeCommitSettings fails the plan when the user has explicitly
+// configured merge_commit_* or squash_merge_commit_* values while the
+// corresponding merge strategy is disabled. GitHub rejects any attempt to set
+// these values while the strategy is off (HTTP 422 "no_merge_strategy"), so
+// such a configuration can never be applied. Erroring at plan time tells the
+// user exactly what to fix instead of producing a plan that never converges.
+// See issue #3554.
+//
+// "Configured" means the value is explicitly present in the configuration
+// (checked via the raw config), not merely equal to the schema default, so a
+// config that only sets allow_merge_commit = false without touching the
+// title/message is not affected.
+func validateMergeCommitSettings(_ context.Context, diff *schema.ResourceDiff, _ any) error {
+	rawConfig := diff.GetRawConfig()
+	if rawConfig.IsNull() {
+		return nil
+	}
+
+	configured := func(attr string) bool {
+		v := rawConfig.GetAttr(attr)
+		return !v.IsNull() && v.IsKnown()
+	}
+
+	var errs []string
+
+	if !diff.Get("allow_merge_commit").(bool) {
+		for _, attr := range []string{"merge_commit_title", "merge_commit_message"} {
+			if configured(attr) {
+				errs = append(errs, fmt.Sprintf("%q cannot be set while allow_merge_commit is false", attr))
+			}
+		}
+	}
+
+	if !diff.Get("allow_squash_merge").(bool) {
+		for _, attr := range []string{"squash_merge_commit_title", "squash_merge_commit_message"} {
+			if configured(attr) {
+				errs = append(errs, fmt.Sprintf("%q cannot be set while allow_squash_merge is false", attr))
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf(
+			"invalid github_repository configuration: %s. GitHub does not allow "+
+				"changing these values while the corresponding merge strategy is "+
+				"disabled; remove them or enable the strategy",
+			strings.Join(errs, "; "),
+		)
+	}
+
+	return nil
 }
 
 // valueChangedButNotEmpty is a customdiff function that triggers recreation of the resource

--- a/github/resource_github_repository_test.go
+++ b/github/resource_github_repository_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -843,6 +844,70 @@ resource "github_repository" "test" {
 						resource.TestCheckResourceAttr("github_repository.test", "merge_commit_title", updatedMergeCommitTitle),
 						resource.TestCheckResourceAttr("github_repository.test", "merge_commit_message", updatedMergeCommitMessage),
 					),
+				},
+			},
+		})
+	})
+
+	t.Run("errors at plan when merge_commit_* is set while merge commits are disabled", func(t *testing.T) {
+		t.Parallel()
+
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		testRepoName := fmt.Sprintf("%splan-err-co-%s", testResourcePrefix, randomID)
+
+		// See https://github.com/integrations/terraform-provider-github/issues/3554
+		// GitHub rejects any change to merge_commit_title/message while merge
+		// commits are disabled (HTTP 422 "no_merge_strategy"), so this config can
+		// never be applied. The provider must fail the plan with a clear message.
+		config := fmt.Sprintf(`
+resource "github_repository" "test" {
+		name                 = "%[1]s"
+		allow_merge_commit   = false
+		merge_commit_title   = "MERGE_MESSAGE"
+		merge_commit_message = "PR_TITLE"
+		visibility           = "%[2]s"
+}
+`, testRepoName, testAccConf.testRepositoryVisibility)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:      config,
+					PlanOnly:    true,
+					ExpectError: regexp.MustCompile(`"merge_commit_title" cannot be set while allow_merge_commit is false`),
+				},
+			},
+		})
+	})
+
+	t.Run("errors at plan when squash_merge_commit_* is set while squash merges are disabled", func(t *testing.T) {
+		t.Parallel()
+
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		testRepoName := fmt.Sprintf("%splan-err-sq-%s", testResourcePrefix, randomID)
+
+		// allow_merge_commit defaults to true, so the repo still has a valid
+		// merge strategy while squash merges are disabled.
+		config := fmt.Sprintf(`
+resource "github_repository" "test" {
+		name                        = "%[1]s"
+		allow_squash_merge          = false
+		squash_merge_commit_title   = "COMMIT_OR_PR_TITLE"
+		squash_merge_commit_message = "COMMIT_MESSAGES"
+		visibility                  = "%[2]s"
+}
+`, testRepoName, testAccConf.testRepositoryVisibility)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:      config,
+					PlanOnly:    true,
+					ExpectError: regexp.MustCompile(`"squash_merge_commit_title" cannot be set while allow_squash_merge is false`),
 				},
 			},
 		})


### PR DESCRIPTION
Resolves #3554

> **Alternative approach.** This is one of two proposed fixes for #3554. The other (#3556) *suppresses* the diff and emits an apply-time warning so the config silently converges. **This** PR takes the stricter route: it **fails the plan** with a clear error. Opened as a draft so maintainers can compare the two.

----

### Background

`merge_commit_title` / `merge_commit_message` (and the `squash_merge_commit_*` equivalents) **cannot be set on GitHub while the corresponding merge strategy is disabled**. With `allow_merge_commit = false`, the REST API returns:

```
HTTP 422 Validation Failed
Sorry, you need to allow the merge commit strategy in order to set the default
merge commit message title and message. (no_merge_strategy)
```

The current provider avoids the 422 by simply **not sending** these fields when the strategy is off — but nothing tells the user, so the plan keeps showing a change that the apply silently never makes: perpetual, non-convergent drift.

### After the change?

A `CustomizeDiff` validation **fails the plan** when the user has **explicitly configured** `merge_commit_*` / `squash_merge_commit_*` while the corresponding `allow_merge_commit` / `allow_squash_merge` is `false`:

```
Error: invalid github_repository configuration: "merge_commit_title" cannot be
set while allow_merge_commit is false. GitHub does not allow changing these
values while the corresponding merge strategy is disabled; remove them or
enable the strategy
```

Key details:

- **Only explicit config triggers it.** "Configured" is detected via the raw config (`GetRawConfig`), i.e. the value is actually present in the user's `.tf`. Because `merge_commit_*` have schema defaults, a config that only sets `allow_merge_commit = false` and never mentions the title/message is **not** affected.
- **When the strategy is enabled**, these fields behave exactly as before.
- The error is at **plan** time (`CustomizeDiff`), so it's caught before any apply.

### Trade-off vs #3556

| | #3556 (suppress + warn) | This PR (error at plan) |
|---|---|---|
| Result | Plan converges; ignored values, apply-time warning | Plan **fails** with an explicit message |
| Signal timing | Warning at apply (SDKv2 can't warn at plan) | Error at **plan** |
| Behaviour change | Non-breaking (previously-drifty config now converges) | **Potentially breaking**: a config that previously applied (with drift) now fails to plan |
| Philosophy | Be lenient, inform | Be strict, force the user to fix the config |

### Verification

Verified against a real repository:

- `allow_merge_commit=false` + `merge_commit_title` explicitly set → **plan errors** ✅
- `allow_merge_commit=false`, title/message not set → **plan succeeds** ✅ (no false positive)
- `allow_merge_commit=true` + title set → **plan succeeds** ✅

### Pull request checklist

- [ ] Schema migrations have been created if needed
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed

### Does this introduce a breaking change?

- [x] Yes — a configuration that sets `merge_commit_*` / `squash_merge_commit_*` while the corresponding strategy is disabled will now fail at plan time (previously it applied with perpetual drift).
- [ ] No
