### PR TITLE
feat: support use_immutable_subject and sub_claim_prefix on repository OIDC subject claim template

### DIFF
--- a/docs/resources/actions_repository_oidc_subject_claim_customization_template.md
+++ b/docs/resources/actions_repository_oidc_subject_claim_customization_template.md
@@ -29,6 +29,11 @@ resource "github_actions_repository_oidc_subject_claim_customization_template" "
   repository         = github_repository.example.name
   use_default        = false
   include_claim_keys = ["actor", "context", "repository_owner"]
+
+  # Opt this repository into immutable subject claims (owner and repository IDs)
+  # ahead of an org-wide rollout.
+  use_immutable_subject = true
+  sub_claim_prefix      = "custom-prefix"
 }
 ```
 
@@ -38,6 +43,8 @@ The following arguments are supported:
 
 - `use_default` - (Required) Whether to use the default template or not. If `true`, `include_claim_keys` must not be set.
 - `include_claim_keys` - (Optional) A list of OpenID Connect claims.
+- `use_immutable_subject` - (Optional) Whether to use immutable subject claims, which include the immutable repository and owner IDs, for this repository.
+- `sub_claim_prefix` - (Optional) An optional prefix to add to the repository's subject claim.
 
 ## Import
 

--- a/examples/resources/actions_repository_oidc_subject_claim_customization_template/example_1.tf
+++ b/examples/resources/actions_repository_oidc_subject_claim_customization_template/example_1.tf
@@ -6,4 +6,9 @@ resource "github_actions_repository_oidc_subject_claim_customization_template" "
   repository         = github_repository.example.name
   use_default        = false
   include_claim_keys = ["actor", "context", "repository_owner"]
+
+  # Opt this repository into immutable subject claims (owner and repository IDs)
+  # ahead of an org-wide rollout.
+  use_immutable_subject = true
+  sub_claim_prefix      = "custom-prefix"
 }

--- a/github/resource_github_actions_repository_oidc_subject_claim_customization_template.go
+++ b/github/resource_github_actions_repository_oidc_subject_claim_customization_template.go
@@ -39,6 +39,18 @@ func resourceGithubActionsRepositoryOIDCSubjectClaimCustomizationTemplate() *sch
 					Type: schema.TypeString,
 				},
 			},
+			"use_immutable_subject": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Whether to use immutable subject claims, which include the immutable repository and owner IDs, for this repository.",
+			},
+			"sub_claim_prefix": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "An optional prefix to add to the repository's subject claim.",
+			},
 		},
 	}
 }
@@ -73,6 +85,14 @@ func resourceGithubActionsRepositoryOIDCSubjectClaimCustomizationTemplateCreateO
 		customOIDCSubjectClaimTemplate.IncludeClaimKeys = claimsStr
 	}
 
+	if v, ok := d.GetOk("use_immutable_subject"); ok {
+		customOIDCSubjectClaimTemplate.UseImmutableSubject = new(v.(bool))
+	}
+
+	if v, ok := d.GetOk("sub_claim_prefix"); ok {
+		customOIDCSubjectClaimTemplate.SubClaimPrefix = new(v.(string))
+	}
+
 	ctx := context.Background()
 	_, err := client.Actions.SetRepoOIDCSubjectClaimCustomTemplate(ctx, owner, repository, customOIDCSubjectClaimTemplate)
 	if err != nil {
@@ -102,6 +122,12 @@ func resourceGithubActionsRepositoryOIDCSubjectClaimCustomizationTemplateRead(d 
 		return err
 	}
 	if err = d.Set("include_claim_keys", template.IncludeClaimKeys); err != nil {
+		return err
+	}
+	if err = d.Set("use_immutable_subject", template.UseImmutableSubject); err != nil {
+		return err
+	}
+	if err = d.Set("sub_claim_prefix", template.SubClaimPrefix); err != nil {
 		return err
 	}
 

--- a/github/resource_github_actions_repository_oidc_subject_claim_customization_template_test.go
+++ b/github/resource_github_actions_repository_oidc_subject_claim_customization_template_test.go
@@ -61,6 +61,45 @@ func TestAccGithubActionsRepositoryOIDCSubjectClaimCustomizationTemplate(t *test
 		})
 	})
 
+	t.Run("creates repository oidc subject claim customization template with immutable subject without error", func(t *testing.T) {
+		t.Parallel()
+
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%srepo-act-oidc-%s", testResourcePrefix, randomID)
+		config := fmt.Sprintf(`
+		resource "github_repository" "test" {
+			name = "%s"
+			visibility = "private"
+		}
+
+		resource "github_actions_repository_oidc_subject_claim_customization_template" "test" {
+			repository = github_repository.test.name
+			use_default = false
+			include_claim_keys = ["repo"]
+			use_immutable_subject = true
+			sub_claim_prefix = "custom-prefix"
+		}`, repoName)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_actions_repository_oidc_subject_claim_customization_template.test",
+				"use_immutable_subject", "true"),
+			resource.TestCheckResourceAttr(
+				"github_actions_repository_oidc_subject_claim_customization_template.test",
+				"sub_claim_prefix", "custom-prefix"),
+		)
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check:  check,
+				},
+			},
+		})
+	})
+
 	t.Run("updates repository oidc subject claim customization template without error", func(t *testing.T) {
 		t.Parallel()
 

--- a/github/resource_github_actions_repository_oidc_subject_claim_customization_template_test.go
+++ b/github/resource_github_actions_repository_oidc_subject_claim_customization_template_test.go
@@ -62,6 +62,45 @@ func TestAccGithubActionsRepositoryOIDCSubjectClaimCustomizationTemplate(t *test
 		})
 	})
 
+	t.Run("creates repository oidc subject claim customization template with immutable subject without error", func(t *testing.T) {
+		t.Parallel()
+
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%srepo-act-oidc-%s", testResourcePrefix, randomID)
+		config := fmt.Sprintf(`
+		resource "github_repository" "test" {
+			name = "%s"
+			visibility = "private"
+		}
+
+		resource "github_actions_repository_oidc_subject_claim_customization_template" "test" {
+			repository = github_repository.test.name
+			use_default = false
+			include_claim_keys = ["repo"]
+			use_immutable_subject = true
+			sub_claim_prefix = "custom-prefix"
+		}`, repoName)
+
+		check := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_actions_repository_oidc_subject_claim_customization_template.test",
+				"use_immutable_subject", "true"),
+			resource.TestCheckResourceAttr(
+				"github_actions_repository_oidc_subject_claim_customization_template.test",
+				"sub_claim_prefix", "custom-prefix"),
+		)
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check:  check,
+				},
+			},
+		})
+	})
+
 	t.Run("updates repository oidc subject claim customization template without error", func(t *testing.T) {
 		t.Parallel()
 

--- a/templates/resources/actions_repository_oidc_subject_claim_customization_template.md.tmpl
+++ b/templates/resources/actions_repository_oidc_subject_claim_customization_template.md.tmpl
@@ -28,6 +28,8 @@ The following arguments are supported:
 
 - `use_default` - (Required) Whether to use the default template or not. If `true`, `include_claim_keys` must not be set.
 - `include_claim_keys` - (Optional) A list of OpenID Connect claims.
+- `use_immutable_subject` - (Optional) Whether to use immutable subject claims, which include the immutable repository and owner IDs, for this repository.
+- `sub_claim_prefix` - (Optional) An optional prefix to add to the repository's subject claim.
 
 ## Import
 


### PR DESCRIPTION
## Summary

Wires `use_immutable_subject` and `sub_claim_prefix` — already present on go-github v89's `OIDCSubjectClaimCustomTemplate` struct — through to `github_actions_repository_oidc_subject_claim_customization_template`.

This lets a repository created before GitHub's July 15, 2026 immutable-subject-claims rollout opt in individually via Terraform, instead of requiring an org-wide toggle or an out-of-band REST call that Terraform can't track.

## Changes

- `use_immutable_subject` (bool, optional, computed) and `sub_claim_prefix` (string, optional, computed) added to the resource schema
- Both fields wired into `CreateOrUpdate` and `Read`, following the existing `GetOk` + `new(...)` pattern already used elsewhere in this resource (`include_claim_keys`) and in sibling resources (e.g. `resource_github_enterprise_actions_workflow_permissions.go`)
- Docs (`docs/resources/...md` and its `.tmpl` source) and the example under `examples/resources/...` updated to cover both new arguments
- New acceptance test subtest asserting both fields round-trip correctly

Scoped to the repository-level resource only, matching the issue — the organization-level resource and this resource's `Delete` behavior are unchanged.

Closes #3548

## Test plan

- [ ] Maintainer-run acceptance suite (`TestAccGithubActionsRepositoryOIDCSubjectClaimCustomizationTemplate`), since these require a live GitHub token this environment doesn't have
- [x] Manual diff review against the existing `use_default`/`include_claim_keys` and `can_approve_pull_request_reviews` patterns for consistency