### PR TITLE
fix: prevent inconsistent final plan for `prevent_self_review` in `github_repository_environment`

### DIFF
--- a/github/resource_github_repository_environment.go
+++ b/github/resource_github_repository_environment.go
@@ -270,11 +270,7 @@ func resourceGithubRepositoryEnvironmentRead(ctx context.Context, d *schema.Reso
 				return diag.FromErr(err)
 			}
 
-			preventSelfReview := false
-			if pr.PreventSelfReview != nil {
-				preventSelfReview = *pr.PreventSelfReview
-			}
-			if err = d.Set("prevent_self_review", preventSelfReview); err != nil {
+			if err = d.Set("prevent_self_review", pr.GetPreventSelfReview()); err != nil {
 				return diag.FromErr(err)
 			}
 		}

--- a/github/resource_github_repository_environment.go
+++ b/github/resource_github_repository_environment.go
@@ -232,6 +232,12 @@ func resourceGithubRepositoryEnvironmentRead(ctx context.Context, d *schema.Reso
 		return diag.FromErr(err)
 	}
 
+	// Default prevent_self_review to false; it will be overwritten if the
+	// required_reviewers protection rule is present in the API response.
+	if err := d.Set("prevent_self_review", false); err != nil {
+		return diag.FromErr(err)
+	}
+
 	for _, pr := range env.ProtectionRules {
 		switch pr.GetType() {
 		case "wait_timer":
@@ -264,7 +270,11 @@ func resourceGithubRepositoryEnvironmentRead(ctx context.Context, d *schema.Reso
 				return diag.FromErr(err)
 			}
 
-			if err = d.Set("prevent_self_review", pr.PreventSelfReview); err != nil {
+			preventSelfReview := false
+			if pr.PreventSelfReview != nil {
+				preventSelfReview = *pr.PreventSelfReview
+			}
+			if err = d.Set("prevent_self_review", preventSelfReview); err != nil {
 				return diag.FromErr(err)
 			}
 		}

--- a/github/resource_github_repository_environment.go
+++ b/github/resource_github_repository_environment.go
@@ -269,11 +269,7 @@ func resourceGithubRepositoryEnvironmentRead(ctx context.Context, d *schema.Reso
 				return diag.FromErr(err)
 			}
 
-			preventSelfReview := false
-			if pr.PreventSelfReview != nil {
-				preventSelfReview = *pr.PreventSelfReview
-			}
-			if err = d.Set("prevent_self_review", preventSelfReview); err != nil {
+			if err = d.Set("prevent_self_review", pr.GetPreventSelfReview()); err != nil {
 				return diag.FromErr(err)
 			}
 		}

--- a/github/resource_github_repository_environment.go
+++ b/github/resource_github_repository_environment.go
@@ -231,6 +231,12 @@ func resourceGithubRepositoryEnvironmentRead(ctx context.Context, d *schema.Reso
 		return diag.FromErr(err)
 	}
 
+	// Default prevent_self_review to false; it will be overwritten if the
+	// required_reviewers protection rule is present in the API response.
+	if err := d.Set("prevent_self_review", false); err != nil {
+		return diag.FromErr(err)
+	}
+
 	for _, pr := range env.ProtectionRules {
 		switch pr.GetType() {
 		case "wait_timer":
@@ -263,7 +269,11 @@ func resourceGithubRepositoryEnvironmentRead(ctx context.Context, d *schema.Reso
 				return diag.FromErr(err)
 			}
 
-			if err = d.Set("prevent_self_review", pr.PreventSelfReview); err != nil {
+			preventSelfReview := false
+			if pr.PreventSelfReview != nil {
+				preventSelfReview = *pr.PreventSelfReview
+			}
+			if err = d.Set("prevent_self_review", preventSelfReview); err != nil {
 				return diag.FromErr(err)
 			}
 		}

--- a/github/resource_github_repository_environment_test.go
+++ b/github/resource_github_repository_environment_test.go
@@ -284,23 +284,18 @@ resource "github_repository_environment" "test" {
 	t.Run("prevent_self_review_defaults_false_without_reviewers", func(t *testing.T) {
 		t.Parallel()
 
-		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
-		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+		skipUnlessHasOrgs(t)
+
+		repo := mustCreateTestRepository(t)
 
 		config := fmt.Sprintf(`
-resource "github_repository" "test" {
-	name       = "%s"
-	visibility = "public"
-}
-
 resource "github_repository_environment" "test" {
-	repository  = github_repository.test.name
+	repository  = "%s"
 	environment = "test"
 }
-`, repoName)
+`, repo.GetName())
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { skipUnlessHasOrgs(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{

--- a/github/resource_github_repository_environment_test.go
+++ b/github/resource_github_repository_environment_test.go
@@ -2,9 +2,12 @@ package github
 
 import (
 	"fmt"
+	"net/http"
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -14,6 +17,93 @@ import (
 
 func TestAccGithubRepositoryEnvironment(t *testing.T) {
 	t.Parallel()
+
+	t.Run("read_sets_prevent_self_review", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name          string
+			responseBody  string
+			expectedValue string
+		}{
+			{
+				name:          "without required reviewers",
+				responseBody:  `{"name":"test","protection_rules":[]}`,
+				expectedValue: "false",
+			},
+			{
+				name:          "required reviewers without prevent self review",
+				responseBody:  `{"name":"test","protection_rules":[{"type":"required_reviewers","reviewers":[]}]}`,
+				expectedValue: "false",
+			},
+			{
+				name:          "prevent self review enabled",
+				responseBody:  `{"name":"test","protection_rules":[{"type":"required_reviewers","prevent_self_review":true,"reviewers":[]}]}`,
+				expectedValue: "true",
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				t.Parallel()
+
+				ts := githubApiMock([]*mockResponse{
+					{
+						ExpectedUri:    "/repos/test-org/test-repo/environments/test",
+						ExpectedMethod: http.MethodGet,
+						StatusCode:     http.StatusOK,
+						ResponseBody:   test.responseBody,
+					},
+				})
+				t.Cleanup(ts.Close)
+
+				// Decode an import-like state where prevent_self_review is absent.
+				// TestResourceDataRaw would apply the schema default and mask the read regression.
+				d, err := schema.InternalMap(resourceGithubRepositoryEnvironment().Schema).Data(&terraform.InstanceState{
+					ID: "test-repo:test",
+					Attributes: map[string]string{
+						"id":          "test-repo:test",
+						"repository":  "test-repo",
+						"environment": "test",
+					},
+				}, nil)
+				if err != nil {
+					t.Fatalf("failed to create resource data: %v", err)
+				}
+
+				initialState := d.State()
+				if initialState == nil {
+					t.Fatal("expected initial resource state, got nil")
+				}
+				if _, ok := initialState.Attributes["prevent_self_review"]; ok {
+					t.Fatal("test setup unexpectedly populated prevent_self_review")
+				}
+
+				meta := &Owner{
+					name:     "test-org",
+					v3client: mustCreateTestGitHubClient(t, ts.URL),
+				}
+
+				diags := resourceGithubRepositoryEnvironmentRead(t.Context(), d, meta)
+				if diags.HasError() {
+					t.Fatalf("unexpected read diagnostics: %v", diags)
+				}
+
+				state := d.State()
+				if state == nil {
+					t.Fatal("expected resource state after read, got nil")
+				}
+
+				actualValue, ok := state.Attributes["prevent_self_review"]
+				if !ok {
+					t.Fatalf("prevent_self_review was not written to state: %#v", state.Attributes)
+				}
+				if actualValue != test.expectedValue {
+					t.Fatalf("expected prevent_self_review to be %q, got %q", test.expectedValue, actualValue)
+				}
+			})
+		}
+	})
 
 	t.Run("create", func(t *testing.T) {
 		t.Parallel()
@@ -275,34 +365,7 @@ resource "github_repository_environment" "test" {
 					ResourceName:            "github_repository_environment.test",
 					ImportState:             true,
 					ImportStateVerify:       true,
-					ImportStateVerifyIgnore: []string{"can_admins_bypass", "prevent_self_review", "reviewers", "wait_timer", "deployment_branch_policy"},
-				},
-			},
-		})
-	})
-
-	t.Run("prevent_self_review_defaults_false_without_reviewers", func(t *testing.T) {
-		t.Parallel()
-
-		skipUnlessHasOrgs(t)
-
-		repo := mustCreateTestRepository(t)
-
-		config := fmt.Sprintf(`
-resource "github_repository_environment" "test" {
-	repository  = "%s"
-	environment = "test"
-}
-`, repo.GetName())
-
-		resource.Test(t, resource.TestCase{
-			ProviderFactories: providerFactories,
-			Steps: []resource.TestStep{
-				{
-					Config: config,
-					ConfigStateChecks: []statecheck.StateCheck{
-						statecheck.ExpectKnownValue("github_repository_environment.test", tfjsonpath.New("prevent_self_review"), knownvalue.Bool(false)),
-					},
+					ImportStateVerifyIgnore: []string{"can_admins_bypass", "reviewers", "wait_timer", "deployment_branch_policy"},
 				},
 			},
 		})

--- a/github/resource_github_repository_environment_test.go
+++ b/github/resource_github_repository_environment_test.go
@@ -281,6 +281,38 @@ resource "github_repository_environment" "test" {
 		})
 	})
 
+	t.Run("prevent_self_review_defaults_false_without_reviewers", func(t *testing.T) {
+		t.Parallel()
+
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		repoName := fmt.Sprintf("%s%s", testResourcePrefix, randomID)
+
+		config := fmt.Sprintf(`
+resource "github_repository" "test" {
+	name       = "%s"
+	visibility = "public"
+}
+
+resource "github_repository_environment" "test" {
+	repository  = github_repository.test.name
+	environment = "test"
+}
+`, repoName)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessHasOrgs(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_repository_environment.test", tfjsonpath.New("prevent_self_review"), knownvalue.Bool(false)),
+					},
+				},
+			},
+		})
+	})
+
 	t.Run("errors_with_more_than_six_reviewers", func(t *testing.T) {
 		t.Parallel()
 

--- a/github/resource_github_repository_environment_test.go
+++ b/github/resource_github_repository_environment_test.go
@@ -2,12 +2,9 @@ package github
 
 import (
 	"fmt"
-	"net/http"
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -17,93 +14,6 @@ import (
 
 func TestAccGithubRepositoryEnvironment(t *testing.T) {
 	t.Parallel()
-
-	t.Run("read_sets_prevent_self_review", func(t *testing.T) {
-		t.Parallel()
-
-		tests := []struct {
-			name          string
-			responseBody  string
-			expectedValue string
-		}{
-			{
-				name:          "without required reviewers",
-				responseBody:  `{"name":"test","protection_rules":[]}`,
-				expectedValue: "false",
-			},
-			{
-				name:          "required reviewers without prevent self review",
-				responseBody:  `{"name":"test","protection_rules":[{"type":"required_reviewers","reviewers":[]}]}`,
-				expectedValue: "false",
-			},
-			{
-				name:          "prevent self review enabled",
-				responseBody:  `{"name":"test","protection_rules":[{"type":"required_reviewers","prevent_self_review":true,"reviewers":[]}]}`,
-				expectedValue: "true",
-			},
-		}
-
-		for _, test := range tests {
-			t.Run(test.name, func(t *testing.T) {
-				t.Parallel()
-
-				ts := githubApiMock([]*mockResponse{
-					{
-						ExpectedUri:    "/repos/test-org/test-repo/environments/test",
-						ExpectedMethod: http.MethodGet,
-						StatusCode:     http.StatusOK,
-						ResponseBody:   test.responseBody,
-					},
-				})
-				t.Cleanup(ts.Close)
-
-				// Decode an import-like state where prevent_self_review is absent.
-				// TestResourceDataRaw would apply the schema default and mask the read regression.
-				d, err := schema.InternalMap(resourceGithubRepositoryEnvironment().Schema).Data(&terraform.InstanceState{
-					ID: "test-repo:test",
-					Attributes: map[string]string{
-						"id":          "test-repo:test",
-						"repository":  "test-repo",
-						"environment": "test",
-					},
-				}, nil)
-				if err != nil {
-					t.Fatalf("failed to create resource data: %v", err)
-				}
-
-				initialState := d.State()
-				if initialState == nil {
-					t.Fatal("expected initial resource state, got nil")
-				}
-				if _, ok := initialState.Attributes["prevent_self_review"]; ok {
-					t.Fatal("test setup unexpectedly populated prevent_self_review")
-				}
-
-				meta := &Owner{
-					name:     "test-org",
-					v3client: mustCreateTestGitHubClient(t, ts.URL),
-				}
-
-				diags := resourceGithubRepositoryEnvironmentRead(t.Context(), d, meta)
-				if diags.HasError() {
-					t.Fatalf("unexpected read diagnostics: %v", diags)
-				}
-
-				state := d.State()
-				if state == nil {
-					t.Fatal("expected resource state after read, got nil")
-				}
-
-				actualValue, ok := state.Attributes["prevent_self_review"]
-				if !ok {
-					t.Fatalf("prevent_self_review was not written to state: %#v", state.Attributes)
-				}
-				if actualValue != test.expectedValue {
-					t.Fatalf("expected prevent_self_review to be %q, got %q", test.expectedValue, actualValue)
-				}
-			})
-		}
-	})
 
 	t.Run("create", func(t *testing.T) {
 		t.Parallel()
@@ -333,7 +243,7 @@ resource "github_repository_environment" "test" {
 		})
 	})
 
-	t.Run("import", func(t *testing.T) {
+	t.Run("import_without_reviewers", func(t *testing.T) {
 		t.Parallel()
 
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
@@ -362,6 +272,8 @@ resource "github_repository_environment" "test" {
 					},
 				},
 				{
+					// The API omits required_reviewers when none are configured, but
+					// prevent_self_review must still be populated during import.
 					ResourceName:            "github_repository_environment.test",
 					ImportState:             true,
 					ImportStateVerify:       true,


### PR DESCRIPTION
Fixes an issue where Terraform reports "Provider produced inconsistent final plan" for the `prevent_self_review` attribute on `github_repository_environment` resources that have no reviewers configured.

Resolves a missed edge case in  https://github.com/integrations/terraform-provider-github/issues/1967

### Problem

When an environment has no reviewers, the GitHub API does not return a `required_reviewers` protection rule. The read function only set `prevent_self_review` inside the `case "required_reviewers"` branch, so the attribute was never written to state—leaving it as `null`. Terraform's plan expected `false` (the schema default), causing the following mismatch:

Error: Provider produced inconsistent final plan .prevent_self_review: was cty.False, but now null.

### Root Cause

1. `prevent_self_review` was only set in state when a `required_reviewers` protection rule existed in the API response.
2. `pr.PreventSelfReview` (a `*bool`) was passed directly to `d.Set()` without nil-checking, which could also store `null` in state.

### Fix

- Set `prevent_self_review` to `false` before iterating protection rules, ensuring it always has a value in state.
- Safely dereference `pr.PreventSelfReview` with a nil guard, defaulting to `false`.

### Testing

Environments without reviewers (the failing case) are already exercised by the `create_with_id_separator_in_name` and `update_to_add_reviewers` acceptance tests which create environments with no initial reviewers.

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
