### PR TITLE
fix: wait for hosted runner public IP provisioning

### DIFF
--- a/docs/resources/actions_hosted_runner.md
+++ b/docs/resources/actions_hosted_runner.md
@@ -74,6 +74,8 @@ The following arguments are supported:
 
 The `timeouts` block allows you to specify timeouts for certain actions:
 
+- `create` - (Defaults to 30 minutes) Used for waiting for the hosted runner to become ready and, when enabled, receive its static public IPs.
+- `update` - (Defaults to 30 minutes) Used for waiting for hosted runner updates to complete and, when enabled, static public IPs to become available.
 - `delete` - (Defaults to 10 minutes) Used for waiting for the hosted runner deletion to complete.
 
 Example:
@@ -91,6 +93,8 @@ resource "github_actions_hosted_runner" "example" {
   runner_group_id = github_actions_runner_group.example.id
 
   timeouts {
+    create = "45m"
+    update = "45m"
     delete = "15m"
   }
 }
@@ -131,7 +135,7 @@ terraform import github_actions_hosted_runner.example 123456
 - The `size` field can be updated to scale the runner up or down as needed.
 - Image IDs for GitHub-owned images are numeric strings (e.g., "2306" for Ubuntu Latest 24.04), not names like "ubuntu-latest".
 - Deletion of hosted runners is asynchronous. The provider will poll for up to 10 minutes (configurable via timeouts) to confirm deletion.
-- Runner creation and updates may take several minutes as GitHub provisions the infrastructure.
+- Runner creation and updates wait until the runner is ready. When static public IPs are enabled, they also wait until the IPs are available.
 - Static public IPs are subject to account limits. Check your organization's limits before enabling.
 
 ## Getting Available Images and Sizes

--- a/examples/resources/actions_hosted_runner/example_3.tf
+++ b/examples/resources/actions_hosted_runner/example_3.tf
@@ -10,6 +10,8 @@ resource "github_actions_hosted_runner" "example" {
   runner_group_id = github_actions_runner_group.example.id
 
   timeouts {
+    create = "45m"
+    update = "45m"
     delete = "15m"
   }
 }

--- a/github/resource_github_actions_hosted_runner.go
+++ b/github/resource_github_actions_hosted_runner.go
@@ -336,7 +336,7 @@ func resourceGithubActionsHostedRunnerCreate(d *schema.ResourceData, meta any) e
 		return fmt.Errorf("failed to get runner ID from response: %+v", runner)
 	}
 
-	if err := waitForRunnerReady(ctx, client, orgName, d.Id(), d.Get("public_ip_enabled").(bool), d.Timeout(schema.TimeoutCreate)); err != nil {
+	if err := waitForRunnerReady(ctx, client, orgName, d.Id(), nil, d.Get("public_ip_enabled").(bool), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return err
 	}
 
@@ -495,14 +495,14 @@ func resourceGithubActionsHostedRunnerUpdate(d *schema.ResourceData, meta any) e
 		}
 	}
 
-	if err := waitForRunnerReady(ctx, client, orgName, runnerID, d.Get("public_ip_enabled").(bool), d.Timeout(schema.TimeoutUpdate)); err != nil {
+	if err := waitForRunnerReady(ctx, client, orgName, runnerID, payload, d.Get("public_ip_enabled").(bool), d.Timeout(schema.TimeoutUpdate)); err != nil {
 		return err
 	}
 
 	return resourceGithubActionsHostedRunnerRead(d, meta)
 }
 
-func waitForRunnerReady(ctx context.Context, client *github.Client, orgName, runnerID string, requirePublicIPs bool, timeout time.Duration) error {
+func waitForRunnerReady(ctx context.Context, client *github.Client, orgName, runnerID string, expectedUpdate map[string]any, requirePublicIPs bool, timeout time.Duration) error {
 	conf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
@@ -525,7 +525,7 @@ func waitForRunnerReady(ctx context.Context, client *github.Client, orgName, run
 				return nil, "", fmt.Errorf("no runner data returned from API")
 			}
 
-			state, err := hostedRunnerProvisioningState(runner, requirePublicIPs)
+			state, err := hostedRunnerProvisioningState(runner, expectedUpdate, requirePublicIPs)
 			return runner, state, err
 		},
 		Timeout:    timeout,
@@ -537,7 +537,7 @@ func waitForRunnerReady(ctx context.Context, client *github.Client, orgName, run
 	return err
 }
 
-func hostedRunnerProvisioningState(runner map[string]any, requirePublicIPs bool) (string, error) {
+func hostedRunnerProvisioningState(runner, expectedUpdate map[string]any, requirePublicIPs bool) (string, error) {
 	status, ok := runner["status"].(string)
 	if !ok {
 		return "", fmt.Errorf("failed to get hosted runner status from response: %+v", runner)
@@ -550,6 +550,10 @@ func hostedRunnerProvisioningState(runner map[string]any, requirePublicIPs bool)
 		return "pending", nil
 	}
 
+	if !hostedRunnerUpdateApplied(runner, expectedUpdate) {
+		return "pending", nil
+	}
+
 	if requirePublicIPs {
 		publicIPs, ok := runner["public_ips"].([]any)
 		if !ok || len(publicIPs) == 0 {
@@ -558,6 +562,62 @@ func hostedRunnerProvisioningState(runner map[string]any, requirePublicIPs bool)
 	}
 
 	return "ready", nil
+}
+
+func hostedRunnerUpdateApplied(runner, expectedUpdate map[string]any) bool {
+	for key, expected := range expectedUpdate {
+		var (
+			actual any
+			ok     bool
+		)
+
+		switch key {
+		case "size":
+			machineSize, found := runner["machine_size_details"].(map[string]any)
+			if !found {
+				return false
+			}
+			actual, ok = machineSize["id"]
+		case "enable_static_ip":
+			actual, ok = runner["public_ip_enabled"]
+		case "image_version":
+			image, found := runner["image_details"].(map[string]any)
+			if !found {
+				return false
+			}
+			actual, ok = image["version"]
+		default:
+			actual, ok = runner[key]
+		}
+
+		if !ok || !hostedRunnerValuesEqual(actual, expected) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func hostedRunnerValuesEqual(actual, expected any) bool {
+	switch expected := expected.(type) {
+	case bool:
+		actual, ok := actual.(bool)
+		return ok && actual == expected
+	case int:
+		switch actual := actual.(type) {
+		case int:
+			return actual == expected
+		case float64:
+			return actual == float64(expected)
+		default:
+			return false
+		}
+	case string:
+		actual, ok := actual.(string)
+		return ok && actual == expected
+	default:
+		return false
+	}
 }
 
 func resourceGithubActionsHostedRunnerDelete(d *schema.ResourceData, meta any) error {

--- a/github/resource_github_actions_hosted_runner.go
+++ b/github/resource_github_actions_hosted_runner.go
@@ -27,6 +27,8 @@ func resourceGithubActionsHostedRunner() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
@@ -334,6 +336,10 @@ func resourceGithubActionsHostedRunnerCreate(d *schema.ResourceData, meta any) e
 		return fmt.Errorf("failed to get runner ID from response: %+v", runner)
 	}
 
+	if err := waitForRunnerReady(ctx, client, orgName, d.Id(), d.Get("public_ip_enabled").(bool), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return err
+	}
+
 	return resourceGithubActionsHostedRunnerRead(d, meta)
 }
 
@@ -489,7 +495,69 @@ func resourceGithubActionsHostedRunnerUpdate(d *schema.ResourceData, meta any) e
 		}
 	}
 
+	if err := waitForRunnerReady(ctx, client, orgName, runnerID, d.Get("public_ip_enabled").(bool), d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return err
+	}
+
 	return resourceGithubActionsHostedRunnerRead(d, meta)
+}
+
+func waitForRunnerReady(ctx context.Context, client *github.Client, orgName, runnerID string, requirePublicIPs bool, timeout time.Duration) error {
+	conf := &retry.StateChangeConf{
+		Pending: []string{"pending"},
+		Target:  []string{"ready"},
+		Refresh: func() (any, string, error) {
+			req, err := client.NewRequest(ctx, "GET", fmt.Sprintf("orgs/%s/actions/hosted-runners/%s", orgName, runnerID), nil)
+			if err != nil {
+				return nil, "", err
+			}
+
+			var runner map[string]any
+			resp, err := client.Do(req, &runner)
+			if resp != nil && resp.StatusCode == http.StatusNotFound {
+				// Keep the result non-nil to avoid StateChangeConf's not-found retry limit.
+				return runnerID, "pending", nil
+			}
+			if err != nil {
+				return nil, "", err
+			}
+			if runner == nil {
+				return nil, "", fmt.Errorf("no runner data returned from API")
+			}
+
+			state, err := hostedRunnerProvisioningState(runner, requirePublicIPs)
+			return runner, state, err
+		},
+		Timeout:    timeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+
+	_, err := conf.WaitForStateContext(ctx)
+	return err
+}
+
+func hostedRunnerProvisioningState(runner map[string]any, requirePublicIPs bool) (string, error) {
+	status, ok := runner["status"].(string)
+	if !ok {
+		return "", fmt.Errorf("failed to get hosted runner status from response: %+v", runner)
+	}
+
+	if status == "Stuck" {
+		return "", fmt.Errorf("hosted runner provisioning is stuck")
+	}
+	if status != "Ready" {
+		return "pending", nil
+	}
+
+	if requirePublicIPs {
+		publicIPs, ok := runner["public_ips"].([]any)
+		if !ok || len(publicIPs) == 0 {
+			return "pending", nil
+		}
+	}
+
+	return "ready", nil
 }
 
 func resourceGithubActionsHostedRunnerDelete(d *schema.ResourceData, meta any) error {

--- a/github/resource_github_actions_hosted_runner.go
+++ b/github/resource_github_actions_hosted_runner.go
@@ -336,7 +336,8 @@ func resourceGithubActionsHostedRunnerCreate(d *schema.ResourceData, meta any) e
 		return fmt.Errorf("failed to get runner ID from response: %+v", runner)
 	}
 
-	if err := waitForRunnerReady(ctx, client, orgName, d.Id(), nil, d.Get("public_ip_enabled").(bool), d.Timeout(schema.TimeoutCreate)); err != nil {
+	publicIPEnabled, _ := d.Get("public_ip_enabled").(bool)
+	if err := waitForRunnerReady(ctx, client, orgName, d.Id(), nil, publicIPEnabled, d.Timeout(schema.TimeoutCreate)); err != nil {
 		return err
 	}
 
@@ -495,7 +496,8 @@ func resourceGithubActionsHostedRunnerUpdate(d *schema.ResourceData, meta any) e
 		}
 	}
 
-	if err := waitForRunnerReady(ctx, client, orgName, runnerID, payload, d.Get("public_ip_enabled").(bool), d.Timeout(schema.TimeoutUpdate)); err != nil {
+	publicIPEnabled, _ := d.Get("public_ip_enabled").(bool)
+	if err := waitForRunnerReady(ctx, client, orgName, runnerID, payload, publicIPEnabled, d.Timeout(schema.TimeoutUpdate)); err != nil {
 		return err
 	}
 
@@ -581,11 +583,16 @@ func hostedRunnerUpdateApplied(runner, expectedUpdate map[string]any) bool {
 		case "enable_static_ip":
 			actual, ok = runner["public_ip_enabled"]
 		case "image_version":
+			// image_details and its version are optional in the API response,
+			// so the requested version can only be verified when reported.
 			image, found := runner["image_details"].(map[string]any)
 			if !found {
-				return false
+				continue
 			}
 			actual, ok = image["version"]
+			if !ok {
+				continue
+			}
 		default:
 			actual, ok = runner[key]
 		}

--- a/github/resource_github_actions_hosted_runner.go
+++ b/github/resource_github_actions_hosted_runner.go
@@ -505,17 +505,16 @@ func resourceGithubActionsHostedRunnerUpdate(d *schema.ResourceData, meta any) e
 }
 
 func waitForRunnerReady(ctx context.Context, client *github.Client, orgName, runnerID string, expectedUpdate map[string]any, requirePublicIPs bool, timeout time.Duration) error {
+	id, err := strconv.ParseInt(runnerID, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid hosted runner ID %q: %w", runnerID, err)
+	}
+
 	conf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (any, string, error) {
-			req, err := client.NewRequest(ctx, "GET", fmt.Sprintf("orgs/%s/actions/hosted-runners/%s", orgName, runnerID), nil)
-			if err != nil {
-				return nil, "", err
-			}
-
-			var runner map[string]any
-			resp, err := client.Do(req, &runner)
+			runner, resp, err := client.Actions.GetHostedRunner(ctx, orgName, id)
 			if resp != nil && resp.StatusCode == http.StatusNotFound {
 				// Keep the result non-nil to avoid StateChangeConf's not-found retry limit.
 				return runnerID, "pending", nil
@@ -535,16 +534,16 @@ func waitForRunnerReady(ctx context.Context, client *github.Client, orgName, run
 		MinTimeout: 5 * time.Second,
 	}
 
-	_, err := conf.WaitForStateContext(ctx)
+	_, err = conf.WaitForStateContext(ctx)
 	return err
 }
 
-func hostedRunnerProvisioningState(runner, expectedUpdate map[string]any, requirePublicIPs bool) (string, error) {
-	status, ok := runner["status"].(string)
-	if !ok {
+func hostedRunnerProvisioningState(runner *github.HostedRunner, expectedUpdate map[string]any, requirePublicIPs bool) (string, error) {
+	if runner.Status == nil {
 		return "", fmt.Errorf("failed to get hosted runner status from response: %+v", runner)
 	}
 
+	status := runner.GetStatus()
 	if status == "Stuck" {
 		return "", fmt.Errorf("hosted runner provisioning is stuck")
 	}
@@ -556,75 +555,54 @@ func hostedRunnerProvisioningState(runner, expectedUpdate map[string]any, requir
 		return "pending", nil
 	}
 
-	if requirePublicIPs {
-		publicIPs, ok := runner["public_ips"].([]any)
-		if !ok || len(publicIPs) == 0 {
-			return "pending", nil
-		}
+	if requirePublicIPs && len(runner.PublicIPs) == 0 {
+		return "pending", nil
 	}
 
 	return "ready", nil
 }
 
-func hostedRunnerUpdateApplied(runner, expectedUpdate map[string]any) bool {
+func hostedRunnerUpdateApplied(runner *github.HostedRunner, expectedUpdate map[string]any) bool {
 	for key, expected := range expectedUpdate {
-		var (
-			actual any
-			ok     bool
-		)
+		applied := false
 
 		switch key {
+		case "name":
+			name, ok := expected.(string)
+			applied = ok && runner.GetName() == name
 		case "size":
-			machineSize, found := runner["machine_size_details"].(map[string]any)
-			if !found {
-				return false
-			}
-			actual, ok = machineSize["id"]
+			size, ok := expected.(string)
+			machineSize := runner.GetMachineSizeDetails()
+			applied = ok && machineSize != nil && machineSize.ID == size
+		case "runner_group_id":
+			groupID, ok := expected.(int)
+			applied = ok && runner.GetRunnerGroupID() == int64(groupID)
+		case "maximum_runners":
+			maxRunners, ok := expected.(int)
+			applied = ok && runner.GetMaximumRunners() == int64(maxRunners)
 		case "enable_static_ip":
-			actual, ok = runner["public_ip_enabled"]
+			enabled, ok := expected.(bool)
+			applied = ok && runner.GetPublicIPEnabled() == enabled
 		case "image_version":
 			// image_details and its version are optional in the API response,
 			// so the requested version can only be verified when reported.
-			image, found := runner["image_details"].(map[string]any)
-			if !found {
+			imageDetails := runner.GetImageDetails()
+			if imageDetails == nil || imageDetails.Version == nil {
 				continue
 			}
-			actual, ok = image["version"]
-			if !ok {
-				continue
-			}
+			version, ok := expected.(string)
+			applied = ok && imageDetails.GetVersion() == version
 		default:
-			actual, ok = runner[key]
+			// Fields the response does not expose cannot be verified.
+			continue
 		}
 
-		if !ok || !hostedRunnerValuesEqual(actual, expected) {
+		if !applied {
 			return false
 		}
 	}
 
 	return true
-}
-
-func hostedRunnerValuesEqual(actual, expected any) bool {
-	switch expected := expected.(type) {
-	case bool:
-		actual, ok := actual.(bool)
-		return ok && actual == expected
-	case int:
-		switch actual := actual.(type) {
-		case int:
-			return actual == expected
-		case float64:
-			return actual == float64(expected)
-		default:
-			return false
-		}
-	case string:
-		actual, ok := actual.(string)
-		return ok && actual == expected
-	default:
-		return false
-	}
 }
 
 func resourceGithubActionsHostedRunnerDelete(d *schema.ResourceData, meta any) error {

--- a/github/resource_github_actions_hosted_runner_test.go
+++ b/github/resource_github_actions_hosted_runner_test.go
@@ -13,6 +13,7 @@ func TestHostedRunnerProvisioningState(t *testing.T) {
 
 	tests := map[string]struct {
 		runner           map[string]any
+		expectedUpdate   map[string]any
 		requirePublicIPs bool
 		wantState        string
 		wantErr          bool
@@ -29,6 +30,42 @@ func TestHostedRunnerProvisioningState(t *testing.T) {
 			runner:           map[string]any{"status": "Ready", "public_ips": []any{}},
 			requirePublicIPs: true,
 			wantState:        "pending",
+		},
+		"ready before update is applied": {
+			runner: map[string]any{
+				"status":               "Ready",
+				"machine_size_details": map[string]any{"id": "2-core"},
+				"public_ip_enabled":    true,
+				"public_ips":           []any{map[string]any{"prefix": "192.0.2.1"}},
+			},
+			expectedUpdate: map[string]any{
+				"size":             "4-core",
+				"enable_static_ip": true,
+			},
+			requirePublicIPs: true,
+			wantState:        "pending",
+		},
+		"ready after update is applied": {
+			runner: map[string]any{
+				"status":               "Ready",
+				"name":                 "updated",
+				"machine_size_details": map[string]any{"id": "4-core"},
+				"runner_group_id":      float64(2),
+				"maximum_runners":      float64(5),
+				"public_ip_enabled":    true,
+				"public_ips":           []any{map[string]any{"prefix": "192.0.2.1"}},
+				"image_details":        map[string]any{"version": "2"},
+			},
+			expectedUpdate: map[string]any{
+				"name":             "updated",
+				"size":             "4-core",
+				"runner_group_id":  2,
+				"maximum_runners":  5,
+				"enable_static_ip": true,
+				"image_version":    "2",
+			},
+			requirePublicIPs: true,
+			wantState:        "ready",
 		},
 		"ready with public IP allocation": {
 			runner: map[string]any{
@@ -52,7 +89,7 @@ func TestHostedRunnerProvisioningState(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := hostedRunnerProvisioningState(test.runner, test.requirePublicIPs)
+			got, err := hostedRunnerProvisioningState(test.runner, test.expectedUpdate, test.requirePublicIPs)
 			if test.wantErr {
 				if err == nil {
 					t.Fatal("expected an error")
@@ -152,10 +189,31 @@ func TestAccGithubActionsHostedRunner(t *testing.T) {
 		})
 	})
 
-	t.Run("creates hosted runner with optional parameters", func(t *testing.T) {
+	t.Run("updates hosted runner to enable public IPs", func(t *testing.T) {
 		t.Parallel()
 
-		config := fmt.Sprintf(`
+		configBefore := fmt.Sprintf(`
+			resource "github_actions_runner_group" "test" {
+				name       = "tf-acc-test-group-%s"
+				visibility = "all"
+			}
+
+			resource "github_actions_hosted_runner" "test" {
+				name = "tf-acc-test-optional-%s"
+
+				image {
+					id     = "2306"
+					source = "github"
+				}
+
+				size              = "2-core"
+				runner_group_id   = github_actions_runner_group.test.id
+				maximum_runners   = 5
+				public_ip_enabled = false
+			}
+		`, randomID, randomID)
+
+		configAfter := fmt.Sprintf(`
 			resource "github_actions_runner_group" "test" {
 				name       = "tf-acc-test-group-%s"
 				visibility = "all"
@@ -176,7 +234,18 @@ func TestAccGithubActionsHostedRunner(t *testing.T) {
 			}
 		`, randomID, randomID)
 
-		check := resource.ComposeTestCheckFunc(
+		checkBefore := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(
+				"github_actions_hosted_runner.test", "public_ip_enabled",
+				"false",
+			),
+			resource.TestCheckResourceAttr(
+				"github_actions_hosted_runner.test", "status",
+				"Ready",
+			),
+		)
+
+		checkAfter := resource.ComposeTestCheckFunc(
 			resource.TestCheckResourceAttr(
 				"github_actions_hosted_runner.test", "name",
 				fmt.Sprintf("tf-acc-test-optional-%s", randomID),
@@ -207,8 +276,12 @@ func TestAccGithubActionsHostedRunner(t *testing.T) {
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
-					Config: config,
-					Check:  check,
+					Config: configBefore,
+					Check:  checkBefore,
+				},
+				{
+					Config: configAfter,
+					Check:  checkAfter,
 				},
 			},
 		})

--- a/github/resource_github_actions_hosted_runner_test.go
+++ b/github/resource_github_actions_hosted_runner_test.go
@@ -8,6 +8,67 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+func TestHostedRunnerProvisioningState(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		runner           map[string]any
+		requirePublicIPs bool
+		wantState        string
+		wantErr          bool
+	}{
+		"provisioning": {
+			runner:    map[string]any{"status": "Provisioning"},
+			wantState: "pending",
+		},
+		"ready without public IP requirement": {
+			runner:    map[string]any{"status": "Ready"},
+			wantState: "ready",
+		},
+		"ready before public IP allocation": {
+			runner:           map[string]any{"status": "Ready", "public_ips": []any{}},
+			requirePublicIPs: true,
+			wantState:        "pending",
+		},
+		"ready with public IP allocation": {
+			runner: map[string]any{
+				"status":     "Ready",
+				"public_ips": []any{map[string]any{"prefix": "192.0.2.1"}},
+			},
+			requirePublicIPs: true,
+			wantState:        "ready",
+		},
+		"stuck": {
+			runner:  map[string]any{"status": "Stuck"},
+			wantErr: true,
+		},
+		"missing status": {
+			runner:  map[string]any{},
+			wantErr: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := hostedRunnerProvisioningState(test.runner, test.requirePublicIPs)
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != test.wantState {
+				t.Fatalf("got state %q, want %q", got, test.wantState)
+			}
+		})
+	}
+}
+
 func TestAccGithubActionsHostedRunner(t *testing.T) {
 	t.Parallel()
 
@@ -55,8 +116,9 @@ func TestAccGithubActionsHostedRunner(t *testing.T) {
 			resource.TestCheckResourceAttrSet(
 				"github_actions_hosted_runner.test", "id",
 			),
-			resource.TestCheckResourceAttrSet(
+			resource.TestCheckResourceAttr(
 				"github_actions_hosted_runner.test", "status",
+				"Ready",
 			),
 			resource.TestCheckResourceAttrSet(
 				"github_actions_hosted_runner.test", "platform",
@@ -130,6 +192,13 @@ func TestAccGithubActionsHostedRunner(t *testing.T) {
 			resource.TestCheckResourceAttr(
 				"github_actions_hosted_runner.test", "public_ip_enabled",
 				"true",
+			),
+			resource.TestCheckResourceAttr(
+				"github_actions_hosted_runner.test", "status",
+				"Ready",
+			),
+			resource.TestCheckResourceAttrSet(
+				"github_actions_hosted_runner.test", "public_ips.0.prefix",
 			),
 		)
 

--- a/github/resource_github_actions_hosted_runner_test.go
+++ b/github/resource_github_actions_hosted_runner_test.go
@@ -7,6 +7,9 @@ import (
 	"github.com/google/go-github/v89/github"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestHostedRunnerProvisioningState(t *testing.T) {
@@ -243,54 +246,27 @@ func TestAccGithubActionsHostedRunner(t *testing.T) {
 			}
 		`, randomID, randomID)
 
-		checkBefore := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(
-				"github_actions_hosted_runner.test", "public_ip_enabled",
-				"false",
-			),
-			resource.TestCheckResourceAttr(
-				"github_actions_hosted_runner.test", "status",
-				"Ready",
-			),
-		)
-
-		checkAfter := resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttr(
-				"github_actions_hosted_runner.test", "name",
-				fmt.Sprintf("tf-acc-test-optional-%s", randomID),
-			),
-			resource.TestCheckResourceAttr(
-				"github_actions_hosted_runner.test", "size",
-				"2-core",
-			),
-			resource.TestCheckResourceAttr(
-				"github_actions_hosted_runner.test", "maximum_runners",
-				"5",
-			),
-			resource.TestCheckResourceAttr(
-				"github_actions_hosted_runner.test", "public_ip_enabled",
-				"true",
-			),
-			resource.TestCheckResourceAttr(
-				"github_actions_hosted_runner.test", "status",
-				"Ready",
-			),
-			resource.TestCheckResourceAttrSet(
-				"github_actions_hosted_runner.test", "public_ips.0.prefix",
-			),
-		)
-
 		resource.Test(t, resource.TestCase{
 			PreCheck:          func() { skipUnlessHasPaidOrgs(t) },
 			ProviderFactories: providerFactories,
 			Steps: []resource.TestStep{
 				{
 					Config: configBefore,
-					Check:  checkBefore,
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_actions_hosted_runner.test", tfjsonpath.New("public_ip_enabled"), knownvalue.Bool(false)),
+						statecheck.ExpectKnownValue("github_actions_hosted_runner.test", tfjsonpath.New("status"), knownvalue.StringExact("Ready")),
+					},
 				},
 				{
 					Config: configAfter,
-					Check:  checkAfter,
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("github_actions_hosted_runner.test", tfjsonpath.New("name"), knownvalue.StringExact(fmt.Sprintf("tf-acc-test-optional-%s", randomID))),
+						statecheck.ExpectKnownValue("github_actions_hosted_runner.test", tfjsonpath.New("size"), knownvalue.StringExact("2-core")),
+						statecheck.ExpectKnownValue("github_actions_hosted_runner.test", tfjsonpath.New("maximum_runners"), knownvalue.Int64Exact(5)),
+						statecheck.ExpectKnownValue("github_actions_hosted_runner.test", tfjsonpath.New("public_ip_enabled"), knownvalue.Bool(true)),
+						statecheck.ExpectKnownValue("github_actions_hosted_runner.test", tfjsonpath.New("status"), knownvalue.StringExact("Ready")),
+						statecheck.ExpectKnownValue("github_actions_hosted_runner.test", tfjsonpath.New("public_ips").AtSliceIndex(0).AtMapKey("prefix"), knownvalue.NotNull()),
+					},
 				},
 			},
 		})

--- a/github/resource_github_actions_hosted_runner_test.go
+++ b/github/resource_github_actions_hosted_runner_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/go-github/v89/github"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -12,31 +13,31 @@ func TestHostedRunnerProvisioningState(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		runner           map[string]any
+		runner           *github.HostedRunner
 		expectedUpdate   map[string]any
 		requirePublicIPs bool
 		wantState        string
 		wantErr          bool
 	}{
 		"provisioning": {
-			runner:    map[string]any{"status": "Provisioning"},
+			runner:    &github.HostedRunner{Status: new("Provisioning")},
 			wantState: "pending",
 		},
 		"ready without public IP requirement": {
-			runner:    map[string]any{"status": "Ready"},
+			runner:    &github.HostedRunner{Status: new("Ready")},
 			wantState: "ready",
 		},
 		"ready before public IP allocation": {
-			runner:           map[string]any{"status": "Ready", "public_ips": []any{}},
+			runner:           &github.HostedRunner{Status: new("Ready")},
 			requirePublicIPs: true,
 			wantState:        "pending",
 		},
 		"ready before update is applied": {
-			runner: map[string]any{
-				"status":               "Ready",
-				"machine_size_details": map[string]any{"id": "2-core"},
-				"public_ip_enabled":    true,
-				"public_ips":           []any{map[string]any{"prefix": "192.0.2.1"}},
+			runner: &github.HostedRunner{
+				Status:             new("Ready"),
+				MachineSizeDetails: &github.HostedRunnerMachineSpec{ID: "2-core"},
+				PublicIPEnabled:    new(true),
+				PublicIPs:          []*github.HostedRunnerPublicIP{{Prefix: "192.0.2.1"}},
 			},
 			expectedUpdate: map[string]any{
 				"size":             "4-core",
@@ -46,15 +47,15 @@ func TestHostedRunnerProvisioningState(t *testing.T) {
 			wantState:        "pending",
 		},
 		"ready after update is applied": {
-			runner: map[string]any{
-				"status":               "Ready",
-				"name":                 "updated",
-				"machine_size_details": map[string]any{"id": "4-core"},
-				"runner_group_id":      float64(2),
-				"maximum_runners":      float64(5),
-				"public_ip_enabled":    true,
-				"public_ips":           []any{map[string]any{"prefix": "192.0.2.1"}},
-				"image_details":        map[string]any{"version": "2"},
+			runner: &github.HostedRunner{
+				Status:             new("Ready"),
+				Name:               new("updated"),
+				MachineSizeDetails: &github.HostedRunnerMachineSpec{ID: "4-core"},
+				RunnerGroupID:      new(int64(2)),
+				MaximumRunners:     new(int64(5)),
+				PublicIPEnabled:    new(true),
+				PublicIPs:          []*github.HostedRunnerPublicIP{{Prefix: "192.0.2.1"}},
+				ImageDetails:       &github.HostedRunnerImageDetail{Version: new("2")},
 			},
 			expectedUpdate: map[string]any{
 				"name":             "updated",
@@ -68,27 +69,27 @@ func TestHostedRunnerProvisioningState(t *testing.T) {
 			wantState:        "ready",
 		},
 		"ready when image version is not reported": {
-			runner: map[string]any{
-				"status":        "Ready",
-				"image_details": map[string]any{"id": "custom"},
+			runner: &github.HostedRunner{
+				Status:       new("Ready"),
+				ImageDetails: &github.HostedRunnerImageDetail{ID: new("custom")},
 			},
 			expectedUpdate: map[string]any{"image_version": "2"},
 			wantState:      "ready",
 		},
 		"ready with public IP allocation": {
-			runner: map[string]any{
-				"status":     "Ready",
-				"public_ips": []any{map[string]any{"prefix": "192.0.2.1"}},
+			runner: &github.HostedRunner{
+				Status:    new("Ready"),
+				PublicIPs: []*github.HostedRunnerPublicIP{{Prefix: "192.0.2.1"}},
 			},
 			requirePublicIPs: true,
 			wantState:        "ready",
 		},
 		"stuck": {
-			runner:  map[string]any{"status": "Stuck"},
+			runner:  &github.HostedRunner{Status: new("Stuck")},
 			wantErr: true,
 		},
 		"missing status": {
-			runner:  map[string]any{},
+			runner:  &github.HostedRunner{},
 			wantErr: true,
 		},
 	}

--- a/github/resource_github_actions_hosted_runner_test.go
+++ b/github/resource_github_actions_hosted_runner_test.go
@@ -67,6 +67,14 @@ func TestHostedRunnerProvisioningState(t *testing.T) {
 			requirePublicIPs: true,
 			wantState:        "ready",
 		},
+		"ready when image version is not reported": {
+			runner: map[string]any{
+				"status":        "Ready",
+				"image_details": map[string]any{"id": "custom"},
+			},
+			expectedUpdate: map[string]any{"image_version": "2"},
+			wantState:      "ready",
+		},
 		"ready with public IP allocation": {
 			runner: map[string]any{
 				"status":     "Ready",

--- a/templates/resources/actions_hosted_runner.md.tmpl
+++ b/templates/resources/actions_hosted_runner.md.tmpl
@@ -38,6 +38,8 @@ The following arguments are supported:
 
 The `timeouts` block allows you to specify timeouts for certain actions:
 
+- `create` - (Defaults to 30 minutes) Used for waiting for the hosted runner to become ready and, when enabled, receive its static public IPs.
+- `update` - (Defaults to 30 minutes) Used for waiting for hosted runner updates to complete and, when enabled, static public IPs to become available.
 - `delete` - (Defaults to 10 minutes) Used for waiting for the hosted runner deletion to complete.
 
 Example:
@@ -79,7 +81,7 @@ terraform import github_actions_hosted_runner.example 123456
 - The `size` field can be updated to scale the runner up or down as needed.
 - Image IDs for GitHub-owned images are numeric strings (e.g., "2306" for Ubuntu Latest 24.04), not names like "ubuntu-latest".
 - Deletion of hosted runners is asynchronous. The provider will poll for up to 10 minutes (configurable via timeouts) to confirm deletion.
-- Runner creation and updates may take several minutes as GitHub provisions the infrastructure.
+- Runner creation and updates wait until the runner is ready. When static public IPs are enabled, they also wait until the IPs are available.
 - Static public IPs are subject to account limits. Check your organization's limits before enabling.
 
 ## Getting Available Images and Sizes


### PR DESCRIPTION
Resolves #3626

----

### Before the change?

`github_actions_hosted_runner` returned after a single read following create or update. GitHub provisions hosted runners asynchronously, so Terraform could finish while the runner was still provisioning and persist an empty `public_ips` value.

### After the change?

Create and update wait until the runner is ready. When static public IPs are enabled, they also wait until GitHub returns the allocated IPs, so dependent outputs are populated by the completed operation.

The implementation was prepared with Copilot assistance. Tests were run locally

### Pull request checklist

- [x] Schema migrations have been created if needed (not needed; the state schema shape is unchanged)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
