### PR TITLE
feat: Update repository collaborators to ignore non-direct teams

### DIFF
--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -186,7 +186,7 @@ The overall status of each resource or data source is captured in this document 
 | `github_repository` | ❓ | ❓ | ❓ | ❓ | ❓ | ❓ | ❓ |
 | `github_repository_autolink_reference` | ❓ | ❓ | ❓ | ❓ | ❓ | ❓ | ❓ |
 | `github_repository_collaborator` | ❓ | ❓ | ❓ | ❓ | ❓ | ❓ | ❓ |
-| `github_repository_collaborators` | ⚠️ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
+| `github_repository_collaborators` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `github_repository_custom_property` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `github_repository_dependabot_security_updates` | ❓ | ❓ | ❓ | ❓ | ❓ | ❓ | ❓ |
 | `github_repository_deploy_key` | ❓ | ❓ | ❓ | ❓ | ❓ | ❓ | ❓ |

--- a/docs/resources/repository_collaborators.md
+++ b/docs/resources/repository_collaborators.md
@@ -2,12 +2,12 @@
 page_title: "github_repository_collaborators (Resource) - GitHub"
 subcategory: ""
 description: |-
-  Manage the complete set of collaborators (users and teams) for a GitHub repository.
+  Resource to manage the complete set of collaborators (users and teams) for a repository.
 ---
 
 # github_repository_collaborators (Resource)
 
-Manage the complete set of collaborators (users and teams) for a GitHub repository.
+Resource to manage the complete set of collaborators (users and teams) for a repository.
 
 ~> This resource (`github_repository_collaborators`) cannot be used in conjunction with [`github_repository_collaborator`](repository_collaborator) or [`github_team_repository`](team_repository) as they will conflict over the management of collaborators.
 
@@ -76,7 +76,7 @@ resource "github_repository_collaborators" "some_repo_collaborators" {
 
 ### Optional
 
-- `ignore_team` (Block Set) Teams to ignore when managing repository collaborators. (see [below for nested schema](#nestedblock--ignore_team))
+- `ignore_team` (Block Set, Deprecated) Teams to ignore when managing repository collaborators. (see [below for nested schema](#nestedblock--ignore_team))
 - `team` (Block Set) Teams to grant access to the repository. (see [below for nested schema](#nestedblock--team))
 - `user` (Block Set) Users to grant access to the repository. (see [below for nested schema](#nestedblock--user))
 

--- a/docs/resources/repository_collaborators.md
+++ b/docs/resources/repository_collaborators.md
@@ -21,7 +21,7 @@ For repositories owned by an organization, collaborators can have explicit (and 
 
 ### Teams
 
-Teams will be added to the repository on apply, and removed if removed from the configuration or on destroy. Teams added to the repository outside of Terraform can be managed by adding them to the configuration, or ignored by using the `ignore_team` argument. This is particularly important for organization/enterprise teams, which either need to be added to the configuration or ignored, as otherwise they will cause perpetual drift.
+Teams will be added to the repository on apply, and removed if removed from the configuration or on destroy. Teams added to the repository outside of Terraform can be managed by adding them to the configuration.
 
 ## Personal Repositories
 

--- a/github/acc_helpers_repository_test.go
+++ b/github/acc_helpers_repository_test.go
@@ -24,7 +24,9 @@ func mustCreateTestRepository(t *testing.T, f ...createTestRepositoryOptionsFunc
 	}
 
 	for _, fn := range f {
-		fn(req)
+		if fn != nil {
+			fn(req)
+		}
 	}
 
 	var org string

--- a/github/acc_helpers_repository_test.go
+++ b/github/acc_helpers_repository_test.go
@@ -1,0 +1,59 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-github/v89/github"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+)
+
+type createTestRepositoryOptionsFunc func(*github.Repository)
+
+func mustCreateTestRepository(t *testing.T, f ...createTestRepositoryOptionsFunc) *github.Repository {
+	t.Helper()
+
+	randomID := acctest.RandString(testRandomIDLength)
+	name := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+
+	req := &github.Repository{
+		Name:     &name,
+		AutoInit: new(true),
+	}
+
+	for _, fn := range f {
+		fn(req)
+	}
+
+	var org string
+	if testAccConf.meta.IsOrganization {
+		org = testAccConf.meta.name
+	}
+
+	repo, _, err := testAccConf.meta.v3client.Repositories.Create(t.Context(), org, req)
+	if err != nil {
+		t.Fatalf("failed to create test repository: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if _, err := testAccConf.meta.v3client.Repositories.Delete(context.Background(), testAccConf.meta.name, name); err != nil {
+			if err, ok := errors.AsType[*github.ErrorResponse](err); ok && err.Response.StatusCode == 404 {
+				return
+			}
+			t.Logf("failed to delete test repository %s: %v", name, err)
+		}
+	})
+
+	return repo
+}
+
+func mustRenameTestRepository(t *testing.T, repo *github.Repository, newName string) {
+	t.Helper()
+
+	_, _, err := testAccConf.meta.v3client.Repositories.Edit(t.Context(), testAccConf.meta.name, repo.GetName(), &github.Repository{Name: &newName})
+	if err != nil {
+		t.Fatalf("failed to rename test repository %s to %s: %v", repo.GetName(), newName, err)
+	}
+}

--- a/github/acc_helpers_team_test.go
+++ b/github/acc_helpers_team_test.go
@@ -1,0 +1,116 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-github/v89/github"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+)
+
+type createTestTeamOptionsFunc func(*github.NewTeam)
+
+func withNewTeamParent(parentID int64) createTestTeamOptionsFunc {
+	return func(team *github.NewTeam) {
+		team.ParentTeamID = &parentID
+	}
+}
+
+func mustCreateTestTeam(t *testing.T, f ...createTestTeamOptionsFunc) *github.Team {
+	t.Helper()
+
+	randomID := acctest.RandString(testRandomIDLength)
+	name := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+
+	req := &github.NewTeam{
+		Name:    name,
+		Privacy: new("closed"),
+	}
+
+	for _, fn := range f {
+		fn(req)
+	}
+
+	team, _, err := testAccConf.meta.v3client.Teams.CreateTeam(t.Context(), testAccConf.meta.name, *req)
+	if err != nil {
+		t.Fatalf("failed to create test team: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if _, err := testAccConf.meta.v3client.Teams.DeleteTeamByID(context.Background(), testAccConf.meta.id, team.GetID()); err != nil {
+			if err, ok := errors.AsType[*github.ErrorResponse](err); ok && err.Response.StatusCode == 404 {
+				return
+			}
+			t.Logf("failed to delete test team %s: %v", name, err)
+		}
+	})
+
+	return team
+}
+
+func mustRenameTeam(t *testing.T, team *github.Team, newName string) {
+	t.Helper()
+
+	_, _, err := testAccConf.meta.v3client.Teams.EditTeamBySlug(t.Context(), testAccConf.meta.name, team.GetSlug(), github.NewTeam{Name: newName}, false)
+	if err != nil {
+		t.Fatalf("failed to rename test team %s to %s: %v", team.GetName(), newName, err)
+	}
+}
+
+func mustDeleteTeam(t *testing.T, team *github.Team) {
+	t.Helper()
+
+	if _, err := testAccConf.meta.v3client.Teams.DeleteTeamBySlug(context.Background(), testAccConf.meta.name, team.GetSlug()); err != nil {
+		if err, ok := errors.AsType[*github.ErrorResponse](err); ok && err.Response.StatusCode == 404 {
+			return
+		}
+		t.Fatalf("failed to delete test team %s: %v", team.GetName(), err)
+	}
+}
+
+func mustAddTeamMember(t *testing.T, team *github.Team, username string) {
+	t.Helper()
+
+	_, _, err := testAccConf.meta.v3client.Teams.AddTeamMembershipBySlug(t.Context(), testAccConf.meta.name, team.GetSlug(), username, &github.TeamAddTeamMembershipOptions{Role: "member"})
+	if err != nil {
+		t.Fatalf("failed to add member %s to test team %s: %v", username, team.GetName(), err)
+	}
+}
+
+func mustAddTeamMaintainer(t *testing.T, team *github.Team, username string) {
+	t.Helper()
+
+	_, _, err := testAccConf.meta.v3client.Teams.AddTeamMembershipBySlug(t.Context(), testAccConf.meta.name, team.GetSlug(), username, &github.TeamAddTeamMembershipOptions{Role: "maintainer"})
+	if err != nil {
+		t.Fatalf("failed to add member %s to test team %s: %v", username, team.GetName(), err)
+	}
+}
+
+func mustAssignOrganizationRoleToTeam(t *testing.T, team *github.Team, roleID int64) {
+	t.Helper()
+
+	_, err := testAccConf.meta.v3client.Organizations.AssignOrgRoleToTeam(t.Context(), testAccConf.meta.name, team.GetSlug(), roleID)
+	if err != nil {
+		t.Fatalf("failed to assign organization role %d to team %s: %v", roleID, team.GetName(), err)
+	}
+
+	t.Cleanup(func() {
+		if _, err := testAccConf.meta.v3client.Organizations.RemoveOrgRoleFromTeam(context.Background(), testAccConf.meta.name, team.GetSlug(), roleID); err != nil {
+			if err, ok := errors.AsType[*github.ErrorResponse](err); ok && err.Response.StatusCode == 404 {
+				return
+			}
+			t.Logf("failed to unassign organization role %d from team %s: %v", roleID, team.GetName(), err)
+		}
+	})
+}
+
+func mustAddRepositoryToTeam(t *testing.T, team *github.Team, repo *github.Repository) {
+	t.Helper()
+
+	_, err := testAccConf.meta.v3client.Teams.AddTeamRepoByID(t.Context(), testAccConf.meta.id, team.GetID(), testAccConf.meta.name, repo.GetName(), &github.TeamAddTeamRepoOptions{Permission: "pull"})
+	if err != nil {
+		t.Fatalf("failed to add team %s to test repository %s: %v", team.GetName(), repo.GetName(), err)
+	}
+}

--- a/github/acc_helpers_team_test.go
+++ b/github/acc_helpers_team_test.go
@@ -88,9 +88,13 @@ func mustAddTeamMember(t *testing.T, team *github.Team, username string) {
 func mustAddTeamMaintainer(t *testing.T, team *github.Team, username string) {
 	t.Helper()
 
-	_, _, err := testAccConf.meta.v3client.Teams.AddTeamMembershipBySlug(t.Context(), testAccConf.meta.name, team.GetSlug(), username, &github.TeamAddTeamMembershipOptions{Role: "maintainer"})
+	membership, _, err := testAccConf.meta.v3client.Teams.AddTeamMembershipBySlug(t.Context(), testAccConf.meta.name, team.GetSlug(), username, &github.TeamAddTeamMembershipOptions{Role: "maintainer"})
 	if err != nil {
 		t.Fatalf("failed to add member %s to test team %s: %v", username, team.GetName(), err)
+	}
+
+	if membership.GetState() != "active" {
+		t.Fatalf("failed to add member %s to test team %s: membership state is %s", username, team.GetName(), membership.GetState())
 	}
 }
 

--- a/github/acc_helpers_team_test.go
+++ b/github/acc_helpers_team_test.go
@@ -30,7 +30,9 @@ func mustCreateTestTeam(t *testing.T, f ...createTestTeamOptionsFunc) *github.Te
 	}
 
 	for _, fn := range f {
-		fn(req)
+		if fn != nil {
+			fn(req)
+		}
 	}
 
 	team, _, err := testAccConf.meta.v3client.Teams.CreateTeam(t.Context(), testAccConf.meta.name, *req)
@@ -73,9 +75,13 @@ func mustDeleteTeam(t *testing.T, team *github.Team) {
 func mustAddTeamMember(t *testing.T, team *github.Team, username string) {
 	t.Helper()
 
-	_, _, err := testAccConf.meta.v3client.Teams.AddTeamMembershipBySlug(t.Context(), testAccConf.meta.name, team.GetSlug(), username, &github.TeamAddTeamMembershipOptions{Role: "member"})
+	membership, _, err := testAccConf.meta.v3client.Teams.AddTeamMembershipBySlug(t.Context(), testAccConf.meta.name, team.GetSlug(), username, &github.TeamAddTeamMembershipOptions{Role: "member"})
 	if err != nil {
 		t.Fatalf("failed to add member %s to test team %s: %v", username, team.GetName(), err)
+	}
+
+	if membership.GetState() != "active" {
+		t.Fatalf("failed to add member %s to test team %s: membership state is %s", username, team.GetName(), membership.GetState())
 	}
 }
 

--- a/github/acc_helpers_test.go
+++ b/github/acc_helpers_test.go
@@ -63,38 +63,20 @@ func mustGetOrganizationRole(t *testing.T, roleID int64) *github.CustomOrgRole {
 	return role
 }
 
-func mustAddOrganizationRoleUser(t *testing.T, role *github.CustomOrgRole, username string) {
+func mustAssignOrganizationRoleToUser(t *testing.T, username string, roleID int64) {
 	t.Helper()
 
-	_, err := testAccConf.meta.v3client.Organizations.AssignOrgRoleToUser(t.Context(), testAccConf.meta.name, username, role.GetID())
+	_, err := testAccConf.meta.v3client.Organizations.AssignOrgRoleToUser(t.Context(), testAccConf.meta.name, username, roleID)
 	if err != nil {
-		t.Fatalf("failed to add user %s to test organization role %s: %v", username, role.GetName(), err)
+		t.Fatalf("failed to add user %s to test organization role %d: %v", username, roleID, err)
 	}
 
 	t.Cleanup(func() {
-		if _, err := testAccConf.meta.v3client.Organizations.RemoveOrgRoleFromUser(context.Background(), testAccConf.meta.name, username, role.GetID()); err != nil {
+		if _, err := testAccConf.meta.v3client.Organizations.RemoveOrgRoleFromUser(context.Background(), testAccConf.meta.name, username, roleID); err != nil {
 			if err, ok := errors.AsType[*github.ErrorResponse](err); ok && err.Response.StatusCode == 404 {
 				return
 			}
-			t.Logf("failed to remove user %s from test organization role %s: %v", username, role.GetName(), err)
-		}
-	})
-}
-
-func mustAddOrganizationRoleTeam(t *testing.T, role *github.CustomOrgRole, team *github.Team) {
-	t.Helper()
-
-	_, err := testAccConf.meta.v3client.Organizations.AssignOrgRoleToTeam(t.Context(), testAccConf.meta.name, team.GetSlug(), role.GetID())
-	if err != nil {
-		t.Fatalf("failed to add team %s to test organization role %s: %v", team.GetName(), role.GetName(), err)
-	}
-
-	t.Cleanup(func() {
-		if _, err := testAccConf.meta.v3client.Organizations.RemoveOrgRoleFromTeam(context.Background(), testAccConf.meta.name, team.GetSlug(), role.GetID()); err != nil {
-			if err, ok := errors.AsType[*github.ErrorResponse](err); ok && err.Response.StatusCode == 404 {
-				return
-			}
-			t.Logf("failed to remove team %s from test organization role %s: %v", team.GetName(), role.GetName(), err)
+			t.Logf("failed to remove user %s from test organization role %d: %v", username, roleID, err)
 		}
 	})
 }
@@ -167,104 +149,6 @@ func mustGetUser(t *testing.T, username string) *github.User {
 	return user
 }
 
-func mustCreateTestTeam(t *testing.T, parentID *int64) *github.Team {
-	t.Helper()
-
-	randomID := acctest.RandString(testRandomIDLength)
-	name := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
-
-	team, _, err := testAccConf.meta.v3client.Teams.CreateTeam(t.Context(), testAccConf.meta.name, github.NewTeam{Name: name, ParentTeamID: parentID, Privacy: new("closed")})
-	if err != nil {
-		t.Fatalf("failed to create test team: %v", err)
-	}
-
-	t.Cleanup(func() {
-		if _, err := testAccConf.meta.v3client.Teams.DeleteTeamByID(context.Background(), testAccConf.meta.id, team.GetID()); err != nil {
-			if err, ok := errors.AsType[*github.ErrorResponse](err); ok && err.Response.StatusCode == 404 {
-				return
-			}
-			t.Logf("failed to delete test team %s: %v", name, err)
-		}
-	})
-
-	return team
-}
-
-func mustRenameTestTeam(t *testing.T, team *github.Team, newName string) {
-	t.Helper()
-
-	_, _, err := testAccConf.meta.v3client.Teams.EditTeamBySlug(t.Context(), testAccConf.meta.name, team.GetSlug(), github.NewTeam{Name: newName}, false)
-	if err != nil {
-		t.Fatalf("failed to rename test team %s to %s: %v", team.GetName(), newName, err)
-	}
-}
-
-func mustDeleteTestTeam(t *testing.T, team *github.Team) {
-	t.Helper()
-
-	if _, err := testAccConf.meta.v3client.Teams.DeleteTeamBySlug(context.Background(), testAccConf.meta.name, team.GetSlug()); err != nil {
-		if err, ok := errors.AsType[*github.ErrorResponse](err); ok && err.Response.StatusCode == 404 {
-			return
-		}
-		t.Fatalf("failed to delete test team %s: %v", team.GetName(), err)
-	}
-}
-
-func mustAddTeamMember(t *testing.T, team *github.Team, username string) {
-	t.Helper()
-
-	_, _, err := testAccConf.meta.v3client.Teams.AddTeamMembershipBySlug(t.Context(), testAccConf.meta.name, team.GetSlug(), username, &github.TeamAddTeamMembershipOptions{Role: "member"})
-	if err != nil {
-		t.Fatalf("failed to add member %s to test team %s: %v", username, team.GetName(), err)
-	}
-}
-
-func mustAddTeamMaintainer(t *testing.T, team *github.Team, username string) {
-	t.Helper()
-
-	_, _, err := testAccConf.meta.v3client.Teams.AddTeamMembershipBySlug(t.Context(), testAccConf.meta.name, team.GetSlug(), username, &github.TeamAddTeamMembershipOptions{Role: "maintainer"})
-	if err != nil {
-		t.Fatalf("failed to add member %s to test team %s: %v", username, team.GetName(), err)
-	}
-}
-
-func mustCreateTestRepository(t *testing.T) *github.Repository {
-	t.Helper()
-
-	randomID := acctest.RandString(testRandomIDLength)
-	name := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
-
-	req := &github.Repository{
-		Name:     &name,
-		AutoInit: new(true),
-	}
-
-	repo, _, err := testAccConf.meta.v3client.Repositories.Create(t.Context(), testAccConf.meta.name, req)
-	if err != nil {
-		t.Fatalf("failed to create test repository: %v", err)
-	}
-
-	t.Cleanup(func() {
-		if _, err := testAccConf.meta.v3client.Repositories.Delete(context.Background(), testAccConf.meta.name, name); err != nil {
-			if err, ok := errors.AsType[*github.ErrorResponse](err); ok && err.Response.StatusCode == 404 {
-				return
-			}
-			t.Logf("failed to delete test repository %s: %v", name, err)
-		}
-	})
-
-	return repo
-}
-
-func mustRenameTestRepository(t *testing.T, repo *github.Repository, newName string) {
-	t.Helper()
-
-	_, _, err := testAccConf.meta.v3client.Repositories.Edit(t.Context(), testAccConf.meta.name, repo.GetName(), &github.Repository{Name: &newName})
-	if err != nil {
-		t.Fatalf("failed to rename test repository %s to %s: %v", repo.GetName(), newName, err)
-	}
-}
-
 func mustCreateTestBranch(t *testing.T, repo *github.Repository) string {
 	t.Helper()
 
@@ -294,15 +178,6 @@ func mustAddRepositoryCollaborator(t *testing.T, repo *github.Repository, userna
 	_, _, err := testAccConf.meta.v3client.Repositories.AddCollaborator(t.Context(), testAccConf.meta.name, repo.GetName(), username, &github.RepositoryAddCollaboratorOptions{Permission: "push"})
 	if err != nil {
 		t.Fatalf("failed to add collaborator %s to test repository %s: %v", username, repo.GetName(), err)
-	}
-}
-
-func mustAddRepositoryTeam(t *testing.T, repo *github.Repository, team *github.Team) {
-	t.Helper()
-
-	_, err := testAccConf.meta.v3client.Teams.AddTeamRepoByID(t.Context(), testAccConf.meta.id, team.GetID(), testAccConf.meta.name, repo.GetName(), &github.TeamAddTeamRepoOptions{Permission: "pull"})
-	if err != nil {
-		t.Fatalf("failed to add team %s to test repository %s: %v", team.GetName(), repo.GetName(), err)
 	}
 }
 

--- a/github/data_source_github_organization_role_teams_test.go
+++ b/github/data_source_github_organization_role_teams_test.go
@@ -18,16 +18,16 @@ func TestAccDataSourceGithubOrganizationRoleTeams(t *testing.T) {
 	t.Run("queries_teams", func(t *testing.T) {
 		t.Parallel()
 
-		role := mustGetOrganizationRole(t, 138)
+		roleID := int64(138)
 		team1 := mustCreateTestTeam(t, nil)
-		team2 := mustCreateTestTeam(t, new(team1.GetID()))
-		mustAddOrganizationRoleTeam(t, role, team1)
+		team2 := mustCreateTestTeam(t, withNewTeamParent(team1.GetID()))
+		mustAssignOrganizationRoleToTeam(t, team1, roleID)
 
 		config := fmt.Sprintf(`
 data "github_organization_role_teams" "test" {
 	role_id = %v
 }
-`, role.GetID())
+`, roleID)
 
 		resource.Test(t, resource.TestCase{
 			ProviderFactories: providerFactories,

--- a/github/data_source_github_organization_role_teams_test.go
+++ b/github/data_source_github_organization_role_teams_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceGithubOrganizationRoleTeams(t *testing.T) {
 		t.Parallel()
 
 		roleID := int64(138)
-		team1 := mustCreateTestTeam(t, nil)
+		team1 := mustCreateTestTeam(t)
 		team2 := mustCreateTestTeam(t, withNewTeamParent(team1.GetID()))
 		mustAssignOrganizationRoleToTeam(t, team1, roleID)
 

--- a/github/data_source_github_organization_role_users_test.go
+++ b/github/data_source_github_organization_role_users_test.go
@@ -20,17 +20,17 @@ func TestAccDataSourceGithubOrganizationRoleUsers(t *testing.T) {
 	t.Run("queries_users", func(t *testing.T) {
 		t.Parallel()
 
-		role := mustGetOrganizationRole(t, 138)
-		mustAddOrganizationRoleUser(t, role, testAccConf.testOrgUser1)
+		roleID := int64(138)
+		mustAssignOrganizationRoleToUser(t, testAccConf.testOrgUser1, roleID)
 		team := mustCreateTestTeam(t, nil)
 		mustAddTeamMember(t, team, testAccConf.testOrgUser2)
-		mustAddOrganizationRoleTeam(t, role, team)
+		mustAssignOrganizationRoleToTeam(t, team, roleID)
 
 		config := fmt.Sprintf(`
 data "github_organization_role_users" "test" {
   role_id = %v
 }
-`, role.GetID())
+`, roleID)
 
 		resource.Test(t, resource.TestCase{
 			ProviderFactories: providerFactories,

--- a/github/data_source_github_organization_role_users_test.go
+++ b/github/data_source_github_organization_role_users_test.go
@@ -22,7 +22,7 @@ func TestAccDataSourceGithubOrganizationRoleUsers(t *testing.T) {
 
 		roleID := int64(138)
 		mustAssignOrganizationRoleToUser(t, testAccConf.testOrgUser1, roleID)
-		team := mustCreateTestTeam(t, nil)
+		team := mustCreateTestTeam(t)
 		mustAddTeamMember(t, team, testAccConf.testOrgUser2)
 		mustAssignOrganizationRoleToTeam(t, team, roleID)
 

--- a/github/data_source_github_organization_teams_test.go
+++ b/github/data_source_github_organization_teams_test.go
@@ -19,7 +19,7 @@ func TestAccGithubOrganizationTeamsDataSource(t *testing.T) {
 		t.Parallel()
 
 		team1 := mustCreateTestTeam(t, nil)
-		team2 := mustCreateTestTeam(t, new(team1.GetID()))
+		team2 := mustCreateTestTeam(t, withNewTeamParent(team1.GetID()))
 
 		config := `
 data "github_organization_teams" "test" {
@@ -93,7 +93,7 @@ data "github_organization_teams" "test" {
 		t.Parallel()
 
 		team1 := mustCreateTestTeam(t, nil)
-		team2 := mustCreateTestTeam(t, new(team1.GetID()))
+		team2 := mustCreateTestTeam(t, withNewTeamParent(team1.GetID()))
 
 		config := `
 data "github_organization_teams" "test" {
@@ -151,9 +151,9 @@ data "github_organization_teams" "test" {
 		repo := mustCreateTestRepository(t)
 		team1 := mustCreateTestTeam(t, nil)
 		mustAddTeamMember(t, team1, testAccConf.testOrgUser1)
-		mustAddRepositoryTeam(t, repo, team1)
+		mustAddRepositoryToTeam(t, team1, repo)
 		team2 := mustCreateTestTeam(t, nil)
-		team3 := mustCreateTestTeam(t, new(team1.GetID()))
+		team3 := mustCreateTestTeam(t, withNewTeamParent(team1.GetID()))
 		mustAddTeamMember(t, team3, testAccConf.testOrgUser2)
 
 		config := `

--- a/github/data_source_github_organization_teams_test.go
+++ b/github/data_source_github_organization_teams_test.go
@@ -18,7 +18,7 @@ func TestAccGithubOrganizationTeamsDataSource(t *testing.T) {
 	t.Run("queries_all_teams_summary", func(t *testing.T) {
 		t.Parallel()
 
-		team1 := mustCreateTestTeam(t, nil)
+		team1 := mustCreateTestTeam(t)
 		team2 := mustCreateTestTeam(t, withNewTeamParent(team1.GetID()))
 
 		config := `
@@ -92,7 +92,7 @@ data "github_organization_teams" "test" {
 	t.Run("queries_root_teams_summary", func(t *testing.T) {
 		t.Parallel()
 
-		team1 := mustCreateTestTeam(t, nil)
+		team1 := mustCreateTestTeam(t)
 		team2 := mustCreateTestTeam(t, withNewTeamParent(team1.GetID()))
 
 		config := `
@@ -149,10 +149,10 @@ data "github_organization_teams" "test" {
 		skipUnlessHasOrgUser2(t)
 
 		repo := mustCreateTestRepository(t)
-		team1 := mustCreateTestTeam(t, nil)
+		team1 := mustCreateTestTeam(t)
 		mustAddTeamMember(t, team1, testAccConf.testOrgUser1)
 		mustAddRepositoryToTeam(t, team1, repo)
-		team2 := mustCreateTestTeam(t, nil)
+		team2 := mustCreateTestTeam(t)
 		team3 := mustCreateTestTeam(t, withNewTeamParent(team1.GetID()))
 		mustAddTeamMember(t, team3, testAccConf.testOrgUser2)
 

--- a/github/data_source_github_repository_teams_test.go
+++ b/github/data_source_github_repository_teams_test.go
@@ -19,9 +19,9 @@ func TestAccGithubRepositoryTeamsDataSource(t *testing.T) {
 		t.Parallel()
 
 		repo := mustCreateTestRepository(t)
-		team1 := mustCreateTestTeam(t, nil)
+		team1 := mustCreateTestTeam(t)
 		mustAddRepositoryToTeam(t, team1, repo)
-		team2 := mustCreateTestTeam(t, nil)
+		team2 := mustCreateTestTeam(t)
 		mustAddRepositoryToTeam(t, team2, repo)
 
 		config := fmt.Sprintf(`

--- a/github/data_source_github_repository_teams_test.go
+++ b/github/data_source_github_repository_teams_test.go
@@ -20,9 +20,9 @@ func TestAccGithubRepositoryTeamsDataSource(t *testing.T) {
 
 		repo := mustCreateTestRepository(t)
 		team1 := mustCreateTestTeam(t, nil)
-		mustAddRepositoryTeam(t, repo, team1)
+		mustAddRepositoryToTeam(t, team1, repo)
 		team2 := mustCreateTestTeam(t, nil)
-		mustAddRepositoryTeam(t, repo, team2)
+		mustAddRepositoryToTeam(t, team2, repo)
 
 		config := fmt.Sprintf(`
 data "github_repository_teams" "test" {

--- a/github/data_source_github_team_members_test.go
+++ b/github/data_source_github_team_members_test.go
@@ -26,7 +26,7 @@ func TestAccDataSourceGithubTeamMembers(t *testing.T) {
 		mustAddTeamMaintainer(t, team1, user1.GetLogin())
 
 		user2 := mustGetUser(t, testAccConf.testOrgUser2)
-		team2 := mustCreateTestTeam(t, team1.ID)
+		team2 := mustCreateTestTeam(t, withNewTeamParent(team1.GetID()))
 		mustAddTeamMember(t, team2, user2.GetLogin())
 
 		config := fmt.Sprintf(`
@@ -76,7 +76,7 @@ data "github_team_members" "test" {
 		mustAddTeamMaintainer(t, team1, user1.GetLogin())
 
 		user2 := mustGetUser(t, testAccConf.testOrgUser2)
-		team2 := mustCreateTestTeam(t, team1.ID)
+		team2 := mustCreateTestTeam(t, withNewTeamParent(team1.GetID()))
 		mustAddTeamMember(t, team2, user2.GetLogin())
 
 		config := fmt.Sprintf(`

--- a/github/data_source_github_team_members_test.go
+++ b/github/data_source_github_team_members_test.go
@@ -22,7 +22,7 @@ func TestAccDataSourceGithubTeamMembers(t *testing.T) {
 		skipUnlessHasOrgUser2(t)
 
 		user1 := mustGetUser(t, testAccConf.testOrgUser1)
-		team1 := mustCreateTestTeam(t, nil)
+		team1 := mustCreateTestTeam(t)
 		mustAddTeamMaintainer(t, team1, user1.GetLogin())
 
 		user2 := mustGetUser(t, testAccConf.testOrgUser2)
@@ -72,7 +72,7 @@ data "github_team_members" "test" {
 		skipUnlessHasOrgUser2(t)
 
 		user1 := mustGetUser(t, testAccConf.testOrgUser1)
-		team1 := mustCreateTestTeam(t, nil)
+		team1 := mustCreateTestTeam(t)
 		mustAddTeamMaintainer(t, team1, user1.GetLogin())
 
 		user2 := mustGetUser(t, testAccConf.testOrgUser2)

--- a/github/data_source_github_team_repositories_test.go
+++ b/github/data_source_github_team_repositories_test.go
@@ -20,7 +20,7 @@ func TestAccDataSourceGithubTeamRepositories(t *testing.T) {
 
 		team := mustCreateTestTeam(t, nil)
 		repo := mustCreateTestRepository(t)
-		mustAddRepositoryTeam(t, repo, team)
+		mustAddRepositoryToTeam(t, team, repo)
 
 		config := fmt.Sprintf(`
 data "github_team_repositories" "test" {
@@ -55,7 +55,7 @@ data "github_team_repositories" "test" {
 
 		team := mustCreateTestTeam(t, nil)
 		repo := mustCreateTestRepository(t)
-		mustAddRepositoryTeam(t, repo, team)
+		mustAddRepositoryToTeam(t, team, repo)
 
 		config := fmt.Sprintf(`
 data "github_team_repositories" "test" {

--- a/github/data_source_github_team_repositories_test.go
+++ b/github/data_source_github_team_repositories_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceGithubTeamRepositories(t *testing.T) {
 	t.Run("queries_all_repositories_by_slug", func(t *testing.T) {
 		t.Parallel()
 
-		team := mustCreateTestTeam(t, nil)
+		team := mustCreateTestTeam(t)
 		repo := mustCreateTestRepository(t)
 		mustAddRepositoryToTeam(t, team, repo)
 
@@ -53,7 +53,7 @@ data "github_team_repositories" "test" {
 	t.Run("queries_all_repositories_by_team_id", func(t *testing.T) {
 		t.Parallel()
 
-		team := mustCreateTestTeam(t, nil)
+		team := mustCreateTestTeam(t)
 		repo := mustCreateTestRepository(t)
 		mustAddRepositoryToTeam(t, team, repo)
 

--- a/github/data_source_github_team_test.go
+++ b/github/data_source_github_team_test.go
@@ -97,10 +97,10 @@ data "github_team" "test" {
 
 		team := mustCreateTestTeam(t, nil)
 		mustAddTeamMember(t, team, testAccConf.testOrgUser1)
-		childTeam := mustCreateTestTeam(t, new(team.GetID()))
+		childTeam := mustCreateTestTeam(t, withNewTeamParent(team.GetID()))
 		mustAddTeamMember(t, childTeam, testAccConf.testOrgUser2)
 		repo := mustCreateTestRepository(t)
-		mustAddRepositoryTeam(t, repo, team)
+		mustAddRepositoryToTeam(t, team, repo)
 
 		config := fmt.Sprintf(`
 data "github_team" "test" {
@@ -178,7 +178,7 @@ data "github_team" "test" {
 		t.Parallel()
 
 		parentTeam := mustCreateTestTeam(t, nil)
-		team := mustCreateTestTeam(t, new(parentTeam.GetID()))
+		team := mustCreateTestTeam(t, withNewTeamParent(parentTeam.GetID()))
 
 		config := fmt.Sprintf(`
 data "github_team" "test" {

--- a/github/data_source_github_team_test.go
+++ b/github/data_source_github_team_test.go
@@ -18,7 +18,7 @@ func TestAccGithubTeamDataSource(t *testing.T) {
 	t.Run("queries_root_team_by_slug_summary", func(t *testing.T) {
 		t.Parallel()
 
-		team := mustCreateTestTeam(t, nil)
+		team := mustCreateTestTeam(t)
 
 		config := fmt.Sprintf(`
 data "github_team" "test" {
@@ -55,7 +55,7 @@ data "github_team" "test" {
 	t.Run("queries_root_team_by_id_summary", func(t *testing.T) {
 		t.Parallel()
 
-		team := mustCreateTestTeam(t, nil)
+		team := mustCreateTestTeam(t)
 
 		config := fmt.Sprintf(`
 data "github_team" "test" {
@@ -95,7 +95,7 @@ data "github_team" "test" {
 		skipUnlessHasOrgUser1(t)
 		skipUnlessHasOrgUser2(t)
 
-		team := mustCreateTestTeam(t, nil)
+		team := mustCreateTestTeam(t)
 		mustAddTeamMember(t, team, testAccConf.testOrgUser1)
 		childTeam := mustCreateTestTeam(t, withNewTeamParent(team.GetID()))
 		mustAddTeamMember(t, childTeam, testAccConf.testOrgUser2)
@@ -177,7 +177,7 @@ data "github_team" "test" {
 	t.Run("queries_child_team", func(t *testing.T) {
 		t.Parallel()
 
-		parentTeam := mustCreateTestTeam(t, nil)
+		parentTeam := mustCreateTestTeam(t)
 		team := mustCreateTestTeam(t, withNewTeamParent(parentTeam.GetID()))
 
 		config := fmt.Sprintf(`

--- a/github/resource_github_repository_collaborator.go
+++ b/github/resource_github_repository_collaborator.go
@@ -108,16 +108,13 @@ func resourceGithubRepositoryCollaboratorRead(d *schema.ResourceData, m any) err
 	// First, check if the user has been invited but has not yet accepted
 	invitation, err := findRepoInvitation(meta, ctx, owner, repoNameWithoutOwner, username)
 	if err != nil {
-		var ghErr *github.ErrorResponse
-		if errors.As(err, &ghErr) {
-			if ghErr.Response.StatusCode == http.StatusNotFound {
-				// this short circuits the rest of the code because if the
-				// repo is 404, no reason to try to list existing collaborators
-				log.Printf("[INFO] Removing repository collaborator %s/%s %s from state because it no longer exists in GitHub",
-					owner, repoName, username)
-				d.SetId("")
-				return nil
-			}
+		if ghErr, ok := errors.AsType[*github.ErrorResponse](err); ok && ghErr.Response.StatusCode == http.StatusNotFound {
+			// this short circuits the rest of the code because if the
+			// repo is 404, no reason to try to list existing collaborators
+			log.Printf("[INFO] Removing repository collaborator %s/%s %s from state because it no longer exists in GitHub",
+				owner, repoName, username)
+			d.SetId("")
+			return nil
 		}
 		return err
 	}

--- a/github/resource_github_repository_collaborators.go
+++ b/github/resource_github_repository_collaborators.go
@@ -299,7 +299,7 @@ func resourceGithubRepositoryCollaboratorsDiff(ctx context.Context, d *schema.Re
 			}
 		}
 
-		if hasAddedUser {
+		if hasAddedUser || oldUsers.Len() > newUsers.Len() {
 			if err := d.SetNewComputed("invitation_ids"); err != nil {
 				return fmt.Errorf("error setting invitation_ids to computed: %w", err)
 			}

--- a/github/resource_github_repository_collaborators.go
+++ b/github/resource_github_repository_collaborators.go
@@ -62,10 +62,6 @@ func resourceGithubRepositoryCollaborators() *schema.Resource {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Users to grant access to the repository.",
-				Set: func(v any) int {
-					username, _ := v.(map[string]any)["username"].(string)
-					return schema.HashString(strings.ToLower(username))
-				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"username": {
@@ -87,10 +83,6 @@ func resourceGithubRepositoryCollaborators() *schema.Resource {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Teams to grant access to the repository.",
-				Set: func(v any) int {
-					teamIDStr, _ := v.(map[string]any)["team_id"].(string)
-					return schema.HashString(strings.ToLower(teamIDStr))
-				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"team_id": {
@@ -613,7 +605,12 @@ func resourceGithubRepositoryCollaboratorsImport(ctx context.Context, d *schema.
 		}
 	}
 
-	ghUsers, err := listUserCollaborators(ctx, meta, owner, repoName, nil)
+	inIgnoreUsers := make([]string, 0)
+	if !meta.IsOrganization {
+		inIgnoreUsers = append(inIgnoreUsers, strings.ToLower(owner))
+	}
+
+	ghUsers, err := listUserCollaborators(ctx, meta, owner, repoName, inIgnoreUsers)
 	if err != nil {
 		return nil, err
 	}

--- a/github/resource_github_repository_collaborators.go
+++ b/github/resource_github_repository_collaborators.go
@@ -45,7 +45,7 @@ func resourceGithubRepositoryCollaborators() *schema.Resource {
 			},
 		},
 
-		Description: "Manage the complete set of collaborators (users and teams) for a GitHub repository.",
+		Description: "Resource to manage the complete set of collaborators (users and teams) for a repository.",
 
 		Schema: map[string]*schema.Schema{
 			"repository": {
@@ -62,6 +62,10 @@ func resourceGithubRepositoryCollaborators() *schema.Resource {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Users to grant access to the repository.",
+				Set: func(v any) int {
+					username, _ := v.(map[string]any)["username"].(string)
+					return schema.HashString(strings.ToLower(username))
+				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"username": {
@@ -83,12 +87,17 @@ func resourceGithubRepositoryCollaborators() *schema.Resource {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Teams to grant access to the repository.",
+				Set: func(v any) int {
+					teamIDStr, _ := v.(map[string]any)["team_id"].(string)
+					return schema.HashString(strings.ToLower(teamIDStr))
+				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"team_id": {
-							Type:        schema.TypeString,
-							Description: "ID or slug of the team to add to the repository as a collaborator.",
-							Required:    true,
+							Type:             schema.TypeString,
+							Description:      "ID or slug of the team to add to the repository as a collaborator.",
+							Required:         true,
+							DiffSuppressFunc: caseInsensitive(),
 						},
 						"permission": {
 							Type:        schema.TypeString,
@@ -116,6 +125,7 @@ func resourceGithubRepositoryCollaborators() *schema.Resource {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Teams to ignore when managing repository collaborators.",
+				Deprecated:  "This argument is deprecated and will be removed in a future version as this resource now automatically excludes non-direct teams.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"team_id": {
@@ -131,38 +141,32 @@ func resourceGithubRepositoryCollaborators() *schema.Resource {
 }
 
 func resourceGithubRepositoryCollaboratorsDiff(ctx context.Context, d *schema.ResourceDiff, m any) error {
-	tflog.Debug(ctx, "Diffing collaborators")
+	tflog.Debug(ctx, "Diffing repository collaborators.")
 
 	meta, _ := m.(*Owner)
 
-	if d.HasChange("user") {
-		users, ok := d.Get("user").(*schema.Set)
-		if !ok {
-			return fmt.Errorf("error reading user config")
+	if d.HasChange("user") && d.NewValueKnown("user") {
+		v, diags := d.GetRawConfigAt(cty.GetAttrPath("user"))
+		if diags.HasError() {
+			return fmt.Errorf("error reading user config: %v", diags)
 		}
 
-		seen := make(map[string]any)
-		for _, u := range users.List() {
-			user, ok := u.(map[string]any)
-			if !ok {
-				return fmt.Errorf("error reading user config")
-			}
+		if !v.IsNull() && v.IsKnown() {
+			seen := make(map[string]struct{})
+			it := v.ElementIterator()
+			for it.Next() {
+				_, elem := it.Element()
+				val := elem.GetAttr("username")
+				if val.IsNull() || !val.IsKnown() {
+					continue
+				}
 
-			usernameVal, ok := user["username"]
-			if !ok {
-				return fmt.Errorf("error reading user config")
+				username := strings.ToLower(val.AsString())
+				if _, ok := seen[username]; ok {
+					return fmt.Errorf("duplicate user %s found in user collaborators", username)
+				}
+				seen[username] = struct{}{}
 			}
-
-			username, ok := usernameVal.(string)
-			if !ok {
-				return fmt.Errorf("error reading user config")
-			}
-
-			username = strings.ToLower(username)
-			if _, ok := seen[username]; ok {
-				return fmt.Errorf("duplicate username %s found in user collaborators", username)
-			}
-			seen[username] = nil
 		}
 	}
 
@@ -173,7 +177,7 @@ func resourceGithubRepositoryCollaboratorsDiff(ctx context.Context, d *schema.Re
 		}
 
 		if !v.IsNull() && v.IsKnown() {
-			seen := make(map[string]any)
+			seen := make(map[string]struct{})
 			it := v.ElementIterator()
 			for it.Next() {
 				_, elem := it.Element()
@@ -182,11 +186,11 @@ func resourceGithubRepositoryCollaboratorsDiff(ctx context.Context, d *schema.Re
 					continue
 				}
 
-				teamID := val.AsString()
+				teamID := strings.ToLower(val.AsString())
 				if _, ok := seen[teamID]; ok {
 					return fmt.Errorf("duplicate team %s found in team collaborators", teamID)
 				}
-				seen[teamID] = nil
+				seen[teamID] = struct{}{}
 			}
 		}
 	}
@@ -252,8 +256,61 @@ func resourceGithubRepositoryCollaboratorsDiff(ctx context.Context, d *schema.Re
 	}
 
 	if d.HasChange("user") {
-		if err := d.SetNewComputed("invitation_ids"); err != nil {
-			return fmt.Errorf("error setting invitation_ids to computed: %w", err)
+		var hasAddedUser bool
+		oldUsersRaw, newUsersRaw := d.GetChange("user")
+		oldUsers, ok := oldUsersRaw.(*schema.Set)
+		if !ok {
+			return fmt.Errorf("error reading old user config")
+		}
+
+		newUsers, ok := newUsersRaw.(*schema.Set)
+		if !ok {
+			return fmt.Errorf("error reading new user config")
+		}
+
+		oldUserLookup := make(map[string]struct{}, oldUsers.Len())
+		for _, u := range oldUsers.List() {
+			user, ok := u.(map[string]any)
+			if !ok {
+				return fmt.Errorf("error reading old user config")
+			}
+			usernameVal, ok := user["username"]
+			if !ok {
+				return fmt.Errorf("error reading old user config")
+			}
+			username, ok := usernameVal.(string)
+			if !ok {
+				return fmt.Errorf("error reading old user config")
+			}
+
+			oldUserLookup[strings.ToLower(username)] = struct{}{}
+		}
+
+		for _, u := range newUsers.List() {
+			user, ok := u.(map[string]any)
+			if !ok {
+				return fmt.Errorf("error reading new user config")
+			}
+			usernameVal, ok := user["username"]
+			if !ok {
+				return fmt.Errorf("error reading new user config")
+			}
+			username, ok := usernameVal.(string)
+			if !ok {
+				return fmt.Errorf("error reading new user config")
+			}
+			username = strings.ToLower(username)
+
+			if _, ok := oldUserLookup[username]; !ok {
+				hasAddedUser = true
+				break
+			}
+		}
+
+		if hasAddedUser {
+			if err := d.SetNewComputed("invitation_ids"); err != nil {
+				return fmt.Errorf("error setting invitation_ids to computed: %w", err)
+			}
 		}
 	}
 
@@ -261,17 +318,20 @@ func resourceGithubRepositoryCollaboratorsDiff(ctx context.Context, d *schema.Re
 }
 
 func resourceGithubRepositoryCollaboratorsCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	tflog.Debug(ctx, "Creating repository collaborators.")
+
 	meta, _ := m.(*Owner)
 	client := meta.v3client
 	owner := meta.name
 	isOrg := meta.IsOrganization
 
-	repoName := d.Get("repository").(string)
-	users := d.Get("user").(*schema.Set).List()
-	teams := d.Get("team").(*schema.Set).List()
-	ignoreTeams := d.Get("ignore_team").(*schema.Set).List()
-
-	tflog.Debug(ctx, "Creating repository collaborators", map[string]any{"users": users, "teams": teams, "ignoreTeams": ignoreTeams})
+	repoName, _ := d.Get("repository").(string)
+	usersVal, _ := d.Get("user").(*schema.Set)
+	users := usersVal.List()
+	teamsVal, _ := d.Get("team").(*schema.Set)
+	teams := teamsVal.List()
+	ignoreTeamsVal, _ := d.Get("ignore_team").(*schema.Set)
+	ignoreTeams := ignoreTeamsVal.List()
 
 	inUsers, err := getUserCollaborators(users)
 	if err != nil {
@@ -341,14 +401,17 @@ func resourceGithubRepositoryCollaboratorsCreate(ctx context.Context, d *schema.
 }
 
 func resourceGithubRepositoryCollaboratorsRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	tflog.Debug(ctx, "Reading repository collaborators")
+	tflog.Debug(ctx, "Reading repository collaborators.")
+
 	meta, _ := m.(*Owner)
 	owner := meta.name
 	isOrg := meta.IsOrganization
 
-	repoName := d.Get("repository").(string)
-	teams := d.Get("team").(*schema.Set).List()
-	ignoreTeams := d.Get("ignore_team").(*schema.Set).List()
+	repoName, _ := d.Get("repository").(string)
+	teamsVal, _ := d.Get("team").(*schema.Set)
+	teams := teamsVal.List()
+	ignoreTeamsVal, _ := d.Get("ignore_team").(*schema.Set)
+	ignoreTeams := ignoreTeamsVal.List()
 	ownerConfigured, _ := d.Get("owner_configured").(bool)
 
 	inIgnoreUsers := make([]string, 0)
@@ -356,27 +419,17 @@ func resourceGithubRepositoryCollaboratorsRead(ctx context.Context, d *schema.Re
 		inIgnoreUsers = append(inIgnoreUsers, strings.ToLower(owner))
 	}
 
-	inTeams, err := getTeamCollaborators(teams)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	inIgnoreTeams, err := getTeamIdentities(ignoreTeams)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	ghUsers, err := listUserCollaborators(ctx, meta, owner, repoName, inIgnoreUsers)
-	if err != nil {
-		if err, ok := errors.AsType[*github.ErrorResponse](err); ok && err.Response.StatusCode == 404 {
-			tflog.Debug(ctx, fmt.Sprintf("Repository %s not found when listing users, removing from state.", repoName))
-			d.SetId("")
-			return nil
-		}
-		return diag.FromErr(err)
-	}
-
 	if isOrg {
+		inTeams, err := getTeamCollaborators(teams)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		inIgnoreTeams, err := getTeamIdentities(ignoreTeams)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
 		ghTeams, err := listTeamCollaborators(ctx, meta, owner, repoName, inTeams, inIgnoreTeams)
 		if err != nil {
 			if err, ok := errors.AsType[*github.ErrorResponse](err); ok && err.Response.StatusCode == 404 {
@@ -390,6 +443,16 @@ func resourceGithubRepositoryCollaboratorsRead(ctx context.Context, d *schema.Re
 		if err := d.Set("team", ghTeams.flatten()); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	ghUsers, err := listUserCollaborators(ctx, meta, owner, repoName, inIgnoreUsers)
+	if err != nil {
+		if err, ok := errors.AsType[*github.ErrorResponse](err); ok && err.Response.StatusCode == 404 {
+			tflog.Debug(ctx, fmt.Sprintf("Repository %s not found when listing users, removing from state.", repoName))
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(err)
 	}
 
 	ghInvitations, err := listInvitations(ctx, meta, owner, repoName)
@@ -410,15 +473,19 @@ func resourceGithubRepositoryCollaboratorsRead(ctx context.Context, d *schema.Re
 }
 
 func resourceGithubRepositoryCollaboratorsUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	tflog.Debug(ctx, "Updating repository collaborators")
+	tflog.Debug(ctx, "Updating repository collaborators.")
+
 	meta, _ := m.(*Owner)
 	owner := meta.name
 	isOrg := meta.IsOrganization
 
-	repoName := d.Get("repository").(string)
-	users := d.Get("user").(*schema.Set).List()
-	teams := d.Get("team").(*schema.Set).List()
-	ignoreTeams := d.Get("ignore_team").(*schema.Set).List()
+	repoName, _ := d.Get("repository").(string)
+	usersVal, _ := d.Get("user").(*schema.Set)
+	users := usersVal.List()
+	teamsVal, _ := d.Get("team").(*schema.Set)
+	teams := teamsVal.List()
+	ignoreTeamsVal, _ := d.Get("ignore_team").(*schema.Set)
+	ignoreTeams := ignoreTeamsVal.List()
 
 	inUsers, err := getUserCollaborators(users)
 	if err != nil {
@@ -478,13 +545,15 @@ func resourceGithubRepositoryCollaboratorsUpdate(ctx context.Context, d *schema.
 }
 
 func resourceGithubRepositoryCollaboratorsDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	tflog.Debug(ctx, "Deleting repository collaborators")
+	tflog.Debug(ctx, "Deleting repository collaborators.")
+
 	meta, _ := m.(*Owner)
 	owner := meta.name
 	isOrg := meta.IsOrganization
 
-	repoName := d.Get("repository").(string)
-	ignoreTeams := d.Get("ignore_team").(*schema.Set).List()
+	repoName, _ := d.Get("repository").(string)
+	ignoreTeamsVal, _ := d.Get("ignore_team").(*schema.Set)
+	ignoreTeams := ignoreTeamsVal.List()
 
 	inIgnoreTeams, err := getTeamIdentities(ignoreTeams)
 	if err != nil {
@@ -507,7 +576,8 @@ func resourceGithubRepositoryCollaboratorsDelete(ctx context.Context, d *schema.
 }
 
 func resourceGithubRepositoryCollaboratorsImport(ctx context.Context, d *schema.ResourceData, m any) ([]*schema.ResourceData, error) {
-	tflog.Debug(ctx, "Importing repository collaborators")
+	tflog.Debug(ctx, "Importing repository collaborators.")
+
 	meta, _ := m.(*Owner)
 	client := meta.v3client
 	owner := meta.name
@@ -525,6 +595,40 @@ func resourceGithubRepositoryCollaboratorsImport(ctx context.Context, d *schema.
 		return nil, err
 	}
 	if err := d.Set("repository_id", repoID); err != nil {
+		return nil, err
+	}
+
+	if err := d.Set("owner_configured", false); err != nil {
+		return nil, err
+	}
+
+	if meta.IsOrganization {
+		ghTeams, err := listTeamCollaborators(ctx, meta, owner, repoName, nil, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := d.Set("team", ghTeams.flatten()); err != nil {
+			return nil, err
+		}
+	}
+
+	ghUsers, err := listUserCollaborators(ctx, meta, owner, repoName, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ghInvitations, err := listInvitations(ctx, meta, owner, repoName)
+	if err != nil {
+		return nil, err
+	}
+
+	combinedUsersAndInvitations := slices.Concat(ghUsers, ghInvitations)
+	if err := d.Set("user", combinedUsersAndInvitations.flatten()); err != nil {
+		return nil, err
+	}
+
+	if err = d.Set("invitation_ids", ghInvitations.flattenInvitations()); err != nil {
 		return nil, err
 	}
 
@@ -639,143 +743,112 @@ func getTeamIdentity(d any) (teamIdentity, error) {
 }
 
 func listUserCollaborators(ctx context.Context, meta *Owner, owner, repoName string, ignoreUsers []string) (userCollaborators, error) {
-	col := make([]userCollaborator, 0)
-	tflog.Debug(ctx, "Listing user collaborators", map[string]any{
-		"owner":    owner,
-		"repoName": repoName,
-	})
-	affiliations := []string{"direct", "outside"}
-	for _, affiliation := range affiliations {
-		opt := &github.ListCollaboratorsOptions{
-			ListOptions: github.ListOptions{
-				PerPage: meta.maxPerPage,
-			},
-			Affiliation: affiliation,
-		}
+	tflog.Debug(ctx, "Listing user collaborators.", map[string]any{"owner": owner, "repoName": repoName})
 
-		for {
-			collaborators, resp, err := meta.v3client.Repositories.ListCollaborators(ctx, owner, repoName, opt)
+	collaborators := make([]userCollaborator, 0)
+	for _, affiliation := range []string{"direct", "outside"} {
+		for user, err := range meta.v3client.Repositories.ListCollaboratorsIter(ctx, owner, repoName, &github.ListCollaboratorsOptions{Affiliation: affiliation, ListOptions: github.ListOptions{PerPage: meta.maxPerPage}}) {
 			if err != nil {
 				return nil, err
 			}
 
-			for _, c := range collaborators {
-				if slices.Contains(ignoreUsers, strings.ToLower(c.GetLogin())) {
-					continue
-				}
-
-				col = append(col, userCollaborator{
-					userIdentity: userIdentity{
-						login: c.GetLogin(),
-					},
-					permission: getPermission(c.GetRoleName()),
-				})
+			if slices.Contains(ignoreUsers, strings.ToLower(user.GetLogin())) {
+				continue
 			}
 
-			if resp.NextPage == 0 {
-				break
-			}
-			opt.Page = resp.NextPage
+			collaborators = append(collaborators, userCollaborator{
+				userIdentity: userIdentity{
+					login: user.GetLogin(),
+				},
+				permission: getPermission(user.GetRoleName()),
+			})
 		}
 	}
-	return col, nil
+
+	return collaborators, nil
 }
 
 func listInvitations(ctx context.Context, meta *Owner, owner, repoName string) (userCollaborators, error) {
-	col := make([]userCollaborator, 0)
+	tflog.Debug(ctx, "Listing user invitations.", map[string]any{"owner": owner, "repoName": repoName})
 
-	opt := &github.ListOptions{PerPage: meta.maxPerPage}
-	for {
-		invitations, resp, err := meta.v3client.Repositories.ListInvitations(ctx, owner, repoName, opt)
+	collaborators := make([]userCollaborator, 0)
+	for user, err := range meta.v3client.Repositories.ListInvitationsIter(ctx, owner, repoName, &github.ListOptions{PerPage: meta.maxPerPage}) {
 		if err != nil {
 			return nil, err
 		}
 
-		for _, i := range invitations {
-			id := i.GetID()
-
-			col = append(col, userCollaborator{
-				userIdentity: userIdentity{
-					login: i.GetInvitee().GetLogin(),
-				},
-				permission:   getPermission(i.GetPermissions()),
-				invitationID: &id,
-			})
-		}
-
-		if resp.NextPage == 0 {
-			break
-		}
-		opt.Page = resp.NextPage
+		collaborators = append(collaborators, userCollaborator{
+			userIdentity: userIdentity{
+				login: user.GetInvitee().GetLogin(),
+			},
+			permission:   getPermission(user.GetPermissions()),
+			invitationID: new(user.GetID()),
+		})
 	}
 
-	return col, nil
+	return collaborators, nil
 }
 
 func listTeamCollaborators(ctx context.Context, meta *Owner, orgName, repoName string, inTeams teamCollaborators, ignoreTeams []teamIdentity) (teamCollaborators, error) {
+	tflog.Debug(ctx, "Listing team collaborators.", map[string]any{"owner": orgName, "repoName": repoName})
+
 	lookup := make(map[string]teamCollaborator)
 	ignore := len(ignoreTeams) > 0
-	col := make([]teamCollaborator, 0)
 
 	for _, inTeam := range inTeams {
 		lookup[inTeam.getTeamID()] = inTeam
 	}
 
-	opt := &github.ListOptions{
-		PerPage: meta.maxPerPage,
-	}
-
-	for {
-		repoTeams, resp, err := meta.v3client.Repositories.ListTeams(ctx, orgName, repoName, opt)
+	collaborators := make([]teamCollaborator, 0)
+	for team, err := range meta.v3client.Repositories.ListTeamsIter(ctx, orgName, repoName, &github.ListOptions{PerPage: meta.maxPerPage}) {
 		if err != nil {
 			return nil, err
 		}
 
-		for _, t := range repoTeams {
-			slug := t.GetSlug()
-			id := t.GetID()
-			if ignore && slices.ContainsFunc(ignoreTeams, func(ignore teamIdentity) bool {
-				if s, ok := ignore.getSlugOK(); ok {
-					return slug == s
-				} else {
-					return id == ignore.getID()
-				}
-			}) {
-				continue
-			}
-
-			var teamID *string
-			if _, ok := lookup[slug]; ok {
-				teamID = &slug
-			}
-
-			if teamID == nil {
-				idStr := strconv.FormatInt(id, 10)
-				if _, ok := lookup[idStr]; ok {
-					teamID = &idStr
-				}
-			}
-
-			col = append(col, teamCollaborator{
-				teamIdentity: teamIdentity{
-					id:     &id,
-					slug:   &slug,
-					teamID: teamID,
-				},
-				permission: getPermission(t.GetPermission()),
-			})
+		if team.GetAccessSource() != "direct" {
+			continue
 		}
 
-		if resp.NextPage == 0 {
-			break
+		slug := team.GetSlug()
+		id := team.GetID()
+		if ignore && slices.ContainsFunc(ignoreTeams, func(ignore teamIdentity) bool {
+			if s, ok := ignore.getSlugOK(); ok {
+				return slug == s
+			} else {
+				return id == ignore.getID()
+			}
+		}) {
+			continue
 		}
-		opt.Page = resp.NextPage
+
+		var teamID *string
+		if _, ok := lookup[slug]; ok {
+			teamID = &slug
+		}
+
+		if teamID == nil {
+			idStr := strconv.FormatInt(id, 10)
+			if _, ok := lookup[idStr]; ok {
+				teamID = &idStr
+			}
+		}
+
+		collaborators = append(collaborators, teamCollaborator{
+			teamIdentity: teamIdentity{
+				id:     &id,
+				slug:   &slug,
+				teamID: teamID,
+			},
+			permission: getPermission(team.GetPermission()),
+		})
 	}
 
-	return col, nil
+	return collaborators, nil
 }
 
 func updateUserCollaboratorsAndInvites(ctx context.Context, meta *Owner, owner, repoName string, inUsers userCollaborators, ignoreUsers []string) (userCollaborators, error) {
+	tflog.Debug(ctx, "Updating user collaborators and invitations.", map[string]any{"owner": owner, "repoName": repoName, "inUsers": inUsers, "ignoreUsers": ignoreUsers})
+
 	lookup := make(map[string]userCollaborator)
 	seen := make(map[string]any)
 	remove := make([]string, 0)
@@ -783,14 +856,6 @@ func updateUserCollaboratorsAndInvites(ctx context.Context, meta *Owner, owner, 
 	for _, inUser := range inUsers {
 		lookup[inUser.login] = inUser
 	}
-
-	tflog.Debug(ctx, "Updating user collaborators and invitations", map[string]any{
-		"repoName": repoName,
-		"inUsers":  inUsers,
-		"lookup":   lookup,
-		"seen":     seen,
-		"remove":   remove,
-	})
 
 	ghUsers, err := listUserCollaborators(ctx, meta, owner, repoName, ignoreUsers)
 	if err != nil {

--- a/github/resource_github_repository_collaborators_test.go
+++ b/github/resource_github_repository_collaborators_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
@@ -119,6 +120,11 @@ resource "github_repository_collaborators" "test" {
 				},
 				{
 					Config: fmt.Sprintf(config, team1.GetSlug(), "pull", team2.GetSlug()),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("github_repository_collaborators.test", plancheck.ResourceActionUpdate),
+						},
+					},
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("repository_id"), knownvalue.Int32Exact(int32(repo.GetID()))),
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("owner_configured"), knownvalue.Bool(false)),
@@ -127,6 +133,11 @@ resource "github_repository_collaborators" "test" {
 				},
 				{
 					Config: fmt.Sprintf(config, team1.GetSlug(), "push", team2.GetSlug()),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("github_repository_collaborators.test", plancheck.ResourceActionUpdate),
+						},
+					},
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("repository_id"), knownvalue.Int32Exact(int32(repo.GetID()))),
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("owner_configured"), knownvalue.Bool(false)),
@@ -141,6 +152,11 @@ resource "github_repository_collaborators" "test" {
 				},
 				{
 					Config: fmt.Sprintf(configRemoveTeam, team1.GetSlug(), "push"),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("github_repository_collaborators.test", plancheck.ResourceActionUpdate),
+						},
+					},
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("repository_id"), knownvalue.Int32Exact(int32(repo.GetID()))),
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("owner_configured"), knownvalue.Bool(false)),
@@ -202,6 +218,11 @@ resource "github_repository_collaborators" "test" {
 				},
 				{
 					Config: fmt.Sprintf(config, testAccConf.testOrgUser1, "push", testAccConf.testOrgUser2),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("github_repository_collaborators.test", plancheck.ResourceActionUpdate),
+						},
+					},
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("repository_id"), knownvalue.Int32Exact(int32(repo.GetID()))),
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("owner_configured"), knownvalue.Bool(false)),
@@ -216,6 +237,11 @@ resource "github_repository_collaborators" "test" {
 				},
 				{
 					Config: fmt.Sprintf(configRemoveUser, testAccConf.testOrgUser1, "push"),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("github_repository_collaborators.test", plancheck.ResourceActionUpdate),
+						},
+					},
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("repository_id"), knownvalue.Int32Exact(int32(repo.GetID()))),
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("owner_configured"), knownvalue.Bool(false)),
@@ -230,6 +256,11 @@ resource "github_repository_collaborators" "test" {
 						return false, nil
 					},
 					Config: fmt.Sprintf(config, testAccConf.testOrgUser1, "push", testAccConf.testExternalUser1),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("github_repository_collaborators.test", plancheck.ResourceActionUpdate),
+						},
+					},
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("repository_id"), knownvalue.Int32Exact(int32(repo.GetID()))),
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("owner_configured"), knownvalue.Bool(false)),

--- a/github/resource_github_repository_collaborators_test.go
+++ b/github/resource_github_repository_collaborators_test.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -13,123 +12,227 @@ import (
 )
 
 func TestAccGithubRepositoryCollaborators(t *testing.T) {
-	// TODO: Make this test parallel once we can ignore non-direct teams.
-	// t.Parallel()
+	t.Parallel()
 
-	t.Run("create", func(t *testing.T) {
-		if len(testAccConf.testOrgUser1) == 0 {
-			t.Skip("No organization user provided")
-		}
+	t.Run("with_teams_and_users", func(t *testing.T) {
+		t.Parallel()
 
-		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
-		teamName0 := fmt.Sprintf("%s%s-0", testResourcePrefix, randomID)
-		teamName1 := fmt.Sprintf("%s%s-1", testResourcePrefix, randomID)
-		collaboratorUser := testAccConf.testOrgUser1
+		skipUnlessHasOrgs(t)
+		skipUnlessHasOrgUser1(t)
+
+		team0 := mustCreateTestTeam(t)
+		mustAssignOrganizationRoleToTeam(t, team0, 138)
+
+		repo := mustCreateTestRepository(t)
+		team1 := mustCreateTestTeam(t)
+		mustAddRepositoryToTeam(t, team1, repo)
+		_ = mustCreateTestTeam(t, withNewTeamParent(team1.GetID()))
 
 		config := fmt.Sprintf(`
-resource "github_repository" "test" {
-	name       = "%s"
-	visibility = "private"
-}
-
-resource "github_team" "test_0" {
-	name = "%s"
-}
-
-resource "github_team" "test_1" {
-	name = "%s"
-}
-
 resource "github_repository_collaborators" "test" {
-	repository = github_repository.test.name
+  repository = "%v"
 
-	user {
-		username   = "%s"
-		permission = "admin"
-	}
+  team {
+    team_id    = "%v"
+    permission = "push"
+  }
 
-	team {
-		team_id    = github_team.test_0.id
-		permission = "pull"
-	}
-
-	team {
-		team_id = github_team.test_1.slug
-	}
+  user {
+    username = "%v"
+    permission = "pull"
+  }
 }
-`, repoName, teamName0, teamName1, collaboratorUser)
+`, repo.GetName(), team1.GetSlug(), testAccConf.testOrgUser1)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
 					Config: config,
 					ConfigStateChecks: []statecheck.StateCheck{
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("user"), knownvalue.SetExact([]knownvalue.Check{
-							knownvalue.MapExact(map[string]knownvalue.Check{
-								"username":   knownvalue.StringExact(collaboratorUser),
-								"permission": knownvalue.StringExact("admin"),
-							}),
-						})),
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("team"), knownvalue.SetExact([]knownvalue.Check{
-							knownvalue.MapExact(map[string]knownvalue.Check{
-								"team_id":    knownvalue.StringRegexp(regexp.MustCompile(`^\d+$`)),
-								"permission": knownvalue.StringExact("pull"),
-							}),
-							knownvalue.MapExact(map[string]knownvalue.Check{
-								"team_id":    knownvalue.StringExact(teamName1),
-								"permission": knownvalue.StringExact("push"),
-							}),
-						})),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("repository_id"), knownvalue.Int32Exact(int32(repo.GetID()))),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("owner_configured"), knownvalue.Bool(false)),
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(0)),
 					},
 				},
 				{
-					ResourceName:            "github_repository_collaborators.test",
-					ImportState:             true,
-					ImportStateId:           repoName,
-					ImportStateVerify:       true,
-					ImportStateVerifyIgnore: []string{"user", "team", "invitation_ids", "owner_configured"},
+					ResourceName:      "github_repository_collaborators.test",
+					ImportState:       true,
+					ImportStateId:     repo.GetName(),
+					ImportStateVerify: true,
 				},
 			},
 		})
 	})
 
-	t.Run("add_external_user", func(t *testing.T) {
-		if len(testAccConf.testExternalUser1) == 0 {
-			t.Skip("No external user provided")
-		}
+	t.Run("with_only_teams", func(t *testing.T) {
+		t.Parallel()
 
-		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+		skipUnlessHasOrgs(t)
+
+		team0 := mustCreateTestTeam(t)
+		mustAssignOrganizationRoleToTeam(t, team0, 138)
+
+		repo := mustCreateTestRepository(t)
+		team1 := mustCreateTestTeam(t)
+		mustAddRepositoryToTeam(t, team1, repo)
+		team2 := mustCreateTestTeam(t)
+		mustAddRepositoryToTeam(t, team2, repo)
+		_ = mustCreateTestTeam(t, withNewTeamParent(team1.GetID()))
 
 		config := fmt.Sprintf(`
-resource "github_repository" "test" {
-	name       = "%s"
-	visibility = "private"
-}
-
 resource "github_repository_collaborators" "test" {
-	repository = github_repository.test.name
+  repository = "%v"
 
-	user {
-		username   = "%s"
-		permission = "push"
-	}
+  team {
+    team_id    = "%%v"
+    permission = "%%v"
+  }
+
+  team {
+    team_id = "%%v"
+  }
 }
-`, repoName, testAccConf.testExternalUser1)
+`, repo.GetName())
+
+		configRemoveTeam := fmt.Sprintf(`
+resource "github_repository_collaborators" "test" {
+  repository = "%v"
+
+  team {
+    team_id    = "%%v"
+    permission = "%%v"
+  }
+}
+`, repo.GetName())
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnauthenticated(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
-					Config: config,
+					Config: fmt.Sprintf(config, team1.GetID(), "pull", team2.GetID()),
 					ConfigStateChecks: []statecheck.StateCheck{
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("user"), knownvalue.SetSizeExact(1)),
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("team"), knownvalue.SetSizeExact(0)),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("repository_id"), knownvalue.Int32Exact(int32(repo.GetID()))),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("owner_configured"), knownvalue.Bool(false)),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(0)),
+					},
+				},
+				{
+					Config: fmt.Sprintf(config, team1.GetSlug(), "pull", team2.GetSlug()),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("repository_id"), knownvalue.Int32Exact(int32(repo.GetID()))),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("owner_configured"), knownvalue.Bool(false)),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(0)),
+					},
+				},
+				{
+					Config: fmt.Sprintf(config, team1.GetSlug(), "push", team2.GetSlug()),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("repository_id"), knownvalue.Int32Exact(int32(repo.GetID()))),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("owner_configured"), knownvalue.Bool(false)),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(0)),
+					},
+				},
+				{
+					ResourceName:      "github_repository_collaborators.test",
+					ImportState:       true,
+					ImportStateId:     repo.GetName(),
+					ImportStateVerify: true,
+				},
+				{
+					Config: fmt.Sprintf(configRemoveTeam, team1.GetSlug(), "push"),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("repository_id"), knownvalue.Int32Exact(int32(repo.GetID()))),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("owner_configured"), knownvalue.Bool(false)),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(0)),
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("with_only_users", func(t *testing.T) {
+		t.Parallel()
+
+		skipUnlessHasOrgs(t)
+		skipUnlessHasOrgUser1(t)
+		skipUnlessHasOrgUser2(t)
+
+		team0 := mustCreateTestTeam(t)
+		mustAssignOrganizationRoleToTeam(t, team0, 138)
+
+		repo := mustCreateTestRepository(t)
+
+		config := fmt.Sprintf(`
+resource "github_repository_collaborators" "test" {
+  repository = "%v"
+
+  user {
+    username   = "%%v"
+    permission = "%%v"
+  }
+
+  user {
+    username = "%%v"
+  }
+}
+`, repo.GetName())
+
+		configRemoveUser := fmt.Sprintf(`
+resource "github_repository_collaborators" "test" {
+  repository = "%v"
+
+  user {
+    username   = "%%v"
+    permission = "%%v"
+  }
+}
+`, repo.GetName())
+
+		resource.Test(t, resource.TestCase{
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(config, testAccConf.testOrgUser1, "pull", testAccConf.testOrgUser2),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("repository_id"), knownvalue.Int32Exact(int32(repo.GetID()))),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("owner_configured"), knownvalue.Bool(false)),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(0)),
+					},
+				},
+				{
+					Config: fmt.Sprintf(config, testAccConf.testOrgUser1, "push", testAccConf.testOrgUser2),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("repository_id"), knownvalue.Int32Exact(int32(repo.GetID()))),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("owner_configured"), knownvalue.Bool(false)),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(0)),
+					},
+				},
+				{
+					ResourceName:      "github_repository_collaborators.test",
+					ImportState:       true,
+					ImportStateId:     repo.GetName(),
+					ImportStateVerify: true,
+				},
+				{
+					Config: fmt.Sprintf(configRemoveUser, testAccConf.testOrgUser1, "push"),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("repository_id"), knownvalue.Int32Exact(int32(repo.GetID()))),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("owner_configured"), knownvalue.Bool(false)),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(0)),
+					},
+				},
+				{
+					SkipFunc: func() (bool, error) {
+						if len(testAccConf.testExternalUser1) == 0 {
+							return true, nil
+						}
+						return false, nil
+					},
+					Config: fmt.Sprintf(config, testAccConf.testOrgUser1, "push", testAccConf.testExternalUser1),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("repository_id"), knownvalue.Int32Exact(int32(repo.GetID()))),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("owner_configured"), knownvalue.Bool(false)),
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(1)),
 					},
 				},
@@ -137,241 +240,52 @@ resource "github_repository_collaborators" "test" {
 		})
 	})
 
-	t.Run("personal_repo_ignores_owner_when_not_configured", func(t *testing.T) {
-		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+	t.Run("with_user_repo", func(t *testing.T) {
+		t.Parallel()
 
-		config := fmt.Sprintf(`
-resource "github_repository" "test" {
-	name = "%s"
-}
+		skipUnlessMode(t, individual)
 
+		repo := mustCreateTestRepository(t)
+
+		configNoUser := fmt.Sprintf(`
 resource "github_repository_collaborators" "test" {
-	repository = github_repository.test.name
+  repository = "%v"
 }
-`, repoName)
+`, repo.GetName())
+
+		configWithUser := fmt.Sprintf(`
+resource "github_repository_collaborators" "test" {
+  repository = "%v"
+
+  user {
+    username   = "%v"
+    permission = "admin"
+  }
+}
+`, repo.GetName(), testAccConf.owner)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, individual) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
-					Config: config,
+					Config: configNoUser,
 					ConfigStateChecks: []statecheck.StateCheck{
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("user"), knownvalue.SetSizeExact(0)),
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("team"), knownvalue.SetSizeExact(0)),
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(0)),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("repository_id"), knownvalue.Int32Exact(int32(repo.GetID()))),
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("owner_configured"), knownvalue.Bool(false)),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(0)),
 					},
 				},
 				{
-					Config:             config,
-					PlanOnly:           true,
-					ExpectNonEmptyPlan: false,
+					ResourceName:      "github_repository_collaborators.test",
+					ImportState:       true,
+					ImportStateId:     repo.GetName(),
+					ImportStateVerify: true,
 				},
-			},
-		})
-	})
-
-	t.Run("personal_repo_keeps_owner_when_configured", func(t *testing.T) {
-		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
-
-		config := fmt.Sprintf(`
-resource "github_repository" "test" {
-	name = "%s"
-}
-
-resource "github_repository_collaborators" "test" {
-	repository = github_repository.test.name
-
-	user {
-		username   = "%s"
-		permission = "admin"
-	}
-}
-`, repoName, testAccConf.owner)
-
-		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessMode(t, individual) },
-			ProviderFactories: providerFactories,
-			Steps: []resource.TestStep{
 				{
-					Config: config,
+					Config: configWithUser,
 					ConfigStateChecks: []statecheck.StateCheck{
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("user"), knownvalue.SetExact([]knownvalue.Check{
-							knownvalue.MapExact(map[string]knownvalue.Check{
-								"username":   knownvalue.StringExact(testAccConf.owner),
-								"permission": knownvalue.StringExact("admin"),
-							}),
-						})),
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("team"), knownvalue.SetSizeExact(0)),
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(0)),
+						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("repository_id"), knownvalue.Int32Exact(int32(repo.GetID()))),
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("owner_configured"), knownvalue.Bool(true)),
-					},
-				},
-				{
-					Config:             config,
-					PlanOnly:           true,
-					ExpectNonEmptyPlan: false,
-				},
-			},
-		})
-	})
-
-	t.Run("update_teams", func(t *testing.T) {
-		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
-		teamName0 := fmt.Sprintf("%s%s-0", testResourcePrefix, randomID)
-		teamName1 := fmt.Sprintf("%s%s-1", testResourcePrefix, randomID)
-		teamName2 := fmt.Sprintf("%s%s-2", testResourcePrefix, randomID)
-
-		configPre := fmt.Sprintf(`
-resource "github_repository" "test" {
-	name       = "%s"
-	visibility = "private"
-}
-
-resource "github_team" "test_0" {
-	name = "%s"
-}
-
-resource "github_team" "test_1" {
-	name = "%s"
-}
-
-resource "github_team" "test_2" {
-	name = "%s"
-}
-`, repoName, teamName0, teamName1, teamName2)
-
-		config0 := fmt.Sprintf(`
-%s
-
-resource "github_repository_collaborators" "test" {
-	repository = github_repository.test.name
-
-	team {
-		team_id   = github_team.test_0.slug
-		permission = "pull"
-	}
-
-	team {
-		team_id   = github_team.test_1.slug
-		permission = "pull"
-	}
-}
-`, configPre)
-
-		config1 := fmt.Sprintf(`
-%s
-
-resource "github_repository_collaborators" "test" {
-	repository = github_repository.test.name
-
-	team {
-		team_id   = github_team.test_1.slug
-		permission = "push"
-	}
-
-	team {
-		team_id   = github_team.test_2.slug
-		permission = "push"
-	}
-}
-`, configPre)
-
-		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessHasOrgs(t) },
-			ProviderFactories: providerFactories,
-			Steps: []resource.TestStep{
-				{
-					Config: config0,
-					ConfigStateChecks: []statecheck.StateCheck{
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("team"), knownvalue.SetExact([]knownvalue.Check{
-							knownvalue.MapExact(map[string]knownvalue.Check{
-								"team_id":    knownvalue.StringExact(teamName0),
-								"permission": knownvalue.StringExact("pull"),
-							}),
-							knownvalue.MapExact(map[string]knownvalue.Check{
-								"team_id":    knownvalue.StringExact(teamName1),
-								"permission": knownvalue.StringExact("pull"),
-							}),
-						})),
-					},
-				},
-				{
-					Config: config1,
-					ConfigStateChecks: []statecheck.StateCheck{
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("team"), knownvalue.SetExact([]knownvalue.Check{
-							knownvalue.MapExact(map[string]knownvalue.Check{
-								"team_id":    knownvalue.StringExact(teamName1),
-								"permission": knownvalue.StringExact("push"),
-							}),
-							knownvalue.MapExact(map[string]knownvalue.Check{
-								"team_id":    knownvalue.StringExact(teamName2),
-								"permission": knownvalue.StringExact("push"),
-							}),
-						})),
-					},
-				},
-			},
-		})
-	})
-
-	t.Run("remove_user", func(t *testing.T) {
-		if len(testAccConf.testOrgUser1) == 0 {
-			t.Skip("No organization user provided")
-		}
-
-		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
-
-		configPre := fmt.Sprintf(`
-resource "github_repository" "test" {
-	name       = "%s"
-	visibility = "private"
-}
-`, repoName)
-
-		config0 := fmt.Sprintf(`
-%s
-
-resource "github_repository_collaborators" "test" {
-	repository = github_repository.test.name
-
-	user {
-		username   = "%s"
-		permission = "admin"
-	}
-}
-`, configPre, testAccConf.testOrgUser1)
-
-		config1 := fmt.Sprintf(`
-%s
-
-resource "github_repository_collaborators" "test" {
-	repository = github_repository.test.name
-}
-`, configPre)
-
-		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessHasOrgs(t) },
-			ProviderFactories: providerFactories,
-			Steps: []resource.TestStep{
-				{
-					Config: config0,
-					ConfigStateChecks: []statecheck.StateCheck{
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("user"), knownvalue.SetSizeExact(1)),
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("team"), knownvalue.SetSizeExact(0)),
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(0)),
-					},
-				},
-				{
-					Config: config1,
-					ConfigStateChecks: []statecheck.StateCheck{
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("user"), knownvalue.SetSizeExact(0)),
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("team"), knownvalue.SetSizeExact(0)),
 						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(0)),
 					},
 				},
@@ -379,170 +293,71 @@ resource "github_repository_collaborators" "test" {
 		})
 	})
 
-	t.Run("change_team_reference", func(t *testing.T) {
-		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
-		teamName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+	t.Run("errors_with_duplicate_teams", func(t *testing.T) {
+		t.Parallel()
 
-		configPre := fmt.Sprintf(`
-resource "github_repository" "test" {
-	name       = "%s"
-	visibility = "private"
-}
+		skipUnlessHasOrgs(t)
 
-resource "github_team" "test" {
-	name = "%s"
-}
-`, repoName, teamName)
-
-		config0 := fmt.Sprintf(`
-%s
-
-resource "github_repository_collaborators" "test" {
-	repository = github_repository.test.name
-
-	team {
-		team_id    = github_team.test.id
-		permission = "pull"
-	}
-}
-`, configPre)
-
-		config1 := fmt.Sprintf(`
-%s
-
-resource "github_repository_collaborators" "test" {
-	repository = github_repository.test.name
-
-	team {
-		team_id    = github_team.test.slug
-		permission = "pull"
-	}
-}
-`, configPre)
-
-		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessHasOrgs(t) },
-			ProviderFactories: providerFactories,
-			Steps: []resource.TestStep{
-				{
-					Config: config0,
-					ConfigStateChecks: []statecheck.StateCheck{
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("user"), knownvalue.SetSizeExact(0)),
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("team"), knownvalue.SetSizeExact(1)),
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(0)),
-					},
-				},
-				{
-					Config: config1,
-					ConfigStateChecks: []statecheck.StateCheck{
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("user"), knownvalue.SetSizeExact(0)),
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("team"), knownvalue.SetSizeExact(1)),
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(0)),
-					},
-				},
-			},
-		})
-	})
-
-	t.Run("remove_team", func(t *testing.T) {
-		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
-		teamName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
-
-		configPre := fmt.Sprintf(`
-resource "github_repository" "test" {
-	name       = "%s"
-	visibility = "private"
-}
-
-resource "github_team" "test" {
-	name = "%s"
-}
-`, repoName, teamName)
-
-		config0 := fmt.Sprintf(`
-%s
-
-resource "github_repository_collaborators" "test" {
-	repository = github_repository.test.name
-
-	team {
-		team_id    = github_team.test.slug
-		permission = "pull"
-	}
-}
-`, configPre)
-
-		config1 := fmt.Sprintf(`
-%s
-
-resource "github_repository_collaborators" "test" {
-	repository = github_repository.test.name
-}
-`, configPre)
-
-		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessHasOrgs(t) },
-			ProviderFactories: providerFactories,
-			Steps: []resource.TestStep{
-				{
-					Config: config0,
-					ConfigStateChecks: []statecheck.StateCheck{
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("user"), knownvalue.SetSizeExact(0)),
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("team"), knownvalue.SetSizeExact(1)),
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(0)),
-					},
-				},
-				{
-					Config: config1,
-					ConfigStateChecks: []statecheck.StateCheck{
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("user"), knownvalue.SetSizeExact(0)),
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("team"), knownvalue.SetSizeExact(0)),
-						statecheck.ExpectKnownValue("github_repository_collaborators.test", tfjsonpath.New("invitation_ids"), knownvalue.MapSizeExact(0)),
-					},
-				},
-			},
-		})
-	})
-
-	t.Run("duplicate_teams_error", func(t *testing.T) {
-		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
-		teamName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+		repo := mustCreateTestRepository(t)
+		team1 := mustCreateTestTeam(t)
 
 		config := fmt.Sprintf(`
-resource "github_repository" "test" {
-	name       = "%s"
-	visibility = "private"
-}
-
-resource "github_team" "test" {
-	name = "%s"
-}
-
 resource "github_repository_collaborators" "test" {
-	repository = github_repository.test.name
+  repository = "%v"
 
-	team {
-		team_id    = github_team.test.slug
-		permission = "pull"
-	}
+  team {
+    team_id    = "%v"
+    permission = "pull"
+  }
 
-	team {
-		team_id    = github_team.test.slug
-		permission = "push"
-	}
+  team {
+    team_id    = "%v"
+    permission = "push"
+  }
 }
-`, repoName, teamName)
+`, repo.GetName(), team1.GetSlug(), team1.GetSlug())
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
 					Config:      config,
 					ExpectError: regexp.MustCompile(`duplicate team .+ found`),
+				},
+			},
+		})
+	})
+
+	t.Run("errors_with_duplicate_users", func(t *testing.T) {
+		t.Parallel()
+
+		skipUnlessHasOrgs(t)
+		skipUnlessHasOrgUser1(t)
+
+		repo := mustCreateTestRepository(t)
+
+		config := fmt.Sprintf(`
+resource "github_repository_collaborators" "test" {
+  repository = "%v"
+
+  user {
+    username   = "%v"
+    permission = "pull"
+  }
+
+  user {
+    username   = "%v"
+    permission = "push"
+  }
+}
+`, repo.GetName(), testAccConf.testOrgUser1, testAccConf.testOrgUser1)
+
+		resource.Test(t, resource.TestCase{
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:      config,
+					ExpectError: regexp.MustCompile(`duplicate user .+ found`),
 				},
 			},
 		})

--- a/github/resource_github_team_members_test.go
+++ b/github/resource_github_team_members_test.go
@@ -284,7 +284,7 @@ resource "github_team_members" "test" {
 		skipUnlessHasOrgUser2(t)
 
 		team := mustCreateTestTeam(t, nil)
-		childTeam := mustCreateTestTeam(t, team.ID)
+		childTeam := mustCreateTestTeam(t, withNewTeamParent(team.GetID()))
 		mustAddTeamMember(t, childTeam, testAccConf.testOrgUser2)
 
 		config := fmt.Sprintf(`
@@ -339,7 +339,7 @@ resource "github_team_members" "test" {
 					},
 				},
 				{
-					PreConfig: func() { mustRenameTestTeam(t, team, newTeamName) },
+					PreConfig: func() { mustRenameTeam(t, team, newTeamName) },
 					Config:    fmt.Sprintf(config, newTeamName),
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue("github_team_members.test", tfjsonpath.New("team_id"), knownvalue.StringExact(strconv.FormatInt(team.GetID(), 10))),
@@ -376,7 +376,7 @@ resource "github_team_members" "test" {
 					},
 				},
 				{
-					PreConfig:          func() { mustDeleteTestTeam(t, team) },
+					PreConfig:          func() { mustDeleteTeam(t, team) },
 					RefreshState:       true,
 					ExpectNonEmptyPlan: true,
 				},

--- a/github/resource_github_team_members_test.go
+++ b/github/resource_github_team_members_test.go
@@ -22,7 +22,7 @@ func TestAccGithubTeamMembers(t *testing.T) {
 	t.Run("team_by_slug", func(t *testing.T) {
 		t.Parallel()
 
-		team := mustCreateTestTeam(t, nil)
+		team := mustCreateTestTeam(t)
 
 		config := fmt.Sprintf(`
 resource "github_team_members" "test" {
@@ -60,7 +60,7 @@ resource "github_team_members" "test" {
 	t.Run("team_by_id_as_slug", func(t *testing.T) {
 		t.Parallel()
 
-		team := mustCreateTestTeam(t, nil)
+		team := mustCreateTestTeam(t)
 
 		config := fmt.Sprintf(`
 resource "github_team_members" "test" {
@@ -99,7 +99,7 @@ resource "github_team_members" "test" {
 	t.Run("team_by_id", func(t *testing.T) {
 		t.Parallel()
 
-		team := mustCreateTestTeam(t, nil)
+		team := mustCreateTestTeam(t)
 
 		config := fmt.Sprintf(`
 resource "github_team_members" "test" {
@@ -137,7 +137,7 @@ resource "github_team_members" "test" {
 	t.Run("migrate_team_by_id_as_slug_to_slug", func(t *testing.T) {
 		t.Parallel()
 
-		team := mustCreateTestTeam(t, nil)
+		team := mustCreateTestTeam(t)
 
 		config := fmt.Sprintf(`
 resource "github_team_members" "test" {
@@ -190,7 +190,7 @@ resource "github_team_members" "test" {
 	t.Run("migrate_team_by_id_to_slug", func(t *testing.T) {
 		t.Parallel()
 
-		team := mustCreateTestTeam(t, nil)
+		team := mustCreateTestTeam(t)
 
 		config := fmt.Sprintf(`
 resource "github_team_members" "test" {
@@ -245,7 +245,7 @@ resource "github_team_members" "test" {
 
 		skipUnlessHasOrgUser2(t)
 
-		team := mustCreateTestTeam(t, nil)
+		team := mustCreateTestTeam(t)
 		mustAddTeamMember(t, team, testAccConf.testOrgUser2)
 
 		config := fmt.Sprintf(`
@@ -283,7 +283,7 @@ resource "github_team_members" "test" {
 
 		skipUnlessHasOrgUser2(t)
 
-		team := mustCreateTestTeam(t, nil)
+		team := mustCreateTestTeam(t)
 		childTeam := mustCreateTestTeam(t, withNewTeamParent(team.GetID()))
 		mustAddTeamMember(t, childTeam, testAccConf.testOrgUser2)
 
@@ -314,7 +314,7 @@ resource "github_team_members" "test" {
 	t.Run("team_rename_handled", func(t *testing.T) {
 		t.Parallel()
 
-		team := mustCreateTestTeam(t, nil)
+		team := mustCreateTestTeam(t)
 		newTeamName := fmt.Sprintf("%s-renamed", team.GetName())
 
 		config := fmt.Sprintf(`
@@ -353,7 +353,7 @@ resource "github_team_members" "test" {
 	t.Run("team_delete_handled", func(t *testing.T) {
 		t.Parallel()
 
-		team := mustCreateTestTeam(t, nil)
+		team := mustCreateTestTeam(t)
 
 		config := fmt.Sprintf(`
 resource "github_team_members" "test" {
@@ -391,8 +391,8 @@ resource "github_team_members" "test" {
 	t.Run("team_changed_forces_recreate", func(t *testing.T) {
 		t.Parallel()
 
-		team := mustCreateTestTeam(t, nil)
-		newTeam := mustCreateTestTeam(t, nil)
+		team := mustCreateTestTeam(t)
+		newTeam := mustCreateTestTeam(t)
 
 		config := fmt.Sprintf(`
 resource "github_team_members" "test" {

--- a/github/resource_github_team_test.go
+++ b/github/resource_github_team_test.go
@@ -156,7 +156,7 @@ resource "github_team" "test" {
 	t.Run("create_with_parent_team", func(t *testing.T) {
 		t.Parallel()
 
-		parentTeam := mustCreateTestTeam(t, nil)
+		parentTeam := mustCreateTestTeam(t)
 		teamName := fmt.Sprintf("%s%s", testResourcePrefix, acctest.RandString(5))
 
 		resource.Test(t, resource.TestCase{
@@ -176,7 +176,7 @@ resource "github_team" "test" {
 	t.Run("update_with_parent_team", func(t *testing.T) {
 		t.Parallel()
 
-		parentTeam := mustCreateTestTeam(t, nil)
+		parentTeam := mustCreateTestTeam(t)
 		teamName := fmt.Sprintf("%s%s", testResourcePrefix, acctest.RandString(5))
 
 		resource.Test(t, resource.TestCase{

--- a/github/util_team.go
+++ b/github/util_team.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/google/go-github/v89/github"
 )
@@ -22,7 +23,7 @@ func newLegacyTeamIdentity(teamID string) teamIdentity {
 	if id, ok := parseTeamID(teamID); ok {
 		t.id = &id
 	} else {
-		t.slug = &teamID
+		t.slug = new(strings.ToLower(teamID))
 	}
 
 	return t

--- a/templates/resources/repository_collaborators.md.tmpl
+++ b/templates/resources/repository_collaborators.md.tmpl
@@ -21,7 +21,7 @@ For repositories owned by an organization, collaborators can have explicit (and 
 
 ### Teams
 
-Teams will be added to the repository on apply, and removed if removed from the configuration or on destroy. Teams added to the repository outside of Terraform can be managed by adding them to the configuration, or ignored by using the `ignore_team` argument. This is particularly important for organization/enterprise teams, which either need to be added to the configuration or ignored, as otherwise they will cause perpetual drift.
+Teams will be added to the repository on apply, and removed if removed from the configuration or on destroy. Teams added to the repository outside of Terraform can be managed by adding them to the configuration.
 
 ## Personal Repositories
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2781
Resolves #2623

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- The `github_repository_collaborators` resource would churn with organization or enterprise teams present and not passed in via 1ignore_teams`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The `github_repository_collaborators` resource ignores non-direct teams so no longer churns with organization or enterprise teams present
- The `github_repository_collaborators` resource `ignore_teams` field has been deprecated as it's no longer needed (usage for any other reason than ignoring organization or enterprise times was never supported)

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
