### PR TITLE
fix: remove repository file from state when its commit no longer exists

### DIFF
--- a/github/resource_github_repository_file.go
+++ b/github/resource_github_repository_file.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -331,6 +332,19 @@ func resourceGithubRepositoryFileRead(ctx context.Context, d *schema.ResourceDat
 		commit, err = getFileCommit(ctx, client, owner, repoName, file, ref)
 	}
 	if err != nil {
+		// The commit recorded in state, or any commit still containing the file,
+		// may be unreachable because the repository, branch or history is gone.
+		// That is "the resource no longer exists", not a failure to read it.
+		if ghErr, ok := errors.AsType[*github.ErrorResponse](err); ok && ghErr.Response != nil && ghErr.Response.StatusCode == http.StatusNotFound {
+			tflog.Info(ctx, "Removing repository file from state because its commit no longer exists in GitHub")
+			d.SetId("")
+			return nil
+		}
+		if errors.Is(err, errFileCommitNotFound) {
+			tflog.Info(ctx, "Removing repository file from state because no commit contains it")
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 	tflog.Debug(ctx, "Found file in commit", map[string]any{

--- a/github/util_repo.go
+++ b/github/util_repo.go
@@ -33,6 +33,11 @@ func checkRepositoryBranchExists(ctx context.Context, client *github.Client, own
 	return nil
 }
 
+// errFileCommitNotFound reports that no commit reachable from the requested ref
+// still contains the file, so callers can remove the resource from state rather
+// than surfacing a hard error.
+var errFileCommitNotFound = errors.New("no commit contains the file")
+
 func getFileCommit(ctx context.Context, client *github.Client, owner, repo, file, branch string) (*github.RepositoryCommit, error) {
 	opts := &github.CommitsListOptions{
 		SHA:  branch,
@@ -89,7 +94,7 @@ func getFileCommit(ctx context.Context, client *github.Client, owner, repo, file
 		}
 	}
 
-	return nil, fmt.Errorf("cannot find file %s in repo %s/%s", file, owner, repo)
+	return nil, fmt.Errorf("cannot find file %s in repo %s/%s: %w", file, owner, repo, errFileCommitNotFound)
 }
 
 // getAutolinkByKeyPrefix returns a single autolink reference by key prefix that was configured for the given repository.

--- a/github/util_repo_test.go
+++ b/github/util_repo_test.go
@@ -1,0 +1,34 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Test_getFileCommit_NoCommitContainsFile locks in the errFileCommitNotFound
+// sentinel. resourceGithubRepositoryFileRead relies on it to remove the resource
+// from state instead of returning a hard error, so unwrapping this error would
+// silently reintroduce that failure.
+func Test_getFileCommit_NoCommitContainsFile(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		if _, err := w.Write([]byte("[]")); err != nil {
+			t.Errorf("failed to write response: %s", err)
+		}
+	}))
+	defer ts.Close()
+
+	client := mustCreateTestGitHubClient(t, ts.URL+"/")
+
+	_, err := getFileCommit(context.Background(), client, "owner", "repo", "some/file.txt", "main")
+	if err == nil {
+		t.Fatal("expected an error when no commit contains the file, got nil")
+	}
+
+	if !errors.Is(err, errFileCommitNotFound) {
+		t.Errorf("errors.Is(err, errFileCommitNotFound) = false, want true; got error: %s", err)
+	}
+}


### PR DESCRIPTION
Resolves #3586

----

### Before the change?

- `resourceGithubRepositoryFileRead` returns a hard error when the file's commit can no longer be found. Both lookup paths fall through to a bare `return diag.FromErr(err)`: a GitHub 404 from `GetCommit` (used when `commit_sha` is in state), and `getFileCommit`'s `cannot find file ...` case (used when it is not).
- Because read fails rather than clearing the ID, once the commit is unreachable the resource can neither be refreshed nor removed — every later plan/apply fails on the same read, and the entry needs manual state surgery to clear.
- This is inconsistent with the sibling repository resources: `resource_github_repository_custom_property.go`, `resource_github_repository_ruleset.go` and `resource_github_branch_default.go` already detect a 404 on read and call `d.SetId("")`.

### After the change?

- A read that establishes the commit is gone removes the resource from state, matching Terraform's contract and the sibling resources.
- `getFileCommit`'s exhaustion case is wrapped in an `errFileCommitNotFound` sentinel so the read can tell it apart from a genuine failure without string matching. That case is reachable independently of any HTTP status, which is why a sentinel is used rather than only checking for a 404.
- Every error that is not "not found" still propagates unchanged.

### Pull request checklist

- [ ] ~Schema migrations have been created if needed~ — no schema change; this only affects read behaviour.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~Docs have been reviewed and added / updated if needed~ — no user-facing schema or option change, so I did not find anything in `website/` that describes this behaviour. Happy to document it if you would like it called out.

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

A configuration whose file still exists is unaffected. The change only alters what happens when the commit is already gone, where the previous outcome was a permanent read error.

----

### Testing

`Test_getFileCommit_NoCommitContainsFile` drives `getFileCommit` against an `httptest` server that returns an empty commit list, and asserts `errors.Is(err, errFileCommitNotFound)`. It uses the existing `mustCreateTestGitHubClient` helper and needs no credentials. I verified it discriminates: removing the `%w` wrap makes it fail with `errors.Is(...) = false`, which is the regression that would silently restore the old behaviour.

I could not exercise the resource-level 404 path, since the acceptance tests need a live org and credentials I do not have. Note that `go test ./github/...` does not pass cleanly on a fresh checkout in my environment either — `TestAccGithubActionsOrganizationPermissions` panics without credentials — and I confirmed that failure is identical with and without this change. `go build ./...`, `go vet ./github/...` and `gofmt -l` are clean.

### AI use

Per the AI Use Policy: this change was written with AI assistance. I have reviewed it, and the verification described above is what I actually ran rather than a summary of intent. The reasoning for the sentinel over a status-code-only check, and the scope limits above, are stated deliberately — please push back if you would rather solve it differently, for example by handling the exhaustion case at the call site instead.

🤖
