### PR TITLE
fix: populate database_id on enterprise org create; fix enterprise permissions test config

### DIFF
--- a/github/resource_github_enterprise_actions_permissions_test.go
+++ b/github/resource_github_enterprise_actions_permissions_test.go
@@ -57,12 +57,16 @@ func TestAccGithubActionsEnterprisePermissions(t *testing.T) {
 		desc := "Initial org description"
 
 		config := fmt.Sprintf(`
+			data "github_enterprise" "enterprise" {
+				slug = "%s"
+			}
+
 			data "github_user" "current" {
 				username = ""
 			}
 
 			resource "github_enterprise_organization" "org" {
-				enterprise_slug = "%s"
+				enterprise_id   = data.github_enterprise.enterprise.id
 				name            = "%s"
 				display_name    = "%s"
 				description     = "%s"
@@ -73,7 +77,7 @@ func TestAccGithubActionsEnterprisePermissions(t *testing.T) {
 			}
 
 			resource "github_enterprise_actions_permissions" "test" {
-				enterprise_slug = "%s"
+				enterprise_slug = data.github_enterprise.enterprise.slug
 				allowed_actions = "%s"
 				enabled_organizations = "%s"
 				allowed_actions_config {
@@ -82,10 +86,10 @@ func TestAccGithubActionsEnterprisePermissions(t *testing.T) {
 					verified_allowed     = %t
 				}
 				enabled_organizations_config {
-					organization_ids       = [github_enterprise_organization.org.id]
+					organization_ids       = [github_enterprise_organization.org.database_id]
 				}
 			}
-		`, testAccConf.enterpriseSlug, orgName, displayName, desc, testAccConf.enterpriseSlug, allowedActions, enabledOrganizations, githubOwnedAllowed, verifiedAllowed)
+		`, testAccConf.enterpriseSlug, orgName, displayName, desc, allowedActions, enabledOrganizations, githubOwnedAllowed, verifiedAllowed)
 
 		check := resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(
@@ -177,11 +181,14 @@ func TestAccGithubActionsEnterprisePermissions(t *testing.T) {
 		desc2 := fmt.Sprintf("Initial org description %s", randomID2)
 
 		config := fmt.Sprintf(`
+			data "github_enterprise" "enterprise" {
+				slug = "%s"
+			}
 			data "github_user" "current" {
 				username = ""
 			}
 			resource "github_enterprise_organization" "org" {
-				enterprise_slug = "%s"
+				enterprise_id   = data.github_enterprise.enterprise.id
 				name            = "%s"
 				display_name    = "%s"
 				description     = "%s"
@@ -191,7 +198,7 @@ func TestAccGithubActionsEnterprisePermissions(t *testing.T) {
 				]
 			}
 			resource "github_enterprise_organization" "org2" {
-				enterprise_slug = "%s"
+				enterprise_id   = data.github_enterprise.enterprise.id
 				name            = "%s"
 				display_name    = "%s"
 				description     = "%s"
@@ -201,14 +208,14 @@ func TestAccGithubActionsEnterprisePermissions(t *testing.T) {
 				]
 			}
 			resource "github_enterprise_actions_permissions" "test" {
-				enterprise_slug = "%s"
+				enterprise_slug = data.github_enterprise.enterprise.slug
 				allowed_actions = "%s"
 				enabled_organizations = "%s"
 				enabled_organizations_config {
-					organization_ids       = [github_enterprise_organization.org.id, github_enterprise_organization.org2.id]
+					organization_ids       = [github_enterprise_organization.org.database_id, github_enterprise_organization.org2.database_id]
 				}
 			}
-		`, testAccConf.enterpriseSlug, orgName, displayName, desc, testAccConf.enterpriseSlug, orgName2, displayName2, desc2, testAccConf.enterpriseSlug, allowedActions, enabledOrganizations)
+		`, testAccConf.enterpriseSlug, orgName, displayName, desc, orgName2, displayName2, desc2, allowedActions, enabledOrganizations)
 
 		check := resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(

--- a/github/resource_github_enterprise_organization.go
+++ b/github/resource_github_enterprise_organization.go
@@ -88,7 +88,8 @@ func resourceGithubEnterpriseOrganizationCreate(data *schema.ResourceData, m any
 	var mutate struct {
 		CreateEnterpriseOrganization struct {
 			Organization struct {
-				ID githubv4.ID
+				ID         githubv4.ID
+				DatabaseId githubv4.Int
 			}
 		} `graphql:"createEnterpriseOrganization(input:$input)"`
 	}
@@ -114,6 +115,13 @@ func resourceGithubEnterpriseOrganizationCreate(data *schema.ResourceData, m any
 		return err
 	}
 	data.SetId(fmt.Sprintf("%s", mutate.CreateEnterpriseOrganization.Organization.ID))
+
+	// The provider does not read after write, so database_id has to be populated here or it stays
+	// unset until the next refresh, which breaks same-apply references such as
+	// github_enterprise_actions_runner_group.selected_organization_ids.
+	if err := data.Set("database_id", mutate.CreateEnterpriseOrganization.Organization.DatabaseId); err != nil {
+		return err
+	}
 
 	// We use the V3 api to set the description of the org, because there is no mutator in the V4 API to edit the org's
 	// description and display name

--- a/github/resource_github_enterprise_organization_test.go
+++ b/github/resource_github_enterprise_organization_test.go
@@ -9,8 +9,10 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v89/github"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/shurcooL/githubv4"
 )
 
 func TestIsSAMLEnforcementError(t *testing.T) {
@@ -110,6 +112,9 @@ func TestAccGithubEnterpriseOrganization(t *testing.T) {
 			"before": resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttrSet(
 					"github_enterprise_organization.org", "enterprise_id",
+				),
+				resource.TestCheckResourceAttrSet(
+					"github_enterprise_organization.org", "database_id",
 				),
 				resource.TestCheckResourceAttr(
 					"github_enterprise_organization.org", "name",
@@ -564,4 +569,57 @@ func TestAccGithubEnterpriseOrganization(t *testing.T) {
 			},
 		})
 	})
+}
+
+func TestResourceGithubEnterpriseOrganizationCreateSetsDatabaseID(t *testing.T) {
+	// IMPORTANT: This test is not parallelized because it uses a shared HTTP handler.
+
+	const createResponse = `{
+  "data": {
+    "createEnterpriseOrganization": {
+      "organization": {
+        "id": "O_kgDOCg7Zxw",
+        "databaseId": 168828871
+      }
+    }
+  }
+}`
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, req *http.Request) {
+		body := mustRead(req.Body)
+		if !strings.Contains(body, "createEnterpriseOrganization") {
+			t.Errorf("unexpected GraphQL call: %s", body)
+		}
+		if !strings.Contains(body, "databaseId") {
+			t.Errorf("mutation does not select databaseId: %s", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		mustWrite(w, createResponse)
+	})
+
+	meta := &Owner{
+		v4client: githubv4.NewClient(&http.Client{Transport: localRoundTripper{handler: mux}}),
+	}
+
+	data := schema.TestResourceDataRaw(t, resourceGithubEnterpriseOrganization().Schema, map[string]any{
+		"enterprise_id": "E_kgDNAbc",
+		"name":          "some-awesome-org",
+		"billing_email": "octocat@octo.cat",
+		"admin_logins":  []any{"octocat"},
+	})
+
+	if err := resourceGithubEnterpriseOrganizationCreate(data, meta); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if got, want := data.Id(), "O_kgDOCg7Zxw"; got != want {
+		t.Errorf("id = %q, want %q", got, want)
+	}
+
+	// database_id must be populated during create because the provider does not read after write,
+	// and other resources reference it within the same apply.
+	if got, want := data.Get("database_id").(int), 168828871; got != want {
+		t.Errorf("database_id = %d, want %d", got, want)
+	}
 }

--- a/github/resource_github_enterprise_organization_test.go
+++ b/github/resource_github_enterprise_organization_test.go
@@ -619,7 +619,11 @@ func TestResourceGithubEnterpriseOrganizationCreateSetsDatabaseID(t *testing.T) 
 
 	// database_id must be populated during create because the provider does not read after write,
 	// and other resources reference it within the same apply.
-	if got, want := data.Get("database_id").(int), 168828871; got != want {
+	got, ok := data.Get("database_id").(int)
+	if !ok {
+		t.Fatalf("database_id is %T, want int", data.Get("database_id"))
+	}
+	if want := 168828871; got != want {
 		t.Errorf("database_id = %d, want %d", got, want)
 	}
 }

--- a/github/resource_github_enterprise_organization_test.go
+++ b/github/resource_github_enterprise_organization_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/shurcooL/githubv4"
 )
 
 func TestIsSAMLEnforcementError(t *testing.T) {
@@ -572,7 +571,7 @@ func TestAccGithubEnterpriseOrganization(t *testing.T) {
 }
 
 func TestResourceGithubEnterpriseOrganizationCreateSetsDatabaseID(t *testing.T) {
-	// IMPORTANT: This test is not parallelized because it uses a shared HTTP handler.
+	t.Parallel()
 
 	const createResponse = `{
   "data": {
@@ -599,7 +598,7 @@ func TestResourceGithubEnterpriseOrganizationCreateSetsDatabaseID(t *testing.T) 
 	})
 
 	meta := &Owner{
-		v4client: githubv4.NewClient(&http.Client{Transport: localRoundTripper{handler: mux}}),
+		v4client: newTestGraphQLClient(mux),
 	}
 
 	data := schema.TestResourceDataRaw(t, resourceGithubEnterpriseOrganization().Schema, map[string]any{

--- a/github/util_v4_repository_test.go
+++ b/github/util_v4_repository_test.go
@@ -171,7 +171,7 @@ func TestGetRepositoryIDPositiveMatches(t *testing.T) {
 	})
 
 	meta := Owner{
-		v4client: githubv4.NewClient(&http.Client{Transport: localRoundTripper{handler: mux}}),
+		v4client: newTestGraphQLClient(mux),
 		name:     "care-dot-com",
 	}
 
@@ -218,4 +218,10 @@ func mustWrite(w io.Writer, s string) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+// newTestGraphQLClient returns a githubv4 client whose requests are served directly by handler,
+// without going over an HTTP connection.
+func newTestGraphQLClient(handler http.Handler) *githubv4.Client {
+	return githubv4.NewClient(&http.Client{Transport: localRoundTripper{handler: handler}})
 }


### PR DESCRIPTION
Fixes #3593.

## What I did

Two things, and the second one is the interesting one.

**1. The test config was wrong.** `TestAccGithubActionsEnterprisePermissions` declared `github_enterprise_organization` blocks with `enterprise_slug`, but that resource requires `enterprise_id` (the enterprise node ID) and has no slug attribute. Both subtests failed at plan time before touching the API. Fixed by adding a `data "github_enterprise"` block and passing `enterprise_id = data.github_enterprise.enterprise.id`, matching the pattern already used in `resource_github_enterprise_organization_test.go` and in `examples/resources/enterprise_actions_runner_group/example_1.tf`.

The same configs also passed the org's GraphQL node ID to `enabled_organizations_config.organization_ids`. That attribute is a set of `TypeInt` and the read path populates it from REST `Organization.ID` (database IDs), so a node ID string can never satisfy it. Switched to `.database_id`.

**2. Fixing that first issue surfaced a real provider bug.** This provider deliberately doesn't read after write, and `resourceGithubEnterpriseOrganizationCreate` never set the computed `database_id` - it only set the resource ID. So `database_id` stayed `0` in state until the next refresh, and any same-apply reference to it was broken. That includes the example we ship at `examples/resources/enterprise_actions_runner_group/example_1.tf:17`, which does exactly that. Create now selects `databaseId` from the `createEnterpriseOrganization` mutation payload and writes it to state.
