### PR TITLE
fix: restore adopt-existing behavior in github_issue_label create (regression in v6.13.0)

### DIFF
--- a/github/resource_github_issue_label.go
+++ b/github/resource_github_issue_label.go
@@ -89,7 +89,26 @@ func resourceGithubIssueLabelCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.Errorf(`expected "description" to be string`)
 	}
 	label.Description = &description
-	githubLabel, resp, err := client.Issues.CreateLabel(ctx, orgName, repoName, label)
+
+	// Issue labels are keyed off of their "name", so a label with the same
+	// name that already exists on the repository outside of Terraform causes
+	// CreateLabel to fail with "422 Validation Failed [already_exists]". This
+	// is common because GitHub seeds every new repository with a set of default
+	// labels (bug, documentation, enhancement, etc.). To preserve the
+	// documented adopt-existing behavior, first check whether the label already
+	// exists and, if so, update it instead of creating it.
+	existing, resp, err := client.Issues.GetLabel(ctx, orgName, repoName, name)
+	if err != nil && (resp == nil || resp.StatusCode != http.StatusNotFound) {
+		return diag.FromErr(err)
+	}
+
+	var githubLabel *github.Label
+	if existing != nil {
+		tflog.Info(ctx, "Adopting existing issue label", map[string]any{"name": name, "org_name": orgName, "repo_name": repoName})
+		githubLabel, resp, err = client.Issues.EditLabel(ctx, orgName, repoName, name, label)
+	} else {
+		githubLabel, resp, err = client.Issues.CreateLabel(ctx, orgName, repoName, label)
+	}
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/github/resource_github_issue_label_test.go
+++ b/github/resource_github_issue_label_test.go
@@ -129,4 +129,53 @@ func TestAccGithubIssueLabel(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("adopts a pre-existing label on create without error", func(t *testing.T) {
+		t.Parallel()
+
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%srepo-issue-label-adopt-%s", testResourcePrefix, randomID)
+
+		// An auto-initialized repository is seeded with GitHub's default labels
+		// (bug, documentation, enhancement, ...). Managing one of those names
+		// must adopt and update the existing label rather than failing the
+		// initial apply with "422 Validation Failed [already_exists]".
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name      = "%s"
+				auto_init = true
+			}
+
+			resource "github_issue_label" "test" {
+				repository  = github_repository.test.name
+				name        = "bug"
+				color       = "123456"
+				description = "adopted bug label"
+			}
+		`, repoName)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(
+							"github_issue_label.test", "name",
+							"bug",
+						),
+						resource.TestCheckResourceAttr(
+							"github_issue_label.test", "color",
+							"123456",
+						),
+						resource.TestCheckResourceAttr(
+							"github_issue_label.test", "description",
+							"adopted bug label",
+						),
+					),
+				},
+			},
+		})
+	})
 }


### PR DESCRIPTION
Resolves #3559

----

### Before the change?

`resource "github_issue_label"` used to be idempotent on create: a single
`resourceGithubIssueLabelCreateOrUpdate` did a GET first and adopted (updated)
a label that already existed instead of creating it. PR #3342 (released in
v6.13.0) split that into context-aware `Create` and `Update` functions, and the
new `Create` calls `client.Issues.CreateLabel(...)` directly with no GET-first
existence check.

As a result, creating a label whose name already exists on the repository fails
the very first apply with `422 Validation Failed [already_exists]`. This is a
common case, not an edge case: GitHub (and GHES) seed every new repository with
default labels (`bug`, `documentation`, `duplicate`, `enhancement`,
`good first issue`, `help wanted`, `invalid`, `question`, `wontfix`), so any
config that manages one of those names now breaks on first apply. The resource's
own docs still promise the "check if the label exists, then update, otherwise
create" behavior.

### After the change?

`resourceGithubIssueLabelCreate` now restores the pre-6.13.0 adopt-existing
behavior, in the current context-aware CRUD style: it calls
`client.Issues.GetLabel(ctx, owner, repo, name)` first; if the label already
exists it issues an `EditLabel` (adopting/updating it), and if the GET returns
`404` it falls through to `CreateLabel` exactly as today. Any non-404 error from
the GET is returned. `diag.Diagnostics`/`context` signatures and `tflog` logging
are kept consistent with the rest of the file.

An acceptance test (`adopts a pre-existing label on create without error`) is
added: it manages the default `bug` label on an `auto_init` repository and
asserts the apply succeeds and the label's color/description are updated.

> Note: I was not able to exercise the acceptance-test suite here as it requires
> live GitHub org credentials. Maintainers should run
> `TF_ACC=1 go test ./github -run TestAccGithubIssueLabel` to confirm. `gofmt`,
> `go vet ./github`, and `go build ./...` all pass.

### Pull request checklist

- [ ] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No
