### PR TITLE
ci: don't create deployment records for team-review-router

### DIFF
--- a/.github/workflows/team-review-router.yml
+++ b/.github/workflows/team-review-router.yml
@@ -33,7 +33,12 @@ jobs:
     # Protected environment holding APP_ID / APP_PRIVATE_KEY. Configure it in the
     # repo UI: restricted to the default branch, NO required reviewers, ZERO wait
     # timer (either would pause this "immediate" path).
-    environment: team-review-router
+    #
+    # `deployment: false` because this is a secrets container, not a deploy
+    # target - without it every labeled event leaves a stray deployment record.
+    environment:
+      name: team-review-router
+      deployment: false
     steps:
       - name: Mint GitHub App token
         id: app-token


### PR DESCRIPTION
### Before the change?

`team-review-router.yml` uses the string form of `environment:`, so GitHub creates a deployment object on every `labeled` event. The environment isn't a deploy target - it only holds the App credentials (`TF_TEAM_REVIEW_APP_ID` / `TF_TEAM_REVIEW_APP_PRIVATE_KEY`). Two stray records have accumulated already:

```
$ gh api "repos/integrations/terraform-provider-github/deployments?environment=team-review-router"
{"id":5585773255,"ref":"fix-repository-collaborators-indirect-teams","created_at":"2026-07-24T08:07:34Z"}
{"id":5580602912,"ref":"stevehipwell/teams-data-source-child-lookup","created_at":"2026-07-23T22:12:42Z"}
```

Each one is named after a contributor's PR branch, which reads like we deployed that branch somewhere. We didn't.

### After the change?

The map form with [`deployment: false`](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments). Secrets and variables still resolve exactly the same way; no deployment object is created.

```yaml
environment:
  name: team-review-router
  deployment: false
```

This just brings the file in line with what the repo already does elsewhere - `release.yaml` and `acceptance-tests.yaml` both use `deployment: false` for the same reason.

### How I verified it

- `actionlint .github/workflows/team-review-router.yml` - clean.
- Parsed the YAML to confirm the job resolves to `{'name': 'team-review-router', 'deployment': False}`, i.e. the map form actually took (a typo here would silently fall back to treating the whole block as a name).
- Confirmed the environment has **no custom deployment protection rule apps**, which is the one documented incompatibility - `deployment: false` on such an environment fails the job outright:

  ```
  $ gh api repos/integrations/terraform-provider-github/environments/team-review-router
  {"name":"team-review-router","protection_rules":[],"deployment_branch_policy":null}
  ```

### What I did NOT verify

I haven't run this against a live `labeled` event - that needs a maintainer to apply `needs-github-review` to a real PR. The runtime behavior of the job is untouched by this diff (same steps, same secrets, same permissions), so the risk is low, but the "no new deployment record appears" half is unproven until the next label.

### Unrelated thing I noticed

`deployment_branch_policy` is `null` on that environment, but the comment in the workflow says it should be "restricted to the default branch." Not touching it here - just flagging in case it was meant to be configured and got missed. It matters less than it looks like, since `pull_request_target` always runs the workflow file from `main` anyway.

### Pull request checklist

- [ ] Schema migrations have been created if needed - n/a, CI only
- [ ] Tests for the changes have been added - n/a, CI only
- [ ] Docs have been reviewed and added / updated if needed - n/a, CI only

### Does this introduce a breaking change?

- [ ] Yes
- [x] No
