### PR TITLE
docs: document credential-free anonymous acceptance tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,6 +271,12 @@ export GH_TEST_ADVANCED_SECURITY=
 export GH_TEST_ENTERPRISE_IS_EMU=
 ```
 
+Anonymous acceptance tests do not require `GITHUB_OWNER` or `GITHUB_TOKEN`. For example, the IP ranges data source can be tested without credentials:
+
+```sh
+GH_TEST_AUTH_MODE=anonymous make testacc T=TestAccGithubIpRangesDataSource
+```
+
 ### Example _.vscode/settings.json_ file
 
 To run acceptance tests the `TF_ACC` environment variable must be set. Below is an example `settings.json` file for VSCode that sets this variable and the other necessary environment variables when running tests from the editor.


### PR DESCRIPTION
Follow-up to #3602

**AI-assisted:** This documentation-only PR was prepared with GitHub Copilot and reviewed against the existing acceptance-test configuration.

----

### Before the change?

The environment variable reference lists anonymous acceptance mode, but does not show how to run a credential-free test.

### After the change?

Contributors can copy an anonymous IP-ranges test command and see that `GITHUB_OWNER` and `GITHUB_TOKEN` are not required. This also makes the provider-side requirement used by external acceptance-test harnesses easier to discover.

### Pull request checklist

- [x] Schema migrations are not needed for this documentation-only change.
- [x] Tests are not added because provider behavior is unchanged.
- [x] Docs have been reviewed and updated.

### Verification

- `git diff --check`
- `env -u TF_ACC -u GITHUB_TOKEN -u GITHUB_OWNER -u GH_TEST_AUTH_MODE go test ./github -list '^TestAccGithubIpRangesDataSource$'`

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

----