### PR TITLE
feat: add github_repository_immutable_releases resource

### DIFF
--- a/docs/resources/repository_immutable_releases.md
+++ b/docs/resources/repository_immutable_releases.md
@@ -1,0 +1,50 @@
+---
+page_title: "github_repository_immutable_releases (Resource) - GitHub"
+description: |-
+  Manages immutable releases for a GitHub repository
+---
+
+# github_repository_immutable_releases (Resource)
+
+This resource allows you to manage [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases) for a GitHub repository. Once enabled, newly published releases lock their assets and associated Git tags against modification.
+
+-> **Note:** Existing releases remain mutable. Immutability applies only to releases published after this setting is enabled. Prefer a draft → attach assets → publish workflow when attaching release assets.
+
+## Example Usage
+
+```terraform
+resource "github_repository" "example" {
+  name        = "my-repo"
+  description = "GitHub repo managed by Terraform"
+  visibility  = "private"
+}
+
+resource "github_repository_immutable_releases" "example" {
+  repository = github_repository.example.name
+  enabled    = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `repository` - (Required) The name of the repository to configure immutable releases for.
+
+- `enabled` - (Optional) Whether immutable releases are enabled for the repository. Defaults to `true`.
+
+## Attribute Reference
+
+In addition to the above arguments, the following attributes are exported:
+
+- `repository_id` - The ID of the repository.
+
+- `enforced_by_owner` - Whether immutable releases are enforced by the repository owner (organization).
+
+## Import
+
+Repository immutable releases settings can be imported using the `repository_name`:
+
+```sh
+terraform import github_repository_immutable_releases.example my-repo
+```

--- a/examples/resources/repository_immutable_releases/example_1.tf
+++ b/examples/resources/repository_immutable_releases/example_1.tf
@@ -1,0 +1,10 @@
+resource "github_repository" "example" {
+  name        = "my-repo"
+  description = "GitHub repo managed by Terraform"
+  visibility  = "private"
+}
+
+resource "github_repository_immutable_releases" "example" {
+  repository = github_repository.example.name
+  enabled    = true
+}

--- a/github/provider.go
+++ b/github/provider.go
@@ -230,6 +230,7 @@ func NewProvider(version, commit string) func() *schema.Provider {
 				"github_repository_ruleset":                                             resourceGithubRepositoryRuleset(),
 				"github_repository_topics":                                              resourceGithubRepositoryTopics(),
 				"github_repository_webhook":                                             resourceGithubRepositoryWebhook(),
+				"github_repository_immutable_releases":                                  resourceGithubRepositoryImmutableReleases(),
 				"github_repository_vulnerability_alerts":                                resourceGithubRepositoryVulnerabilityAlerts(),
 				"github_team":                                                           resourceGithubTeam(),
 				"github_team_members":                                                   resourceGithubTeamMembers(),

--- a/github/resource_github_repository_immutable_releases.go
+++ b/github/resource_github_repository_immutable_releases.go
@@ -1,0 +1,189 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceGithubRepositoryImmutableReleases() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGithubRepositoryImmutableReleasesCreate,
+		ReadContext:   resourceGithubRepositoryImmutableReleasesRead,
+		UpdateContext: resourceGithubRepositoryImmutableReleasesUpdate,
+		DeleteContext: resourceGithubRepositoryImmutableReleasesDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceGithubRepositoryImmutableReleasesImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"repository": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The repository name to configure immutable releases for.",
+			},
+			"repository_id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The ID of the repository to configure immutable releases for.",
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether immutable releases are enabled for the repository.",
+			},
+			"enforced_by_owner": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether immutable releases are enforced by the repository owner (organization).",
+			},
+		},
+
+		CustomizeDiff: diffRepository,
+	}
+}
+
+func resourceGithubRepositoryImmutableReleasesCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	tflog.Info(ctx, "Creating repository immutable releases setting", map[string]any{"id": d.Id()})
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+
+	owner := meta.name
+	repoName := d.Get("repository").(string)
+
+	immutableReleasesEnabled := d.Get("enabled").(bool)
+	repo, _, err := client.Repositories.Get(ctx, owner, repoName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if repo.GetArchived() {
+		return diag.Errorf("cannot configure immutable releases on archived repository %s/%s", owner, repoName)
+	}
+	if immutableReleasesEnabled {
+		_, err = client.Repositories.EnableImmutableReleases(ctx, owner, repoName)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	} else {
+		_, err = client.Repositories.DisableImmutableReleases(ctx, owner, repoName)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	d.SetId(strconv.Itoa(int(repo.GetID())))
+
+	if err = d.Set("repository_id", repo.GetID()); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceGithubRepositoryImmutableReleasesRead(ctx, d, m)
+}
+
+func resourceGithubRepositoryImmutableReleasesRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	tflog.Info(ctx, "Reading repository immutable releases setting", map[string]any{"id": d.Id()})
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+
+	owner := meta.name
+	repoName := d.Get("repository").(string)
+	status, resp, err := client.Repositories.AreImmutableReleasesEnabled(ctx, owner, repoName)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			// API may 404 when disabled; treat as enabled=false if the repo still exists.
+			repo, _, repoErr := client.Repositories.Get(ctx, owner, repoName)
+			if repoErr != nil {
+				tflog.Warn(ctx, "Removing immutable releases from state; repository not found", map[string]any{"owner": owner, "repo": repoName})
+				d.SetId("")
+				return nil
+			}
+			if err = d.Set("enabled", false); err != nil {
+				return diag.FromErr(err)
+			}
+			if err = d.Set("enforced_by_owner", false); err != nil {
+				return diag.FromErr(err)
+			}
+			if err = d.Set("repository_id", repo.GetID()); err != nil {
+				return diag.FromErr(err)
+			}
+			return nil
+		}
+		return diag.Errorf("error reading repository immutable releases: %s", err.Error())
+	}
+
+	if err = d.Set("enabled", status.GetEnabled()); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("enforced_by_owner", status.GetEnforcedByOwner()); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceGithubRepositoryImmutableReleasesUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	tflog.Info(ctx, "Updating repository immutable releases setting", map[string]any{"id": d.Id()})
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+
+	owner := meta.name
+	repoName := d.Get("repository").(string)
+
+	immutableReleasesEnabled := d.Get("enabled").(bool)
+	var err error
+	if immutableReleasesEnabled {
+		_, err = client.Repositories.EnableImmutableReleases(ctx, owner, repoName)
+	} else {
+		_, err = client.Repositories.DisableImmutableReleases(ctx, owner, repoName)
+	}
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceGithubRepositoryImmutableReleasesRead(ctx, d, m)
+}
+
+func resourceGithubRepositoryImmutableReleasesDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	tflog.Info(ctx, "Deleting repository immutable releases setting", map[string]any{"id": d.Id()})
+	meta, _ := m.(*Owner)
+	client := meta.v3client
+
+	owner := meta.name
+	repoName := d.Get("repository").(string)
+	_, err := client.Repositories.DisableImmutableReleases(ctx, owner, repoName)
+	if err != nil {
+		return diag.FromErr(handleArchivedRepoDelete(err, "repository immutable releases", d.Id(), owner, repoName))
+	}
+
+	return nil
+}
+
+func resourceGithubRepositoryImmutableReleasesImport(ctx context.Context, d *schema.ResourceData, m any) ([]*schema.ResourceData, error) {
+	tflog.Debug(ctx, "Importing repository immutable releases setting", map[string]any{"id": d.Id()})
+	repoName := d.Id()
+	if err := d.Set("repository", repoName); err != nil {
+		return nil, err
+	}
+
+	meta, _ := m.(*Owner)
+	owner := meta.name
+	client := meta.v3client
+
+	repo, _, err := client.Repositories.Get(ctx, owner, repoName)
+	if err != nil {
+		return nil, err
+	}
+
+	d.SetId(strconv.Itoa(int(repo.GetID())))
+
+	if err = d.Set("repository_id", repo.GetID()); err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
+}

--- a/github/resource_github_repository_immutable_releases_test.go
+++ b/github/resource_github_repository_immutable_releases_test.go
@@ -1,0 +1,91 @@
+package github
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/compare"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccGithubRepositoryImmutableReleases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates_immutable_releases_as_enabled_without_error", func(t *testing.T) {
+		t.Parallel()
+
+		randomID := acctest.RandString(5)
+		repoName := fmt.Sprintf("%simmutable-releases-%s", testResourcePrefix, randomID)
+
+		config := fmt.Sprintf(`
+			resource "github_repository" "test" {
+				name       = "%s"
+				visibility = "private"
+				auto_init  = true
+			}
+
+			resource "github_repository_immutable_releases" "test" {
+				repository = github_repository.test.name
+				enabled    = true
+			}
+		`, repoName)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_immutable_releases.test", tfjsonpath.New("enabled"), knownvalue.Bool(true)),
+						statecheck.CompareValuePairs("github_repository_immutable_releases.test", tfjsonpath.New("repository"), "github_repository.test", tfjsonpath.New("name"), compare.ValuesSame()),
+						statecheck.ExpectKnownValue("github_repository_immutable_releases.test", tfjsonpath.New("repository_id"), knownvalue.NotNull()),
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("updates_immutable_releases_without_error", func(t *testing.T) {
+		t.Parallel()
+
+		randomID := acctest.RandString(5)
+		repoName := fmt.Sprintf("%simmutable-releases-%s", testResourcePrefix, randomID)
+
+		config := `
+			resource "github_repository" "test" {
+				name       = "%s"
+				visibility = "private"
+				auto_init  = true
+			}
+
+			resource "github_repository_immutable_releases" "test" {
+				repository = github_repository.test.name
+				enabled    = %t
+			}
+		`
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(config, repoName, true),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_immutable_releases.test", tfjsonpath.New("enabled"), knownvalue.Bool(true)),
+					},
+				},
+				{
+					Config: fmt.Sprintf(config, repoName, false),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_immutable_releases.test", tfjsonpath.New("enabled"), knownvalue.Bool(false)),
+					},
+				},
+			},
+		})
+	})
+}

--- a/templates/resources/repository_immutable_releases.md.tmpl
+++ b/templates/resources/repository_immutable_releases.md.tmpl
@@ -1,0 +1,39 @@
+---
+page_title: "{{.Name}} ({{.Type}}) - {{.RenderedProviderName}}"
+description: |-
+  Manages immutable releases for a GitHub repository
+---
+
+# {{.Name}} ({{.Type}})
+
+This resource allows you to manage [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases) for a GitHub repository. Once enabled, newly published releases lock their assets and associated Git tags against modification.
+
+-> **Note:** Existing releases remain mutable. Immutability applies only to releases published after this setting is enabled. Prefer a draft → attach assets → publish workflow when attaching release assets.
+
+## Example Usage
+
+{{tffile "examples/resources/repository_immutable_releases/example_1.tf"}}
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `repository` - (Required) The name of the repository to configure immutable releases for.
+
+- `enabled` - (Optional) Whether immutable releases are enabled for the repository. Defaults to `true`.
+
+## Attribute Reference
+
+In addition to the above arguments, the following attributes are exported:
+
+- `repository_id` - The ID of the repository.
+
+- `enforced_by_owner` - Whether immutable releases are enforced by the repository owner (organization).
+
+## Import
+
+Repository immutable releases settings can be imported using the `repository_name`:
+
+```sh
+terraform import github_repository_immutable_releases.example my-repo
+```


### PR DESCRIPTION
## Summary

Adds `github_repository_immutable_releases` to manage [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases) at the repository level via the existing go-github APIs (`EnableImmutableReleases` / `DisableImmutableReleases` / `AreImmutableReleasesEnabled`).

This mirrors `github_repository_vulnerability_alerts` (context-aware CRUD, `repository_id`, import by repo name, archived-repo handling).

Closes #2746. Revives the approach from closed #3447 with current provider patterns (docs/templates, acceptance tests).

## Test plan

- [x] `go build` succeeds against go-github/v89
- [ ] Acceptance: `TestAccGithubRepositoryImmutableReleases` (requires authenticated GitHub token)
- [ ] Manual: enable on a test repo, confirm `GET /repos/{owner}/{repo}/immutable-releases` shows `enabled: true`
- [ ] Manual: publish a release and confirm `"immutable": true` on the Releases API

---
Cursor (Composer) · immutable releases provider resource

Made with [Cursor](https://cursor.com)