### PR TITLE
fix: read every default_value type for github_organization_custom_properties

### DIFF
--- a/github/resource_github_organization_custom_properties.go
+++ b/github/resource_github_organization_custom_properties.go
@@ -2,6 +2,8 @@ package github
 
 import (
 	"context"
+	"strconv"
+	"strings"
 
 	"github.com/google/go-github/v89/github"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -92,9 +94,14 @@ func resourceGithubCustomPropertiesCreate(d *schema.ResourceData, meta any) erro
 		PropertyName:  &propertyName,
 		ValueType:     valueType,
 		Required:      &required,
-		DefaultValue:  &defaultValue,
 		Description:   &description,
 		AllowedValues: allowedValuesString,
+	}
+	// Only send a default when one is configured; an empty string is not a
+	// valid default for any value type and is rejected for non-required
+	// properties.
+	if defaultValue != "" {
+		customProperty.DefaultValue = &defaultValue
 	}
 
 	if val, ok := d.GetOk("values_editable_by"); ok {
@@ -121,8 +128,7 @@ func resourceGithubCustomPropertiesRead(d *schema.ResourceData, meta any) error 
 		return err
 	}
 
-	// TODO: Add support for other types of default values
-	defaultValue, _ := customProperty.DefaultValueString()
+	defaultValue := customPropertyDefaultValueString(customProperty)
 
 	d.SetId(*customProperty.PropertyName)
 	_ = d.Set("allowed_values", customProperty.AllowedValues)
@@ -160,4 +166,34 @@ func resourceGithubCustomPropertiesImport(d *schema.ResourceData, meta any) ([]*
 		return nil, err
 	}
 	return []*schema.ResourceData{d}, nil
+}
+
+// customPropertyDefaultValueString renders a custom property's default value as
+// the string stored in the `default_value` attribute, for every value type the
+// API supports. go-github exposes typed accessors per value type; using only
+// DefaultValueString() left true_false and multi_select defaults reading back as
+// "" and produced a permanent plan diff.
+func customPropertyDefaultValueString(cp *github.CustomProperty) string {
+	if cp == nil || cp.DefaultValue == nil {
+		return ""
+	}
+	switch cp.ValueType {
+	case github.PropertyValueTypeTrueFalse:
+		if b, ok := cp.DefaultValueBool(); ok {
+			return strconv.FormatBool(b)
+		}
+	case github.PropertyValueTypeMultiSelect:
+		if vals, ok := cp.DefaultValueStrings(); ok {
+			return strings.Join(vals, ",")
+		}
+	default:
+		if s, ok := cp.DefaultValueString(); ok {
+			return s
+		}
+	}
+	// Fall back to the raw value when the API returns an unexpected shape.
+	if s, ok := cp.DefaultValue.(string); ok {
+		return s
+	}
+	return ""
 }

--- a/github/resource_github_organization_custom_properties_test.go
+++ b/github/resource_github_organization_custom_properties_test.go
@@ -69,6 +69,40 @@ resource "github_organization_custom_properties" "test" {
 		})
 	})
 
+	t.Run("reads back a true_false default_value without drift", func(t *testing.T) {
+		t.Parallel()
+
+		name := fmt.Sprintf("%s%s", testResourcePrefix, acctest.RandString(5))
+
+		config := fmt.Sprintf(`
+resource "github_organization_custom_properties" "test" {
+  description   = "Test Description"
+  default_value = "false"
+  property_name = "%s"
+  required      = true
+  value_type    = "true_false"
+}
+`, name)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { skipUnlessHasOrgs(t) },
+			ProviderFactories: providerFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("github_organization_custom_properties.test", "value_type", "true_false"),
+						resource.TestCheckResourceAttr("github_organization_custom_properties.test", "default_value", "false"),
+					),
+				},
+				{
+					Config:   config,
+					PlanOnly: true,
+				},
+			},
+		})
+	})
+
 	t.Run("create custom property and update them", func(t *testing.T) {
 		t.Parallel()
 

--- a/github/resource_github_organization_custom_properties_unit_test.go
+++ b/github/resource_github_organization_custom_properties_unit_test.go
@@ -1,0 +1,35 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/google/go-github/v89/github"
+)
+
+func TestCustomPropertyDefaultValueString(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		prop *github.CustomProperty
+		want string
+	}{
+		"nil property":            {prop: nil, want: ""},
+		"nil default":             {prop: &github.CustomProperty{ValueType: github.PropertyValueTypeString}, want: ""},
+		"string":                  {prop: &github.CustomProperty{ValueType: github.PropertyValueTypeString, DefaultValue: "dev"}, want: "dev"},
+		"single_select":           {prop: &github.CustomProperty{ValueType: github.PropertyValueTypeSingleSelect, DefaultValue: "gold"}, want: "gold"},
+		"url":                     {prop: &github.CustomProperty{ValueType: github.PropertyValueTypeURL, DefaultValue: "https://example.com"}, want: "https://example.com"},
+		"true_false false":        {prop: &github.CustomProperty{ValueType: github.PropertyValueTypeTrueFalse, DefaultValue: "false"}, want: "false"},
+		"true_false true":         {prop: &github.CustomProperty{ValueType: github.PropertyValueTypeTrueFalse, DefaultValue: "true"}, want: "true"},
+		"multi_select":            {prop: &github.CustomProperty{ValueType: github.PropertyValueTypeMultiSelect, DefaultValue: []any{"a", "b"}}, want: "a,b"},
+		"unexpected shape string": {prop: &github.CustomProperty{ValueType: github.PropertyValueTypeTrueFalse, DefaultValue: "not-a-bool"}, want: "not-a-bool"},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := customPropertyDefaultValueString(tc.prop); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Resolves #3618

----

### Before the change?

- `resourceGithubCustomPropertiesRead` obtains the default via go-github's `DefaultValueString()`, which only returns a value for `string`, `single_select` and `url` property types. For `true_false` (and `multi_select`) properties it returns `("", false)`, so `default_value` is always stored as `""` and every plan shows `+ default_value = "false"` even though GitHub has the default (`GET /orgs/{org}/properties/schema/{name}` returns it, repositories report it). The code carried a `// TODO: Add support for other types of default values`.
- Create/Update always sent `default_value` in the request body — as `""` when unset — which GitHub rejects for non-required properties.

### After the change?

- New `customPropertyDefaultValueString()` renders the default for every value type using go-github's typed accessors (`DefaultValueBool` → `"true"`/`"false"`, `DefaultValueStrings` → comma-joined, `DefaultValueString` otherwise), with a raw-string fallback. `true_false` properties with a default now plan clean after apply.
- `default_value` is only included in the Create/Update body when configured, so `required = false` without a default applies.
- Unit tests for the helper (`go test ./github -run TestCustomPropertyDefaultValueString`), and an acceptance test that creates a `true_false` property with `default_value = "false"` and asserts an empty follow-up plan.

### Pull request checklist

- [ ] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go)) — not needed, no schema change
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features) — no doc change needed; `default_value` docs already describe the intended behaviour

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

Note: `multi_select` defaults are now read back comma-joined into the string attribute (previously `""`). Users who never set `default_value` on a `multi_select` property are unaffected; users who did will see a one-time correction instead of a permanent diff.

----