### PR TITLE
feat: Add child teams lookup to teams data source

### DIFF
--- a/docs/data-sources/team.md
+++ b/docs/data-sources/team.md
@@ -22,14 +22,16 @@ data "github_team" "example" {
 
 ### Optional
 
+- `lookup_child_teams` (Boolean) If `true`, child teams will be looked up and returned in the `child_teams` attribute.
 - `membership_type` (String) If `summary_only` is `false` this controls which members are returned; this can be set to either `all` or `immediate`.
 - `results_per_page` (Number, Deprecated) This is unused and will be removed in a future version of the provider.
 - `slug` (String) Slug of the team name. One of `team_id` or `slug` must be specified.
-- `summary_only` (Boolean) If true, non-default team details such as `members` & `repositories` will be omitted.
+- `summary_only` (Boolean) If `true`, non-default team details such as `members` & `repositories` will be omitted.
 - `team_id` (Number) ID of the team. One of `team_id` or `slug` must be specified.
 
 ### Read-Only
 
+- `child_teams` (List of Object) List of child teams; only set if `lookup_child_teams` is `true`. (see [below for nested schema](#nestedatt--child_teams))
 - `description` (String) Description of the team.
 - `id` (String) The ID of this resource.
 - `members` (List of String, Deprecated) List of members of the team.
@@ -43,13 +45,36 @@ data "github_team" "example" {
 - `repositories_detailed` (List of Object, Deprecated) List of repositories the team has access to. (see [below for nested schema](#nestedatt--repositories_detailed))
 - `type` (String) Ownership type of the team; one of `enterprise` or `organization`.
 
+<a id="nestedatt--child_teams"></a>
+### Nested Schema for `child_teams`
+
+Read-Only:
+
+- `description` (String)
+- `id` (Number)
+- `name` (String)
+- `node_id` (String)
+- `notification_setting` (String)
+- `permission` (String)
+- `privacy` (String)
+- `slug` (String)
+- `type` (String)
+
+
 <a id="nestedatt--parent_team"></a>
 ### Nested Schema for `parent_team`
 
 Read-Only:
 
+- `description` (String)
 - `id` (Number)
+- `name` (String)
+- `node_id` (String)
+- `notification_setting` (String)
+- `permission` (String)
+- `privacy` (String)
 - `slug` (String)
+- `type` (String)
 
 
 <a id="nestedatt--repositories_detailed"></a>
@@ -66,14 +91,16 @@ Read-Only:
 
 ### Optional
 
+- `lookup_child_teams` (Boolean) If `true`, child teams will be looked up and returned in the `child_teams` attribute.
 - `membership_type` (String) If `summary_only` is `false` this controls which members are returned; this can be set to either `all` or `immediate`.
 - `results_per_page` (Number, Deprecated) This is unused and will be removed in a future version of the provider.
 - `slug` (String) Slug of the team name. One of `team_id` or `slug` must be specified.
-- `summary_only` (Boolean) If true, non-default team details such as `members` & `repositories` will be omitted.
+- `summary_only` (Boolean) If `true`, non-default team details such as `members` & `repositories` will be omitted.
 - `team_id` (Number) ID of the team. One of `team_id` or `slug` must be specified.
 
 ### Read-Only
 
+- `child_teams` (List of Object) List of child teams; only set if `lookup_child_teams` is `true`. (see [below for nested schema](#nestedatt--child_teams))
 - `description` (String) Description of the team.
 - `id` (String) The ID of this resource.
 - `members` (List of String, Deprecated) List of members of the team.
@@ -87,13 +114,35 @@ Read-Only:
 - `repositories_detailed` (List of Object, Deprecated) List of repositories the team has access to. (see [below for nested schema](#nestedatt--repositories_detailed))
 - `type` (String) Ownership type of the team; one of `enterprise` or `organization`.
 
+<a id="nestedatt--child_teams"></a>
+### Nested Schema for `child_teams`
+
+Read-Only:
+
+- `description` (String) Description of the child team.
+- `id` (Number) ID of the child team.
+- `name` (String) Name of the child team.
+- `node_id` (String) Node ID of the child team.
+- `notification_setting` (String) Notification setting for the child team; one of `notifications_enabled`, or `notifications_disabled`.
+- `permission` (String) Legacy default repository permission for the child team (typically pull, push, or admin), used when adding a repository without specifying an explicit permission. This does not represent effective access for all repositories or custom repository roles.
+- `privacy` (String) Privacy level of the child team; one of `secret` or `closed`.
+- `slug` (String) Slug of the child team name.
+- `type` (String) Ownership type of the child team; one of `enterprise` or `organization`.
+
 <a id="nestedatt--parent_team"></a>
 ### Nested Schema for `parent_team`
 
 Read-Only:
 
+- `description` (String) Description of the parent team.
 - `id` (Number) ID of the parent team.
+- `name` (String) Name of the parent team.
+- `node_id` (String) Node ID of the parent team.
+- `notification_setting` (String)
+- `permission` (String) Legacy default repository permission for the parent team (typically pull, push, or admin), used when adding a repository without specifying an explicit permission. This does not represent effective access for all repositories or custom repository roles.
+- `privacy` (String) Privacy level of the parent team; one of `secret` or `closed`.
 - `slug` (String) Slug of the parent team name.
+- `type` (String) Ownership type of the parent team; one of `enterprise` or `organization`.
 
 
 <a id="nestedatt--repositories_detailed"></a>

--- a/github/data_source_github_team.go
+++ b/github/data_source_github_team.go
@@ -34,8 +34,14 @@ func dataSourceGithubTeam() *schema.Resource {
 				ExactlyOneOf:     []string{"team_id", "slug"},
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
 			},
+			"lookup_child_teams": {
+				Description: "If `true`, child teams will be looked up and returned in the `child_teams` attribute.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+			},
 			"summary_only": {
-				Description: "If true, non-default team details such as `members` & `repositories` will be omitted.",
+				Description: "If `true`, non-default team details such as `members` & `repositories` will be omitted.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
@@ -95,6 +101,95 @@ func dataSourceGithubTeam() *schema.Resource {
 						},
 						"slug": {
 							Description: "Slug of the parent team name.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"node_id": {
+							Description: "Node ID of the parent team.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"name": {
+							Description: "Name of the parent team.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"description": {
+							Description: "Description of the parent team.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"type": {
+							Description: "Ownership type of the parent team; one of `enterprise` or `organization`.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"privacy": {
+							Description: "Privacy level of the parent team; one of `secret` or `closed`.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"notification_setting": {
+							Description: "Notification setting for the parent team; one of `notifications_enabled`, or `notifications_disabled`.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"permission": {
+							Description: "Legacy default repository permission for the parent team (typically pull, push, or admin), used when adding a repository without specifying an explicit permission. This does not represent effective access for all repositories or custom repository roles.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+					},
+				},
+			},
+			"child_teams": {
+				Description: "List of child teams; only set if `lookup_child_teams` is `true`.",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Description: "ID of the child team.",
+							Type:        schema.TypeInt,
+							Computed:    true,
+						},
+						"slug": {
+							Description: "Slug of the child team name.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"node_id": {
+							Description: "Node ID of the child team.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"name": {
+							Description: "Name of the child team.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"description": {
+							Description: "Description of the child team.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"type": {
+							Description: "Ownership type of the child team; one of `enterprise` or `organization`.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"privacy": {
+							Description: "Privacy level of the child team; one of `secret` or `closed`.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"notification_setting": {
+							Description: "Notification setting for the child team; one of `notifications_enabled`, or `notifications_disabled`.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
+						"permission": {
+							Description: "Legacy default repository permission for the child team (typically pull, push, or admin), used when adding a repository without specifying an explicit permission. This does not represent effective access for all repositories or custom repository roles.",
 							Type:        schema.TypeString,
 							Computed:    true,
 						},
@@ -160,8 +255,6 @@ func dataSourceGithubTeamRead(ctx context.Context, d *schema.ResourceData, m any
 		return diags
 	}
 
-	summaryOnly, _ := d.Get("summary_only").(bool)
-
 	var team *github.Team
 	if v, ok := d.GetOk("team_id"); ok {
 		teamIDInt, _ := v.(int)
@@ -195,16 +288,48 @@ func dataSourceGithubTeamRead(ctx context.Context, d *schema.ResourceData, m any
 	if team.Parent != nil {
 		t["parent_team"] = []map[string]any{
 			{
-				"id":   int(team.Parent.GetID()),
-				"slug": team.Parent.GetSlug(),
+				"id":                   int(team.Parent.GetID()),
+				"slug":                 team.Parent.GetSlug(),
+				"node_id":              team.Parent.GetNodeID(),
+				"name":                 team.Parent.GetName(),
+				"description":          team.Parent.GetDescription(),
+				"type":                 team.Parent.GetType(),
+				"privacy":              team.Parent.GetPrivacy(),
+				"notification_setting": team.Parent.GetNotificationSetting(),
+				"permission":           team.Parent.GetPermission(),
 			},
 		}
 	} else {
 		t["parent_team"] = nil
 	}
 
+	childTeams := make([]map[string]any, 0)
+	lookupChildTeams, _ := d.Get("lookup_child_teams").(bool)
+	if lookupChildTeams {
+		for childTeam, err := range client.Teams.ListChildTeamsByParentSlugIter(ctx, meta.name, team.GetSlug(), &github.ListOptions{PerPage: meta.maxPerPage}) {
+			if err != nil {
+				return diag.FromErr(err)
+			}
+
+			c := map[string]any{
+				"id":                   int(childTeam.GetID()),
+				"slug":                 childTeam.GetSlug(),
+				"node_id":              childTeam.GetNodeID(),
+				"name":                 childTeam.GetName(),
+				"description":          childTeam.GetDescription(),
+				"type":                 childTeam.GetType(),
+				"privacy":              childTeam.GetPrivacy(),
+				"notification_setting": childTeam.GetNotificationSetting(),
+				"permission":           childTeam.GetPermission(),
+			}
+			childTeams = append(childTeams, c)
+		}
+	}
+	t["child_teams"] = childTeams
+
 	var members, repositories []string
 	var repositoriesDetailed []map[string]any
+	summaryOnly, _ := d.Get("summary_only").(bool)
 	if !summaryOnly {
 		membershipType, _ := d.Get("membership_type").(string)
 

--- a/github/data_source_github_team_test.go
+++ b/github/data_source_github_team_test.go
@@ -22,8 +22,9 @@ func TestAccGithubTeamDataSource(t *testing.T) {
 
 		config := fmt.Sprintf(`
 data "github_team" "test" {
-  slug         = "%s"
-  summary_only = true
+  slug               = "%s"
+  lookup_child_teams = false
+  summary_only       = true
 }
 `, team.GetSlug())
 
@@ -43,6 +44,7 @@ data "github_team" "test" {
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("notification_setting"), knownvalue.StringExact(team.GetNotificationSetting())),
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("permission"), knownvalue.StringExact(team.GetPermission())),
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("parent_team"), knownvalue.ListSizeExact(0)),
+						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("child_teams"), knownvalue.ListSizeExact(0)),
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("members"), knownvalue.ListSizeExact(0)),
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("repositories"), knownvalue.ListSizeExact(0)),
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("repositories_detailed"), knownvalue.ListSizeExact(0)),
@@ -59,8 +61,9 @@ data "github_team" "test" {
 
 		config := fmt.Sprintf(`
 data "github_team" "test" {
-  team_id      = "%d"
-  summary_only = true
+  team_id            = "%d"
+  lookup_child_teams = false
+  summary_only       = true
 }
 `, team.GetID())
 
@@ -80,6 +83,7 @@ data "github_team" "test" {
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("notification_setting"), knownvalue.StringExact(team.GetNotificationSetting())),
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("permission"), knownvalue.StringExact(team.GetPermission())),
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("parent_team"), knownvalue.ListSizeExact(0)),
+						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("child_teams"), knownvalue.ListSizeExact(0)),
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("members"), knownvalue.ListSizeExact(0)),
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("repositories"), knownvalue.ListSizeExact(0)),
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("repositories_detailed"), knownvalue.ListSizeExact(0)),
@@ -104,9 +108,10 @@ data "github_team" "test" {
 
 		config := fmt.Sprintf(`
 data "github_team" "test" {
-  slug            = "%s"
-  summary_only    = false
-  membership_type = "%%v"
+  slug               = "%s"
+  lookup_child_teams = false
+  summary_only       = false
+  membership_type    = "%%v"
 }
 `, team.GetSlug())
 
@@ -126,6 +131,7 @@ data "github_team" "test" {
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("notification_setting"), knownvalue.StringExact(team.GetNotificationSetting())),
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("permission"), knownvalue.StringExact(team.GetPermission())),
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("parent_team"), knownvalue.ListSizeExact(0)),
+						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("child_teams"), knownvalue.ListSizeExact(0)),
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("members"), knownvalue.ListExact([]knownvalue.Check{
 							knownvalue.StringExact(testAccConf.testOrgUser1),
 							knownvalue.StringExact(testAccConf.testOrgUser2),
@@ -155,6 +161,7 @@ data "github_team" "test" {
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("notification_setting"), knownvalue.StringExact(team.GetNotificationSetting())),
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("permission"), knownvalue.StringExact(team.GetPermission())),
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("parent_team"), knownvalue.ListSizeExact(0)),
+						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("child_teams"), knownvalue.ListSizeExact(0)),
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("members"), knownvalue.ListExact([]knownvalue.Check{
 							knownvalue.StringExact(testAccConf.testOrgUser1),
 						})),
@@ -174,7 +181,7 @@ data "github_team" "test" {
 		})
 	})
 
-	t.Run("queries_child_team", func(t *testing.T) {
+	t.Run("queries_team_with_parent_team", func(t *testing.T) {
 		t.Parallel()
 
 		parentTeam := mustCreateTestTeam(t)
@@ -182,8 +189,9 @@ data "github_team" "test" {
 
 		config := fmt.Sprintf(`
 data "github_team" "test" {
-  slug         = "%s"
-  summary_only = true
+  slug               = "%s"
+  lookup_child_teams = false
+  summary_only       = true
 }
 `, team.GetSlug())
 
@@ -204,8 +212,80 @@ data "github_team" "test" {
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("permission"), knownvalue.StringExact(team.GetPermission())),
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("parent_team"), knownvalue.ListExact([]knownvalue.Check{
 							knownvalue.MapExact(map[string]knownvalue.Check{
-								"id":   knownvalue.Int32Exact(int32(parentTeam.GetID())),
-								"slug": knownvalue.StringExact(parentTeam.GetSlug()),
+								"id":                   knownvalue.Int32Exact(int32(parentTeam.GetID())),
+								"slug":                 knownvalue.StringExact(parentTeam.GetSlug()),
+								"node_id":              knownvalue.StringExact(parentTeam.GetNodeID()),
+								"name":                 knownvalue.StringExact(parentTeam.GetName()),
+								"description":          knownvalue.StringExact(parentTeam.GetDescription()),
+								"type":                 knownvalue.StringExact(parentTeam.GetType()),
+								"privacy":              knownvalue.StringExact(parentTeam.GetPrivacy()),
+								"notification_setting": knownvalue.StringExact(parentTeam.GetNotificationSetting()),
+								"permission":           knownvalue.StringExact(parentTeam.GetPermission()),
+							}),
+						})),
+						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("child_teams"), knownvalue.ListSizeExact(0)),
+						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("members"), knownvalue.ListSizeExact(0)),
+						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("repositories"), knownvalue.ListSizeExact(0)),
+						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("repositories_detailed"), knownvalue.ListSizeExact(0)),
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("queries_team_with_child_teams", func(t *testing.T) {
+		t.Parallel()
+
+		team := mustCreateTestTeam(t, nil)
+		childTeam1 := mustCreateTestTeam(t, withNewTeamParent(team.GetID()))
+		childTeam2 := mustCreateTestTeam(t, withNewTeamParent(team.GetID()))
+
+		config := fmt.Sprintf(`
+data "github_team" "test" {
+  slug               = "%s"
+  lookup_child_teams = true
+  summary_only       = true
+}
+`, team.GetSlug())
+
+		resource.Test(t, resource.TestCase{
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("team_id"), knownvalue.Int32Exact(int32(team.GetID()))),
+						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("slug"), knownvalue.StringExact(team.GetSlug())),
+						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("node_id"), knownvalue.StringExact(team.GetNodeID())),
+						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("name"), knownvalue.StringExact(team.GetName())),
+						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("description"), knownvalue.StringExact(team.GetDescription())),
+						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("type"), knownvalue.StringExact(team.GetType())),
+						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("privacy"), knownvalue.StringExact(team.GetPrivacy())),
+						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("notification_setting"), knownvalue.StringExact(team.GetNotificationSetting())),
+						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("permission"), knownvalue.StringExact(team.GetPermission())),
+						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("parent_team"), knownvalue.ListSizeExact(0)),
+						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("child_teams"), knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.MapExact(map[string]knownvalue.Check{
+								"id":                   knownvalue.Int32Exact(int32(childTeam1.GetID())),
+								"slug":                 knownvalue.StringExact(childTeam1.GetSlug()),
+								"node_id":              knownvalue.StringExact(childTeam1.GetNodeID()),
+								"name":                 knownvalue.StringExact(childTeam1.GetName()),
+								"description":          knownvalue.StringExact(childTeam1.GetDescription()),
+								"type":                 knownvalue.StringExact(childTeam1.GetType()),
+								"privacy":              knownvalue.StringExact(childTeam1.GetPrivacy()),
+								"notification_setting": knownvalue.StringExact(childTeam1.GetNotificationSetting()),
+								"permission":           knownvalue.StringExact(childTeam1.GetPermission()),
+							}),
+							knownvalue.MapExact(map[string]knownvalue.Check{
+								"id":                   knownvalue.Int32Exact(int32(childTeam2.GetID())),
+								"slug":                 knownvalue.StringExact(childTeam2.GetSlug()),
+								"node_id":              knownvalue.StringExact(childTeam2.GetNodeID()),
+								"name":                 knownvalue.StringExact(childTeam2.GetName()),
+								"description":          knownvalue.StringExact(childTeam2.GetDescription()),
+								"type":                 knownvalue.StringExact(childTeam2.GetType()),
+								"privacy":              knownvalue.StringExact(childTeam2.GetPrivacy()),
+								"notification_setting": knownvalue.StringExact(childTeam2.GetNotificationSetting()),
+								"permission":           knownvalue.StringExact(childTeam2.GetPermission()),
 							}),
 						})),
 						statecheck.ExpectKnownValue("data.github_team.test", tfjsonpath.New("members"), knownvalue.ListSizeExact(0)),

--- a/templates/data-sources/team.md.tmpl
+++ b/templates/data-sources/team.md.tmpl
@@ -31,14 +31,16 @@ description: |-
 
 ### Optional
 
+- `lookup_child_teams` (Boolean) If `true`, child teams will be looked up and returned in the `child_teams` attribute.
 - `membership_type` (String) If `summary_only` is `false` this controls which members are returned; this can be set to either `all` or `immediate`.
 - `results_per_page` (Number, Deprecated) This is unused and will be removed in a future version of the provider.
 - `slug` (String) Slug of the team name. One of `team_id` or `slug` must be specified.
-- `summary_only` (Boolean) If true, non-default team details such as `members` & `repositories` will be omitted.
+- `summary_only` (Boolean) If `true`, non-default team details such as `members` & `repositories` will be omitted.
 - `team_id` (Number) ID of the team. One of `team_id` or `slug` must be specified.
 
 ### Read-Only
 
+- `child_teams` (List of Object) List of child teams; only set if `lookup_child_teams` is `true`. (see [below for nested schema](#nestedatt--child_teams))
 - `description` (String) Description of the team.
 - `id` (String) The ID of this resource.
 - `members` (List of String, Deprecated) List of members of the team.
@@ -52,13 +54,35 @@ description: |-
 - `repositories_detailed` (List of Object, Deprecated) List of repositories the team has access to. (see [below for nested schema](#nestedatt--repositories_detailed))
 - `type` (String) Ownership type of the team; one of `enterprise` or `organization`.
 
+<a id="nestedatt--child_teams"></a>
+### Nested Schema for `child_teams`
+
+Read-Only:
+
+- `description` (String) Description of the child team.
+- `id` (Number) ID of the child team.
+- `name` (String) Name of the child team.
+- `node_id` (String) Node ID of the child team.
+- `notification_setting` (String) Notification setting for the child team; one of `notifications_enabled`, or `notifications_disabled`.
+- `permission` (String) Legacy default repository permission for the child team (typically pull, push, or admin), used when adding a repository without specifying an explicit permission. This does not represent effective access for all repositories or custom repository roles.
+- `privacy` (String) Privacy level of the child team; one of `secret` or `closed`.
+- `slug` (String) Slug of the child team name.
+- `type` (String) Ownership type of the child team; one of `enterprise` or `organization`.
+
 <a id="nestedatt--parent_team"></a>
 ### Nested Schema for `parent_team`
 
 Read-Only:
 
+- `description` (String) Description of the parent team.
 - `id` (Number) ID of the parent team.
+- `name` (String) Name of the parent team.
+- `node_id` (String) Node ID of the parent team.
+- `notification_setting` (String)
+- `permission` (String) Legacy default repository permission for the parent team (typically pull, push, or admin), used when adding a repository without specifying an explicit permission. This does not represent effective access for all repositories or custom repository roles.
+- `privacy` (String) Privacy level of the parent team; one of `secret` or `closed`.
 - `slug` (String) Slug of the parent team name.
+- `type` (String) Ownership type of the parent team; one of `enterprise` or `organization`.
 
 
 <a id="nestedatt--repositories_detailed"></a>


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2728

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- The `github_team` data source didn't support looking up child teams

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The `github_team` data source can lookup child teams by setting `lookup_child_teams` to `true`
- The `github_team` data source `parent_team` field is now fully populated with the team information

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
