### PR TITLE
fix: tolerate a repository license the API cannot serve

### DIFF
--- a/docs/data-sources/repository.md
+++ b/docs/data-sources/repository.md
@@ -94,7 +94,7 @@ The following arguments are supported:
 
 - `repo_id` - GitHub ID for the repository
 
-- `repository_license` - An Array of GitHub repository licenses. Each `repository_license` block consists of the fields documented below.
+- `repository_license` - An Array of GitHub repository licenses. Each `repository_license` block consists of the fields documented below. The array is empty when the repository has no license, and also when GitHub reports a license for the repository but cannot serve it, which happens for example after a LICENSE file has been added and later removed.
 
 ---
 

--- a/github/acc_helpers_repository_test.go
+++ b/github/acc_helpers_repository_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 )
 
-const licenseFilePath = "LICENSE"
-
 type createTestRepositoryOptionsFunc func(*github.Repository)
 
 func mustCreateTestRepository(t *testing.T, f ...createTestRepositoryOptionsFunc) *github.Repository {
@@ -62,19 +60,19 @@ func mustRenameTestRepository(t *testing.T, repo *github.Repository, newName str
 	}
 }
 
-func mustDeleteTestRepositoryLicense(t *testing.T, repo *github.Repository) {
+func mustDeleteRepositoryFile(t *testing.T, repo *github.Repository, path string) {
 	t.Helper()
 
-	license, _, _, err := testAccConf.meta.v3client.Repositories.GetContents(t.Context(), testAccConf.meta.name, repo.GetName(), licenseFilePath, nil)
+	file, _, _, err := testAccConf.meta.v3client.Repositories.GetContents(t.Context(), testAccConf.meta.name, repo.GetName(), path, nil)
 	if err != nil {
-		t.Fatalf("failed to read %s of test repository %s: %v", licenseFilePath, repo.GetName(), err)
+		t.Fatalf("failed to read %s of test repository %s: %v", path, repo.GetName(), err)
 	}
 
-	_, _, err = testAccConf.meta.v3client.Repositories.DeleteFile(t.Context(), testAccConf.meta.name, repo.GetName(), licenseFilePath, &github.RepositoryContentFileOptions{
-		Message: new(fmt.Sprintf("Remove %s", licenseFilePath)),
-		SHA:     license.SHA,
+	_, _, err = testAccConf.meta.v3client.Repositories.DeleteFile(t.Context(), testAccConf.meta.name, repo.GetName(), path, &github.RepositoryContentFileOptions{
+		Message: new(fmt.Sprintf("Remove %s", path)),
+		SHA:     file.SHA,
 	})
 	if err != nil {
-		t.Fatalf("failed to delete %s of test repository %s: %v", licenseFilePath, repo.GetName(), err)
+		t.Fatalf("failed to delete %s of test repository %s: %v", path, repo.GetName(), err)
 	}
 }

--- a/github/acc_helpers_repository_test.go
+++ b/github/acc_helpers_repository_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 )
 
+const licenseFilePath = "LICENSE"
+
 type createTestRepositoryOptionsFunc func(*github.Repository)
 
 func mustCreateTestRepository(t *testing.T, f ...createTestRepositoryOptionsFunc) *github.Repository {
@@ -57,5 +59,22 @@ func mustRenameTestRepository(t *testing.T, repo *github.Repository, newName str
 	_, _, err := testAccConf.meta.v3client.Repositories.Edit(t.Context(), testAccConf.meta.name, repo.GetName(), &github.Repository{Name: &newName})
 	if err != nil {
 		t.Fatalf("failed to rename test repository %s to %s: %v", repo.GetName(), newName, err)
+	}
+}
+
+func mustDeleteTestRepositoryLicense(t *testing.T, repo *github.Repository) {
+	t.Helper()
+
+	license, _, _, err := testAccConf.meta.v3client.Repositories.GetContents(t.Context(), testAccConf.meta.name, repo.GetName(), licenseFilePath, nil)
+	if err != nil {
+		t.Fatalf("failed to read %s of test repository %s: %v", licenseFilePath, repo.GetName(), err)
+	}
+
+	_, _, err = testAccConf.meta.v3client.Repositories.DeleteFile(t.Context(), testAccConf.meta.name, repo.GetName(), licenseFilePath, &github.RepositoryContentFileOptions{
+		Message: new(fmt.Sprintf("Remove %s", licenseFilePath)),
+		SHA:     license.SHA,
+	})
+	if err != nil {
+		t.Fatalf("failed to delete %s of test repository %s: %v", licenseFilePath, repo.GetName(), err)
 	}
 }

--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -431,11 +431,20 @@ func dataSourceGithubRepositoryRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if repo.License != nil {
-		repository_license, _, err := client.Repositories.License(ctx, owner, repoName)
+		repositoryLicense, _, err := client.Repositories.License(ctx, owner, repoName)
 		if err != nil {
-			return diag.FromErr(err)
+			// A repository can report a license while the license endpoint has nothing to serve,
+			// for example after a LICENSE file is added and later removed, which leaves the
+			// repository classified as `other` with a null license URL. Treat that like a
+			// repository without a license instead of failing the whole read, matching how a
+			// missing repository is handled above.
+			var ghErr *github.ErrorResponse
+			if !errors.As(err, &ghErr) || ghErr.Response.StatusCode != http.StatusNotFound {
+				return diag.FromErr(err)
+			}
+			tflog.Debug(ctx, "Missing GitHub repository license", map[string]any{"owner": owner, "repo": repoName})
 		}
-		if err := d.Set("repository_license", flattenRepositoryLicense(repository_license)); err != nil {
+		if err := d.Set("repository_license", flattenRepositoryLicense(repositoryLicense)); err != nil {
 			return diag.Errorf("error setting repository_license: %v", err)
 		}
 	} else {

--- a/github/data_source_github_repository.go
+++ b/github/data_source_github_repository.go
@@ -438,8 +438,7 @@ func dataSourceGithubRepositoryRead(ctx context.Context, d *schema.ResourceData,
 			// repository classified as `other` with a null license URL. Treat that like a
 			// repository without a license instead of failing the whole read, matching how a
 			// missing repository is handled above.
-			var ghErr *github.ErrorResponse
-			if !errors.As(err, &ghErr) || ghErr.Response.StatusCode != http.StatusNotFound {
+			if ghErr, ok := errors.AsType[*github.ErrorResponse](err); !ok || ghErr.Response.StatusCode != http.StatusNotFound {
 				return diag.FromErr(err)
 			}
 			tflog.Debug(ctx, "Missing GitHub repository license", map[string]any{"owner": owner, "repo": repoName})

--- a/github/data_source_github_repository_test.go
+++ b/github/data_source_github_repository_test.go
@@ -391,7 +391,7 @@ data "github_repository" "test" {
 		repo := mustCreateTestRepository(t, func(repo *github.Repository) {
 			repo.LicenseTemplate = new("mit")
 		})
-		mustDeleteTestRepositoryLicense(t, repo)
+		mustDeleteRepositoryFile(t, repo, "LICENSE")
 
 		config := fmt.Sprintf(`
 data "github_repository" "test" {

--- a/github/data_source_github_repository_test.go
+++ b/github/data_source_github_repository_test.go
@@ -381,6 +381,38 @@ data "github_repository" "test" {
 			},
 		})
 	})
+
+	t.Run("tolerates a license the API cannot serve", func(t *testing.T) {
+		t.Parallel()
+
+		// Removing a LICENSE file leaves the repository classified as `other` with a null license
+		// URL, while the license endpoint starts answering 404. Reading such a repository used to
+		// fail the whole data source. See #2092.
+		repo := mustCreateTestRepository(t, func(repo *github.Repository) {
+			repo.LicenseTemplate = new("mit")
+		})
+		mustDeleteTestRepositoryLicense(t, repo)
+
+		config := fmt.Sprintf(`
+data "github_repository" "test" {
+  name = "%s"
+}
+`, repo.GetName())
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnauthenticated(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("data.github_repository.test", tfjsonpath.New("repo_id"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue("data.github_repository.test", tfjsonpath.New("repository_license"), knownvalue.ListSizeExact(0)),
+					},
+				},
+			},
+		})
+	})
 }
 
 func Test_dataSourceGithubRepositoryReadLicense(t *testing.T) {

--- a/github/data_source_github_repository_test.go
+++ b/github/data_source_github_repository_test.go
@@ -3,8 +3,6 @@ package github
 import (
 	"fmt"
 	"net/http"
-	"net/http/httptest"
-	"regexp"
 	"testing"
 
 	"github.com/google/go-github/v89/github"
@@ -421,19 +419,28 @@ func Test_dataSourceGithubRepositoryReadLicense(t *testing.T) {
 	const (
 		owner    = "test-org"
 		repoName = "test-repo"
+		repoID   = 123456
 	)
 
-	repoResponse := fmt.Sprintf(`{
-		"id": 123456,
-		"name": %q,
-		"full_name": "%s/%s",
-		"license": {"key": "other", "name": "Other", "spdx_id": "NOASSERTION", "url": null}
-	}`, repoName, owner, repoName)
+	repoURI := fmt.Sprintf("/repos/%s/%s", owner, repoName)
+
+	// A repository whose LICENSE file was removed keeps an `other` classification with a null
+	// license URL, while the license endpoint answers 404.
+	repository := &github.Repository{
+		ID:       new(int64(repoID)),
+		Name:     new(repoName),
+		FullName: new(fmt.Sprintf("%s/%s", owner, repoName)),
+		License: &github.License{
+			Key:    new("other"),
+			Name:   new("Other"),
+			SPDXID: new("NOASSERTION"),
+		},
+	}
 
 	for _, tt := range []struct {
 		name              string
 		licenseStatus     int
-		licenseResponse   string
+		licenseBody       any
 		wantErr           bool
 		wantLicenseBlocks int
 	}{
@@ -443,9 +450,16 @@ func Test_dataSourceGithubRepositoryReadLicense(t *testing.T) {
 			wantLicenseBlocks: 0,
 		},
 		{
-			name:              "sets the license when the API serves it",
-			licenseStatus:     http.StatusOK,
-			licenseResponse:   `{"name": "LICENSE", "path": "LICENSE", "license": {"key": "mit", "spdx_id": "MIT"}}`,
+			name:          "sets the license when the API serves it",
+			licenseStatus: http.StatusOK,
+			licenseBody: &github.RepositoryLicense{
+				Name: new("LICENSE"),
+				Path: new("LICENSE"),
+				License: &github.License{
+					Key:    new("mit"),
+					SPDXID: new("MIT"),
+				},
+			},
 			wantLicenseBlocks: 1,
 		},
 		{
@@ -457,33 +471,19 @@ func Test_dataSourceGithubRepositoryReadLicense(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if regexp.MustCompile(`/license$`).MatchString(r.URL.Path) {
-					w.WriteHeader(tt.licenseStatus)
-					_, _ = w.Write([]byte(tt.licenseResponse))
-					return
-				}
-
-				if regexp.MustCompile(`/repos/[^/]+/[^/]+$`).MatchString(r.URL.Path) {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write([]byte(repoResponse))
-					return
-				}
-
-				w.WriteHeader(http.StatusNotFound)
-			}))
+			ts := githubApiMock([]*mockResponse{
+				mustGetTestMockResponse(t, repoURI, http.StatusOK, repository),
+				mustGetTestMockResponse(t, repoURI+"/license", tt.licenseStatus, tt.licenseBody),
+			})
 			t.Cleanup(ts.Close)
-
-			client, err := github.NewClient(github.WithURLs(new(ts.URL+"/"), nil))
-			if err != nil {
-				t.Fatalf("failed to create test client: %s", err)
-			}
 
 			d := schema.TestResourceDataRaw(t, dataSourceGithubRepository().Schema, map[string]any{
 				"full_name": fmt.Sprintf("%s/%s", owner, repoName),
 			})
 
-			diags := dataSourceGithubRepositoryRead(t.Context(), d, &Owner{name: owner, v3client: client})
+			meta := &Owner{name: owner, v3client: mustCreateTestGitHubClient(t, ts.URL)}
+
+			diags := dataSourceGithubRepositoryRead(t.Context(), d, meta)
 
 			if diags.HasError() != tt.wantErr {
 				t.Fatalf("expected error to be %v, got %v", tt.wantErr, diags)
@@ -493,12 +493,12 @@ func Test_dataSourceGithubRepositoryReadLicense(t *testing.T) {
 				return
 			}
 
-			repoID, ok := d.Get("repo_id").(int)
+			gotID, ok := d.Get("repo_id").(int)
 			if !ok {
 				t.Fatalf("expected repo_id to be an int, got %T", d.Get("repo_id"))
 			}
-			if repoID != 123456 {
-				t.Errorf("expected repo_id to be 123456, got %d", repoID)
+			if gotID != repoID {
+				t.Errorf("expected repo_id to be %d, got %d", repoID, gotID)
 			}
 
 			licenses, ok := d.Get("repository_license").([]any)

--- a/github/data_source_github_repository_test.go
+++ b/github/data_source_github_repository_test.go
@@ -493,12 +493,20 @@ func Test_dataSourceGithubRepositoryReadLicense(t *testing.T) {
 				return
 			}
 
-			if got := d.Get("repo_id").(int); got != 123456 {
-				t.Errorf("expected repo_id to be 123456, got %d", got)
+			repoID, ok := d.Get("repo_id").(int)
+			if !ok {
+				t.Fatalf("expected repo_id to be an int, got %T", d.Get("repo_id"))
+			}
+			if repoID != 123456 {
+				t.Errorf("expected repo_id to be 123456, got %d", repoID)
 			}
 
-			if got := len(d.Get("repository_license").([]any)); got != tt.wantLicenseBlocks {
-				t.Errorf("expected %d repository_license blocks, got %d", tt.wantLicenseBlocks, got)
+			licenses, ok := d.Get("repository_license").([]any)
+			if !ok {
+				t.Fatalf("expected repository_license to be a list, got %T", d.Get("repository_license"))
+			}
+			if len(licenses) != tt.wantLicenseBlocks {
+				t.Errorf("expected %d repository_license blocks, got %d", tt.wantLicenseBlocks, len(licenses))
 			}
 		})
 	}

--- a/github/data_source_github_repository_test.go
+++ b/github/data_source_github_repository_test.go
@@ -2,8 +2,13 @@ package github
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
 	"testing"
 
+	"github.com/google/go-github/v89/github"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -376,4 +381,93 @@ data "github_repository" "test" {
 			},
 		})
 	})
+}
+
+func Test_dataSourceGithubRepositoryReadLicense(t *testing.T) {
+	t.Parallel()
+
+	const (
+		owner    = "test-org"
+		repoName = "test-repo"
+	)
+
+	repoResponse := fmt.Sprintf(`{
+		"id": 123456,
+		"name": %q,
+		"full_name": "%s/%s",
+		"license": {"key": "other", "name": "Other", "spdx_id": "NOASSERTION", "url": null}
+	}`, repoName, owner, repoName)
+
+	for _, tt := range []struct {
+		name              string
+		licenseStatus     int
+		licenseResponse   string
+		wantErr           bool
+		wantLicenseBlocks int
+	}{
+		{
+			name:              "tolerates a license the API cannot serve",
+			licenseStatus:     http.StatusNotFound,
+			wantLicenseBlocks: 0,
+		},
+		{
+			name:              "sets the license when the API serves it",
+			licenseStatus:     http.StatusOK,
+			licenseResponse:   `{"name": "LICENSE", "path": "LICENSE", "license": {"key": "mit", "spdx_id": "MIT"}}`,
+			wantLicenseBlocks: 1,
+		},
+		{
+			name:          "returns other license errors",
+			licenseStatus: http.StatusInternalServerError,
+			wantErr:       true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if regexp.MustCompile(`/license$`).MatchString(r.URL.Path) {
+					w.WriteHeader(tt.licenseStatus)
+					_, _ = w.Write([]byte(tt.licenseResponse))
+					return
+				}
+
+				if regexp.MustCompile(`/repos/[^/]+/[^/]+$`).MatchString(r.URL.Path) {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(repoResponse))
+					return
+				}
+
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			t.Cleanup(ts.Close)
+
+			client, err := github.NewClient(github.WithURLs(new(ts.URL+"/"), nil))
+			if err != nil {
+				t.Fatalf("failed to create test client: %s", err)
+			}
+
+			d := schema.TestResourceDataRaw(t, dataSourceGithubRepository().Schema, map[string]any{
+				"full_name": fmt.Sprintf("%s/%s", owner, repoName),
+			})
+
+			diags := dataSourceGithubRepositoryRead(t.Context(), d, &Owner{name: owner, v3client: client})
+
+			if diags.HasError() != tt.wantErr {
+				t.Fatalf("expected error to be %v, got %v", tt.wantErr, diags)
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if got := d.Get("repo_id").(int); got != 123456 {
+				t.Errorf("expected repo_id to be 123456, got %d", got)
+			}
+
+			if got := len(d.Get("repository_license").([]any)); got != tt.wantLicenseBlocks {
+				t.Errorf("expected %d repository_license blocks, got %d", tt.wantLicenseBlocks, got)
+			}
+		})
+	}
 }

--- a/templates/data-sources/repository.md.tmpl
+++ b/templates/data-sources/repository.md.tmpl
@@ -90,7 +90,7 @@ The following arguments are supported:
 
 - `repo_id` - GitHub ID for the repository
 
-- `repository_license` - An Array of GitHub repository licenses. Each `repository_license` block consists of the fields documented below.
+- `repository_license` - An Array of GitHub repository licenses. Each `repository_license` block consists of the fields documented below. The array is empty when the repository has no license, and also when GitHub reports a license for the repository but cannot serve it, which happens for example after a LICENSE file has been added and later removed.
 
 ---
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #2092

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

- Adding a `LICENSE` file to a repository and later removing it leaves it classified as `other` with a null license URL, while `GET /repos/{owner}/{repo}/license` returns 404.
- `data.github_repository` calls the license endpoint whenever `license` is non-null and returns any error as-is, so the whole data source fails and you can't read any other attribute of the repository. Reported in #2092 on versions 5.44.0 through 6.6, usually on repositories people can't easily change.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- A 404 from the license endpoint is treated as no license, the same way a missing repository already is, and the rest of the repository is returned. Other errors still fail the read, so real API problems aren't hidden.
- Kept deliberately narrow. It doesn't work around the GitHub behaviour itself, and it doesn't split the license lookup into its own data source, which came up in the issue but is a bigger change.

### Pull request checklist

- [ ] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

No schema change, so no migration is needed.

An acceptance test creates a repository from a license template, deletes `LICENSE` and reads it back. I confirmed it fails without the fix, with the same error as the issue. A unit test covers the 404, 200 and 500 branches, including that a 500 still fails the read.

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

A repository in this state failed the read before, so nothing could have depended on the old behaviour. `repository_license` is now empty for it, the same as a repository with no license.

----

Co-authored with an AI assistant, as described in the AI use policy in CONTRIBUTING.md. I've reviewed and tested the change myself, including running the acceptance test against a real account and confirming it fails without the fix.
