### PR TITLE
Allow credential-free anonymous acceptance tests

### DIFF
--- a/github/acc_test.go
+++ b/github/acc_test.go
@@ -245,16 +245,18 @@ func getTestMeta(conf *testAccConfig) (*Owner, error) {
 		Owner:        conf.owner,
 	}
 
-	if config.LegacyClient || conf.appID == "" {
-		token, err := getTestToken(conf)
-		if err != nil {
-			return nil, fmt.Errorf("error getting test token: %w", err)
+	if conf.authMode != anonymous {
+		if config.LegacyClient || conf.appID == "" {
+			token, err := getTestToken(conf)
+			if err != nil {
+				return nil, fmt.Errorf("error getting test token: %w", err)
+			}
+			config.Token = token
+		} else {
+			config.AppID = &conf.appID
+			config.AppInstallationID = &conf.appInstallationID
+			config.AppPEM = []byte(conf.appPEM)
 		}
-		config.Token = token
-	} else {
-		config.AppID = &conf.appID
-		config.AppInstallationID = &conf.appInstallationID
-		config.AppPEM = []byte(conf.appPEM)
 	}
 
 	return configureProviderMeta(context.Background(), "test", config)

--- a/github/provider_test.go
+++ b/github/provider_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -17,6 +18,33 @@ func TestProvider(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 	})
+}
+
+func Test_getTestMeta_anonymousDoesNotRequireCredentials(t *testing.T) {
+	t.Parallel()
+
+	baseURL, _, err := getBaseURL(DotComAPIURL)
+	if err != nil {
+		t.Fatalf("parsing base URL: %v", err)
+	}
+
+	for _, legacyClient := range []bool{false, true} {
+		t.Run(fmt.Sprintf("legacy_client_%t", legacyClient), func(t *testing.T) {
+			t.Parallel()
+
+			meta, err := getTestMeta(&testAccConfig{
+				authMode:     anonymous,
+				legacyClient: legacyClient,
+				baseURL:      baseURL,
+			})
+			if err != nil {
+				t.Fatalf("configuring anonymous provider meta: %v", err)
+			}
+			if meta == nil {
+				t.Fatal("anonymous provider meta is nil")
+			}
+		})
+	}
 }
 
 func Test_configureProviderMeta(t *testing.T) {


### PR DESCRIPTION
## Summary
- skip token and GitHub App acquisition when acceptance tests run in anonymous mode
- cover anonymous provider metadata setup for both legacy and new clients

## Motivation
The Terraform Provider Tester live smoke discovered that `TestAccGithubIpRangesDataSource` exited before running because `getTestMeta` requested credentials even when `GH_TEST_AUTH_MODE=anonymous`.

## Validation
- targeted anonymous metadata regression test
- provider non-acceptance suite via `make test`
- `go vet ./github`
- live read-only `TestAccGithubIpRangesDataSource` through Terraform Provider Tester
- live tester smoke using `TPT_PROVIDER_ROOT`

AI-assisted change for human review.