### PR TITLE
feat: add write-only secrets attributes for webhook resources

### DIFF
--- a/docs/resources/organization_webhook.md
+++ b/docs/resources/organization_webhook.md
@@ -11,13 +11,21 @@ This resource allows you to create and manage webhooks for GitHub organization.
 ## Example Usage
 
 ```terraform
+variable "webhook_secret" {
+  type      = string
+  sensitive = true
+  ephemeral = true
+}
+
 resource "github_organization_webhook" "foo" {
   name = "web"
 
   configuration {
-    url          = "https://google.de/"
-    content_type = "form"
-    insecure_ssl = false
+    url               = "https://google.de/"
+    content_type      = "form"
+    insecure_ssl      = false
+    secret_wo         = var.webhook_secret
+    secret_wo_version = 1
   }
 
   active = false
@@ -32,11 +40,25 @@ The following arguments are supported:
 
 - `events` - (Required) A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/)
 
-- `configuration` - (Required) key/value pair of configuration for this webhook. Available keys are `url`, `content_type`, `secret` and `insecure_ssl`.
+- `configuration` - (Required) Configuration block for this webhook. Available arguments are detailed below.
 
 - `active` - (Optional) Indicate of the webhook should receive events. Defaults to `true`.
 
 - `name` - (Optional) The type of the webhook. `web` is the default and the only option.
+
+### configuration
+
+- `url` - (Required) The URL of the webhook.
+
+- `content_type` - (Optional) The content type for the payload. Valid values are either `form` or `json`.
+
+- `secret` - (Optional) The shared secret for the webhook. Although sensitive, this legacy argument is stored in Terraform plan and state. It conflicts with `secret_wo`.
+
+- `secret_wo` - (Optional, Write-only) The shared secret for the webhook. Requires Terraform 1.11 or later and must be paired with `secret_wo_version`. It accepts ephemeral or ordinary values and is omitted from Terraform plan and state. It conflicts with `secret`.
+
+- `secret_wo_version` - (Optional) Version of `secret_wo`. It must be at least `1` and must be paired with `secret_wo`. Change this value whenever the secret is rotated; changing the secret value alone does not trigger an update.
+
+- `insecure_ssl` - (Optional) Insecure SSL boolean toggle. Defaults to `false`.
 
 ## Attributes Reference
 
@@ -52,4 +74,4 @@ Organization webhooks can be imported using the `id` of the webhook. The `id` of
 terraform import github_organization_webhook.terraform 123456789
 ```
 
-If secret is populated in the webhook's configuration, the value will be imported as "********".
+Webhook secrets cannot be recovered during import, so neither `secret` nor `secret_wo` is populated in imported state. To establish a write-only secret after import, configure `secret_wo` and `secret_wo_version`; Terraform updates the existing webhook in place.

--- a/docs/resources/organization_webhook.md
+++ b/docs/resources/organization_webhook.md
@@ -52,9 +52,9 @@ The following arguments are supported:
 
 - `content_type` - (Optional) The content type for the payload. Valid values are either `form` or `json`.
 
-- `secret` - (Optional) The shared secret for the webhook. Although sensitive, this legacy argument is stored in Terraform plan and state. It conflicts with `secret_wo`.
+- `secret` - (Optional) The shared secret for the webhook. It conflicts with `secret_wo`.
 
-- `secret_wo` - (Optional, Write-only) The shared secret for the webhook. Requires Terraform 1.11 or later and must be paired with `secret_wo_version`. It accepts ephemeral or ordinary values and is omitted from Terraform plan and state. It conflicts with `secret`.
+- `secret_wo` - (Optional, Write-only) The shared secret for the webhook (write-only variant). Requires Terraform 1.11 or later and must be paired with `secret_wo_version`. It accepts ephemeral or ordinary values and is omitted from Terraform plan and state. It conflicts with `secret`.
 
 - `secret_wo_version` - (Optional) Version of `secret_wo`. It must be at least `1` and must be paired with `secret_wo`. Change this value whenever the secret is rotated; changing the secret value alone does not trigger an update.
 

--- a/docs/resources/repository_webhook.md
+++ b/docs/resources/repository_webhook.md
@@ -62,9 +62,9 @@ The following arguments are supported:
 
 - `content_type` - (Required) The content type for the payload. Valid values are either `form` or `json`.
 
-- `secret` - (Optional) The shared secret for the webhook. Although sensitive, this legacy argument is stored in Terraform plan and state. It conflicts with `secret_wo`. [See API documentation](https://developer.github.com/v3/repos/hooks/#create-a-hook).
+- `secret` - (Optional) The shared secret for the webhook. It conflicts with `secret_wo`. [See API documentation](https://developer.github.com/v3/repos/hooks/#create-a-hook).
 
-- `secret_wo` - (Optional, Write-only) The shared secret for the webhook. Requires Terraform 1.11 or later and must be paired with `secret_wo_version`. It accepts ephemeral or ordinary values and is omitted from Terraform plan and state. It conflicts with `secret`.
+- `secret_wo` - (Optional, Write-only) The shared secret for the webhook (write-only variant). Requires Terraform 1.11 or later and must be paired with `secret_wo_version`. It accepts ephemeral or ordinary values and is omitted from Terraform plan and state. It conflicts with `secret`.
 
 - `secret_wo_version` - (Optional) Version of `secret_wo`. It must be at least `1` and must be paired with `secret_wo`. Change this value whenever the secret is rotated; changing the secret value alone does not trigger an update.
 

--- a/docs/resources/repository_webhook.md
+++ b/docs/resources/repository_webhook.md
@@ -13,6 +13,12 @@ This resource allows you to create and manage webhooks for repositories within y
 ## Example Usage
 
 ```terraform
+variable "webhook_secret" {
+  type      = string
+  sensitive = true
+  ephemeral = true
+}
+
 resource "github_repository" "repo" {
   name         = "foo"
   description  = "Terraform acceptance tests"
@@ -25,9 +31,11 @@ resource "github_repository_webhook" "foo" {
   repository = github_repository.repo.name
 
   configuration {
-    url          = "https://google.de/"
-    content_type = "form"
-    insecure_ssl = false
+    url               = "https://google.de/"
+    content_type      = "form"
+    insecure_ssl      = false
+    secret_wo         = var.webhook_secret
+    secret_wo_version = 1
   }
 
   active = false
@@ -54,7 +62,11 @@ The following arguments are supported:
 
 - `content_type` - (Required) The content type for the payload. Valid values are either `form` or `json`.
 
-- `secret` - (Optional) The shared secret for the webhook. [See API documentation](https://developer.github.com/v3/repos/hooks/#create-a-hook).
+- `secret` - (Optional) The shared secret for the webhook. Although sensitive, this legacy argument is stored in Terraform plan and state. It conflicts with `secret_wo`. [See API documentation](https://developer.github.com/v3/repos/hooks/#create-a-hook).
+
+- `secret_wo` - (Optional, Write-only) The shared secret for the webhook. Requires Terraform 1.11 or later and must be paired with `secret_wo_version`. It accepts ephemeral or ordinary values and is omitted from Terraform plan and state. It conflicts with `secret`.
+
+- `secret_wo_version` - (Optional) Version of `secret_wo`. It must be at least `1` and must be paired with `secret_wo`. Change this value whenever the secret is rotated; changing the secret value alone does not trigger an update.
 
 - `insecure_ssl` - (Optional) Insecure SSL boolean toggle. Defaults to `false`.
 
@@ -74,4 +86,4 @@ Importing uses the name of the repository, as well as the ID of the webhook, e.g
 terraform import github_repository_webhook.terraform terraform/11235813
 ```
 
-If secret is populated in the webhook's configuration, the value will be imported as "********".
+Webhook secrets cannot be recovered during import, so neither `secret` nor `secret_wo` is populated in imported state. To establish a write-only secret after import, configure `secret_wo` and `secret_wo_version`; Terraform updates the existing webhook in place.

--- a/examples/resources/organization_webhook/example_1.tf
+++ b/examples/resources/organization_webhook/example_1.tf
@@ -1,10 +1,18 @@
+variable "webhook_secret" {
+  type      = string
+  sensitive = true
+  ephemeral = true
+}
+
 resource "github_organization_webhook" "foo" {
   name = "web"
 
   configuration {
-    url          = "https://google.de/"
-    content_type = "form"
-    insecure_ssl = false
+    url               = "https://google.de/"
+    content_type      = "form"
+    insecure_ssl      = false
+    secret_wo         = var.webhook_secret
+    secret_wo_version = 1
   }
 
   active = false

--- a/examples/resources/repository_webhook/example_1.tf
+++ b/examples/resources/repository_webhook/example_1.tf
@@ -1,3 +1,9 @@
+variable "webhook_secret" {
+  type      = string
+  sensitive = true
+  ephemeral = true
+}
+
 resource "github_repository" "repo" {
   name         = "foo"
   description  = "Terraform acceptance tests"
@@ -10,9 +16,11 @@ resource "github_repository_webhook" "foo" {
   repository = github_repository.repo.name
 
   configuration {
-    url          = "https://google.de/"
-    content_type = "form"
-    insecure_ssl = false
+    url               = "https://google.de/"
+    content_type      = "form"
+    insecure_ssl      = false
+    secret_wo         = var.webhook_secret
+    secret_wo_version = 1
   }
 
   active = false

--- a/github/resource_github_organization_webhook.go
+++ b/github/resource_github_organization_webhook.go
@@ -18,6 +18,9 @@ func resourceGithubOrganizationWebhook() *schema.Resource {
 		ReadContext:   resourceGithubOrganizationWebhookRead,
 		UpdateContext: resourceGithubOrganizationWebhookUpdate,
 		DeleteContext: resourceGithubOrganizationWebhookDelete,
+		ValidateRawResourceConfigFuncs: []schema.ValidateRawResourceConfigFunc{
+			preferWriteOnlyWebhookSecretValidator(),
+		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -81,6 +84,9 @@ func resourceGithubOrganizationWebhookObject(d *schema.ResourceData) *github.Hoo
 	config := d.Get("configuration").([]any)
 	if len(config) > 0 {
 		hook.Config = webhookConfigFromInterface(config[0].(map[string]any))
+		if secret, configured := d.GetOk("configuration.0.secret"); configured {
+			hook.Config.Secret = new(secret.(string))
+		}
 	}
 
 	return hook
@@ -96,23 +102,22 @@ func resourceGithubOrganizationWebhookCreate(ctx context.Context, d *schema.Reso
 
 	orgName := meta.(*Owner).name
 	webhookObj := resourceGithubOrganizationWebhookObject(d)
+	if _, configured := d.GetOk("configuration.0.secret_wo_version"); configured {
+		secret, diags := readRawWriteOnlyString(d, webhookSecretWriteOnlyPath)
+		if diags.HasError() {
+			return diags
+		}
+		if webhookObj.Config == nil {
+			webhookObj.Config = &github.HookConfig{}
+		}
+		webhookObj.Config.Secret = new(secret)
+	}
 
 	hook, _, err := client.Organizations.CreateHook(ctx, orgName, webhookObj)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	d.SetId(strconv.FormatInt(hook.GetID(), 10))
-
-	// GitHub returns the secret as a string of 8 astrisks "********"
-	// We would prefer to store the real secret in state, so we'll
-	// write the configuration secret in state from our request to GitHub
-	if hook.Config.Secret != nil {
-		hook.Config.Secret = webhookObj.Config.Secret
-	}
-
-	if err = d.Set("configuration", interfaceFromWebhookConfig(hook.Config)); err != nil {
-		return diag.FromErr(err)
-	}
 
 	return resourceGithubOrganizationWebhookRead(ctx, d, meta)
 }
@@ -164,19 +169,7 @@ func resourceGithubOrganizationWebhookRead(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 
-	// GitHub returns the secret as a string of 8 astrisks "********"
-	// We would prefer to store the real secret in state, so we'll
-	// write the configuration secret in state from what we get from
-	// ResourceData
-	if len(d.Get("configuration").([]any)) > 0 {
-		currentSecret := d.Get("configuration").([]any)[0].(map[string]any)["secret"]
-
-		if hook.Config.Secret != nil {
-			hook.Config.Secret = new(currentSecret.(string))
-		}
-	}
-
-	if err = d.Set("configuration", interfaceFromWebhookConfig(hook.Config)); err != nil {
+	if err = d.Set("configuration", interfaceFromWebhookConfigPreservingState(hook.Config, d)); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -193,6 +186,21 @@ func resourceGithubOrganizationWebhookUpdate(ctx context.Context, d *schema.Reso
 
 	orgName := meta.(*Owner).name
 	webhookObj := resourceGithubOrganizationWebhookObject(d)
+	if d.HasChange("configuration.0.secret") {
+		if _, configured := d.GetOk("configuration.0.secret"); !configured && webhookObj.Config != nil {
+			webhookObj.Config.Secret = new("")
+		}
+	}
+	if _, configured := d.GetOk("configuration.0.secret_wo_version"); d.HasChange("configuration.0.secret_wo_version") && configured {
+		secret, diags := readRawWriteOnlyString(d, webhookSecretWriteOnlyPath)
+		if diags.HasError() {
+			return diags
+		}
+		if webhookObj.Config == nil {
+			webhookObj.Config = &github.HookConfig{}
+		}
+		webhookObj.Config.Secret = new(secret)
+	}
 	hookID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
 		return diag.FromErr(unconvertibleIdErr(d.Id(), err))
@@ -250,14 +258,14 @@ func webhookConfigFromInterface(config map[string]any) *github.HookConfig {
 			}
 		}
 	}
-	if config["secret"] != nil {
-		hookConfig.Secret = new(config["secret"].(string))
-	}
 	return hookConfig
 }
 
 func interfaceFromWebhookConfig(config *github.HookConfig) []any {
 	cfg := map[string]any{}
+	if config == nil {
+		return []any{cfg}
+	}
 	if config.URL != nil {
 		cfg["url"] = *config.URL
 	}
@@ -271,4 +279,20 @@ func interfaceFromWebhookConfig(config *github.HookConfig) []any {
 		cfg["secret"] = *config.Secret
 	}
 	return []any{cfg}
+}
+
+func interfaceFromWebhookConfigPreservingState(config *github.HookConfig, d *schema.ResourceData) []any {
+	flattened := interfaceFromWebhookConfig(config)
+	cfg := flattened[0].(map[string]any)
+
+	if secret, configured := d.GetOk("configuration.0.secret"); configured {
+		cfg["secret"] = secret.(string)
+	} else {
+		delete(cfg, "secret")
+	}
+	if version, configured := d.GetOk("configuration.0.secret_wo_version"); configured {
+		cfg["secret_wo_version"] = version.(int)
+	}
+
+	return flattened
 }

--- a/github/resource_github_repository_webhook.go
+++ b/github/resource_github_repository_webhook.go
@@ -20,6 +20,9 @@ func resourceGithubRepositoryWebhook() *schema.Resource {
 		ReadContext:   resourceGithubRepositoryWebhookRead,
 		UpdateContext: resourceGithubRepositoryWebhookUpdate,
 		DeleteContext: resourceGithubRepositoryWebhookDelete,
+		ValidateRawResourceConfigFuncs: []schema.ValidateRawResourceConfigFunc{
+			preferWriteOnlyWebhookSecretValidator(),
+		},
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				parts := strings.Split(d.Id(), "/")
@@ -98,9 +101,12 @@ func resourceGithubRepositoryWebhookObject(d *schema.ResourceData) *github.Hook 
 		Active: &active,
 	}
 
-	config := d.Get("configuration").([]any)[0].(map[string]any)
+	config := d.Get("configuration").([]any)
 	if len(config) > 0 {
-		hook.Config = webhookConfigFromInterface(config)
+		hook.Config = webhookConfigFromInterface(config[0].(map[string]any))
+		if secret, configured := d.GetOk("configuration.0.secret"); configured {
+			hook.Config.Secret = new(secret.(string))
+		}
 	}
 
 	return hook
@@ -112,23 +118,22 @@ func resourceGithubRepositoryWebhookCreate(ctx context.Context, d *schema.Resour
 	owner := meta.(*Owner).name
 	repoName := d.Get("repository").(string)
 	hk := resourceGithubRepositoryWebhookObject(d)
+	if _, configured := d.GetOk("configuration.0.secret_wo_version"); configured {
+		secret, diags := readRawWriteOnlyString(d, webhookSecretWriteOnlyPath)
+		if diags.HasError() {
+			return diags
+		}
+		if hk.Config == nil {
+			hk.Config = &github.HookConfig{}
+		}
+		hk.Config.Secret = new(secret)
+	}
 
 	hook, _, err := client.Repositories.CreateHook(ctx, owner, repoName, hk)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	d.SetId(strconv.FormatInt(hook.GetID(), 10))
-
-	// GitHub returns the secret as a string of 8 astrisks "********"
-	// We would prefer to store the real secret in state, so we'll
-	// write the configuration secret in state from our request to GitHub
-	if hook.Config.Secret != nil {
-		hook.Config.Secret = hk.Config.Secret
-	}
-
-	if err = d.Set("configuration", interfaceFromWebhookConfig(hook.Config)); err != nil {
-		return diag.FromErr(err)
-	}
 
 	return resourceGithubRepositoryWebhookRead(ctx, d, meta)
 }
@@ -172,19 +177,7 @@ func resourceGithubRepositoryWebhookRead(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 
-	// GitHub returns the secret as a string of 8 astrisks "********"
-	// We would prefer to store the real secret in state, so we'll
-	// write the configuration secret in state from what we get from
-	// ResourceData
-	if len(d.Get("configuration").([]any)) > 0 {
-		currentSecret := d.Get("configuration").([]any)[0].(map[string]any)["secret"]
-
-		if hook.Config.Secret != nil {
-			hook.Config.Secret = new(currentSecret.(string))
-		}
-	}
-
-	if err = d.Set("configuration", interfaceFromWebhookConfig(hook.Config)); err != nil {
+	if err = d.Set("configuration", interfaceFromWebhookConfigPreservingState(hook.Config, d)); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -197,6 +190,21 @@ func resourceGithubRepositoryWebhookUpdate(ctx context.Context, d *schema.Resour
 	owner := meta.(*Owner).name
 	repoName := d.Get("repository").(string)
 	hk := resourceGithubRepositoryWebhookObject(d)
+	if d.HasChange("configuration.0.secret") {
+		if _, configured := d.GetOk("configuration.0.secret"); !configured && hk.Config != nil {
+			hk.Config.Secret = new("")
+		}
+	}
+	if _, configured := d.GetOk("configuration.0.secret_wo_version"); d.HasChange("configuration.0.secret_wo_version") && configured {
+		secret, diags := readRawWriteOnlyString(d, webhookSecretWriteOnlyPath)
+		if diags.HasError() {
+			return diags
+		}
+		if hk.Config == nil {
+			hk.Config = &github.HookConfig{}
+		}
+		hk.Config.Secret = new(secret)
+	}
 	hookID, err := strconv.ParseInt(d.Id(), 10, 64)
 	if err != nil {
 		return diag.FromErr(unconvertibleIdErr(d.Id(), err))

--- a/github/resource_github_webhook_configuration_test.go
+++ b/github/resource_github_webhook_configuration_test.go
@@ -1,0 +1,125 @@
+package github
+
+import (
+	"encoding/json"
+	"maps"
+	"testing"
+
+	gh "github.com/google/go-github/v89/github"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestWebhookObjectsOmitWriteOnlySecret(t *testing.T) {
+	t.Parallel()
+
+	for name, resource := range map[string]struct {
+		schema map[string]*schema.Schema
+		object func(*schema.ResourceData) *gh.Hook
+		extra  map[string]any
+	}{
+		"repository": {
+			schema: resourceGithubRepositoryWebhook().Schema,
+			object: resourceGithubRepositoryWebhookObject,
+			extra:  map[string]any{"repository": "example"},
+		},
+		"organization": {
+			schema: resourceGithubOrganizationWebhook().Schema,
+			object: resourceGithubOrganizationWebhookObject,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := map[string]any{
+				"events": []any{"push"},
+				"configuration": []any{map[string]any{
+					"url":               "https://example.test/hook",
+					"secret_wo_version": 1,
+				}},
+			}
+			maps.Copy(raw, resource.extra)
+			d := schema.TestResourceDataRaw(t, resource.schema, raw)
+			hook := resource.object(d)
+			if hook.Config != nil && hook.Config.Secret != nil {
+				t.Fatal("ordinary webhook expansion included a secret")
+			}
+
+			payload, err := json.Marshal(hook)
+			if err != nil {
+				t.Fatalf("marshalling webhook request: %v", err)
+			}
+			var sanitized struct {
+				Config map[string]json.RawMessage `json:"config"`
+			}
+			if err := json.Unmarshal(payload, &sanitized); err != nil {
+				t.Fatalf("parsing webhook request: %v", err)
+			}
+			if _, exists := sanitized.Config["secret"]; exists {
+				t.Fatal("serialized webhook request included a secret field")
+			}
+		})
+	}
+}
+
+func TestInterfaceFromWebhookConfigPreservingState(t *testing.T) {
+	t.Parallel()
+
+	masked := "********"
+	remote := &gh.HookConfig{
+		URL:         new("https://example.test/hook"),
+		ContentType: new("json"),
+		InsecureSSL: new("0"),
+		Secret:      &masked,
+	}
+
+	for name, test := range map[string]struct {
+		configuration map[string]any
+		wantSecret    string
+		wantVersion   int
+	}{
+		"legacy secret": {
+			configuration: map[string]any{"url": "https://example.test/hook", "secret": "legacy-secret"},
+			wantSecret:    "legacy-secret",
+		},
+		"write-only secret": {
+			configuration: map[string]any{"url": "https://example.test/hook", "secret_wo_version": 7},
+			wantVersion:   7,
+		},
+		"import": {
+			configuration: map[string]any{"url": "https://example.test/hook"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			d := schema.TestResourceDataRaw(t, resourceGithubRepositoryWebhook().Schema, map[string]any{
+				"repository":    "example",
+				"events":        []any{"push"},
+				"configuration": []any{test.configuration},
+			})
+			flattened := interfaceFromWebhookConfigPreservingState(remote, d)[0].(map[string]any)
+			if got, ok := flattened["secret"]; test.wantSecret == "" && ok {
+				t.Fatalf("masked remote secret was flattened into state: value length %d", len(got.(string)))
+			} else if test.wantSecret != "" && got != test.wantSecret {
+				t.Fatalf("legacy secret was not preserved")
+			}
+			if got, ok := flattened["secret_wo_version"]; test.wantVersion == 0 && ok {
+				t.Fatalf("unexpected write-only version in state: %v", got)
+			} else if test.wantVersion != 0 && got != test.wantVersion {
+				t.Fatalf("write-only version = %v, want %d", got, test.wantVersion)
+			}
+			if _, ok := flattened["secret_wo"]; ok {
+				t.Fatal("write-only secret was flattened into state")
+			}
+		})
+	}
+}
+
+func TestInterfaceFromNilWebhookConfig(t *testing.T) {
+	t.Parallel()
+
+	flattened := interfaceFromWebhookConfig(nil)
+	if len(flattened) != 1 || flattened[0] == nil {
+		t.Fatalf("nil webhook configuration was not handled safely: %#v", flattened)
+	}
+}

--- a/github/schema_webhook_configuration.go
+++ b/github/schema_webhook_configuration.go
@@ -1,8 +1,18 @@
 package github
 
 import (
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
+
+func preferWriteOnlyWebhookSecretValidator() schema.ValidateRawResourceConfigFunc {
+	configurationItem := cty.UnknownVal(cty.Number)
+	return validation.PreferWriteOnlyAttribute(
+		cty.GetAttrPath("configuration").Index(configurationItem).GetAttr("secret"),
+		cty.GetAttrPath("configuration").Index(configurationItem).GetAttr("secret_wo"),
+	)
+}
 
 func webhookConfigurationSchema() *schema.Schema {
 	return &schema.Schema{
@@ -24,10 +34,27 @@ func webhookConfigurationSchema() *schema.Schema {
 					Description: "The content type for the payload. Valid values are either 'form' or 'json'.",
 				},
 				"secret": {
-					Type:        schema.TypeString,
-					Optional:    true,
-					Sensitive:   true,
-					Description: "The shared secret for the webhook",
+					Type:          schema.TypeString,
+					Optional:      true,
+					Sensitive:     true,
+					ConflictsWith: []string{"configuration.0.secret_wo"},
+					Description:   "The shared secret for the webhook",
+				},
+				"secret_wo": {
+					Type:          schema.TypeString,
+					Optional:      true,
+					Sensitive:     true,
+					WriteOnly:     true,
+					ConflictsWith: []string{"configuration.0.secret"},
+					RequiredWith:  []string{"configuration.0.secret_wo_version"},
+					Description:   "Write-only shared secret for the webhook. Requires Terraform 1.11 or later.",
+				},
+				"secret_wo_version": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					RequiredWith: []string{"configuration.0.secret_wo"},
+					ValidateFunc: validation.IntAtLeast(1),
+					Description:  "Version of the write-only webhook secret. Change this value to rotate the secret.",
 				},
 				"insecure_ssl": {
 					Type:        schema.TypeBool,

--- a/github/schema_webhook_configuration_test.go
+++ b/github/schema_webhook_configuration_test.go
@@ -1,0 +1,125 @@
+package github
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestWebhookWriteOnlySecretSchema(t *testing.T) {
+	t.Parallel()
+
+	for name, resource := range map[string]*schema.Resource{
+		"repository":   resourceGithubRepositoryWebhook(),
+		"organization": resourceGithubOrganizationWebhook(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			configuration := resource.Schema["configuration"].Elem.(*schema.Resource).Schema
+			secret := configuration["secret"]
+			secretWO := configuration["secret_wo"]
+			version := configuration["secret_wo_version"]
+
+			if !secretWO.Optional || !secretWO.Sensitive || !secretWO.WriteOnly {
+				t.Fatalf("secret_wo must be optional, sensitive, and write-only: %#v", secretWO)
+			}
+			if secretWO.Computed || secretWO.ForceNew || secretWO.Default != nil || secretWO.DefaultFunc != nil {
+				t.Fatalf("secret_wo must not be computed, ForceNew, or defaulted: %#v", secretWO)
+			}
+			if version.Type != schema.TypeInt || !version.Optional || version.Sensitive || version.WriteOnly || version.ForceNew {
+				t.Fatalf("secret_wo_version must be an ordinary optional integer: %#v", version)
+			}
+			if _, errors := version.ValidateFunc(0, "configuration.0.secret_wo_version"); len(errors) == 0 {
+				t.Fatal("secret_wo_version must reject zero")
+			}
+			if len(secret.ConflictsWith) != 1 || secret.ConflictsWith[0] != "configuration.0.secret_wo" {
+				t.Fatalf("legacy secret conflict is not configured correctly: %#v", secret.ConflictsWith)
+			}
+			if err := schema.InternalMap(resource.Schema).InternalValidate(nil); err != nil {
+				t.Fatalf("resource schema failed internal validation: %v", err)
+			}
+		})
+	}
+}
+
+func TestPreferWriteOnlyWebhookSecretValidator(t *testing.T) {
+	t.Parallel()
+
+	rawConfig := cty.ObjectVal(map[string]cty.Value{
+		"configuration": cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{
+			"secret":    cty.StringVal("legacy-secret"),
+			"secret_wo": cty.NullVal(cty.String),
+		})}),
+	})
+	request := schema.ValidateResourceConfigFuncRequest{
+		WriteOnlyAttributesAllowed: true,
+		RawConfig:                  rawConfig,
+	}
+	response := new(schema.ValidateResourceConfigFuncResponse)
+	preferWriteOnlyWebhookSecretValidator()(context.Background(), request, response)
+
+	if len(response.Diagnostics) != 1 || response.Diagnostics[0].Severity != diag.Warning {
+		t.Fatalf("preference diagnostics count = %d, want one warning", len(response.Diagnostics))
+	}
+	wantPath := cty.GetAttrPath("configuration").IndexInt(0).GetAttr("secret")
+	if !response.Diagnostics[0].AttributePath.Equals(wantPath) {
+		t.Fatalf("warning path does not identify configuration[0].secret")
+	}
+}
+
+func TestWebhookWriteOnlySecretConfigurationValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		configuration map[string]any
+		wantError     bool
+	}{
+		"write-only pair": {
+			configuration: map[string]any{"url": "https://example.test", "secret_wo": "canary", "secret_wo_version": 1},
+		},
+		"legacy secret": {
+			configuration: map[string]any{"url": "https://example.test", "secret": "legacy"},
+		},
+		"secret without version": {
+			configuration: map[string]any{"url": "https://example.test", "secret_wo": "canary"},
+			wantError:     true,
+		},
+		"version without secret": {
+			configuration: map[string]any{"url": "https://example.test", "secret_wo_version": 1},
+			wantError:     true,
+		},
+		"legacy conflict": {
+			configuration: map[string]any{"url": "https://example.test", "secret": "legacy", "secret_wo": "canary", "secret_wo_version": 1},
+			wantError:     true,
+		},
+		"zero version": {
+			configuration: map[string]any{"url": "https://example.test", "secret_wo": "canary", "secret_wo_version": 0},
+			wantError:     true,
+		},
+		"negative version": {
+			configuration: map[string]any{"url": "https://example.test", "secret_wo": "canary", "secret_wo_version": -1},
+			wantError:     true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			config := terraform.NewResourceConfigRaw(map[string]any{
+				"repository":    "example",
+				"events":        []any{"push"},
+				"configuration": []any{test.configuration},
+			})
+			diags := schema.InternalMap(resourceGithubRepositoryWebhook().Schema).Validate(config)
+			if diags.HasError() != test.wantError {
+				t.Fatalf("validation error = %t, want %t; diagnostic count: %d", diags.HasError(), test.wantError, len(diags))
+			}
+		})
+	}
+}

--- a/github/util_write_only.go
+++ b/github/util_write_only.go
@@ -1,0 +1,43 @@
+package github
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+var webhookSecretWriteOnlyPath = cty.GetAttrPath("configuration").IndexInt(0).GetAttr("secret_wo")
+
+// rawConfigAtReader is deliberately small so the raw-value handling can be
+// tested without placing write-only values in ResourceData's ordinary model.
+type rawConfigAtReader interface {
+	GetRawConfigAt(cty.Path) (cty.Value, diag.Diagnostics)
+}
+
+func readRawWriteOnlyString(d rawConfigAtReader, path cty.Path) (string, diag.Diagnostics) {
+	value, getDiags := d.GetRawConfigAt(path)
+	if getDiags.HasError() {
+		return "", writeOnlyValueDiagnostic(path, "could not be read from the raw configuration")
+	}
+	if !value.IsKnown() {
+		return "", writeOnlyValueDiagnostic(path, "must be known when the webhook operation is applied")
+	}
+	if value.IsNull() {
+		return "", writeOnlyValueDiagnostic(path, "must not be null when the webhook operation is applied")
+	}
+	if !value.Type().Equals(cty.String) {
+		return "", writeOnlyValueDiagnostic(path, "must be a string")
+	}
+
+	return value.AsString(), nil
+}
+
+func writeOnlyValueDiagnostic(path cty.Path, problem string) diag.Diagnostics {
+	return diag.Diagnostics{{
+		Severity:      diag.Error,
+		Summary:       "Invalid write-only webhook secret",
+		Detail:        fmt.Sprintf("The write-only attribute configuration.0.secret_wo %s.", problem),
+		AttributePath: path,
+	}}
+}

--- a/github/util_write_only_test.go
+++ b/github/util_write_only_test.go
@@ -1,0 +1,105 @@
+package github
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+type rawConfigReaderStub struct {
+	config cty.Value
+	diags  diag.Diagnostics
+}
+
+func (r rawConfigReaderStub) GetRawConfigAt(path cty.Path) (cty.Value, diag.Diagnostics) {
+	if r.diags != nil {
+		return cty.DynamicVal, r.diags
+	}
+	value, err := path.Apply(r.config)
+	if err != nil {
+		return cty.DynamicVal, diag.FromErr(errors.New("invalid raw configuration path"))
+	}
+	return value, nil
+}
+
+func TestReadRawWriteOnlyString(t *testing.T) {
+	t.Parallel()
+
+	const canary = "raw-write-only-canary"
+	configuration := func(secret cty.Value) cty.Value {
+		return cty.ObjectVal(map[string]cty.Value{
+			"configuration": cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{
+				"secret_wo": secret,
+			})}),
+		})
+	}
+
+	tests := map[string]struct {
+		reader    rawConfigReaderStub
+		path      cty.Path
+		want      string
+		wantError bool
+	}{
+		"known nested string": {
+			reader: rawConfigReaderStub{config: configuration(cty.StringVal(canary))},
+			path:   webhookSecretWriteOnlyPath,
+			want:   canary,
+		},
+		"null": {
+			reader:    rawConfigReaderStub{config: configuration(cty.NullVal(cty.String))},
+			path:      webhookSecretWriteOnlyPath,
+			wantError: true,
+		},
+		"unknown": {
+			reader:    rawConfigReaderStub{config: configuration(cty.UnknownVal(cty.String))},
+			path:      webhookSecretWriteOnlyPath,
+			wantError: true,
+		},
+		"wrong type": {
+			reader:    rawConfigReaderStub{config: configuration(cty.NumberIntVal(1))},
+			path:      webhookSecretWriteOnlyPath,
+			wantError: true,
+		},
+		"absent": {
+			reader: rawConfigReaderStub{config: cty.ObjectVal(map[string]cty.Value{
+				"configuration": cty.ListVal([]cty.Value{cty.EmptyObjectVal}),
+			})},
+			path:      webhookSecretWriteOnlyPath,
+			wantError: true,
+		},
+		"malformed path": {
+			reader:    rawConfigReaderStub{config: configuration(cty.StringVal(canary))},
+			path:      cty.GetAttrPath("missing"),
+			wantError: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, diags := readRawWriteOnlyString(test.reader, test.path)
+			if got != test.want {
+				t.Fatalf("value mismatch; got length %d, want length %d", len(got), len(test.want))
+			}
+			if diags.HasError() != test.wantError {
+				t.Fatalf("diagnostic error = %t, want %t", diags.HasError(), test.wantError)
+			}
+			if strings.Contains(diagsString(diags), canary) {
+				t.Fatal("diagnostics contained the write-only value")
+			}
+		})
+	}
+}
+
+func diagsString(diags diag.Diagnostics) string {
+	var result strings.Builder
+	for _, diagnostic := range diags {
+		result.WriteString(diagnostic.Summary)
+		result.WriteString(diagnostic.Detail)
+	}
+	return result.String()
+}

--- a/templates/resources/organization_webhook.md.tmpl
+++ b/templates/resources/organization_webhook.md.tmpl
@@ -18,11 +18,25 @@ The following arguments are supported:
 
 - `events` - (Required) A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/)
 
-- `configuration` - (Required) key/value pair of configuration for this webhook. Available keys are `url`, `content_type`, `secret` and `insecure_ssl`.
+- `configuration` - (Required) Configuration block for this webhook. Available arguments are detailed below.
 
 - `active` - (Optional) Indicate of the webhook should receive events. Defaults to `true`.
 
 - `name` - (Optional) The type of the webhook. `web` is the default and the only option.
+
+### configuration
+
+- `url` - (Required) The URL of the webhook.
+
+- `content_type` - (Optional) The content type for the payload. Valid values are either `form` or `json`.
+
+- `secret` - (Optional) The shared secret for the webhook. Although sensitive, this legacy argument is stored in Terraform plan and state. It conflicts with `secret_wo`.
+
+- `secret_wo` - (Optional, Write-only) The shared secret for the webhook. Requires Terraform 1.11 or later and must be paired with `secret_wo_version`. It accepts ephemeral or ordinary values and is omitted from Terraform plan and state. It conflicts with `secret`.
+
+- `secret_wo_version` - (Optional) Version of `secret_wo`. It must be at least `1` and must be paired with `secret_wo`. Change this value whenever the secret is rotated; changing the secret value alone does not trigger an update.
+
+- `insecure_ssl` - (Optional) Insecure SSL boolean toggle. Defaults to `false`.
 
 ## Attributes Reference
 
@@ -38,4 +52,4 @@ Organization webhooks can be imported using the `id` of the webhook. The `id` of
 terraform import github_organization_webhook.terraform 123456789
 ```
 
-If secret is populated in the webhook's configuration, the value will be imported as "********".
+Webhook secrets cannot be recovered during import, so neither `secret` nor `secret_wo` is populated in imported state. To establish a write-only secret after import, configure `secret_wo` and `secret_wo_version`; Terraform updates the existing webhook in place.

--- a/templates/resources/organization_webhook.md.tmpl
+++ b/templates/resources/organization_webhook.md.tmpl
@@ -30,9 +30,9 @@ The following arguments are supported:
 
 - `content_type` - (Optional) The content type for the payload. Valid values are either `form` or `json`.
 
-- `secret` - (Optional) The shared secret for the webhook. Although sensitive, this legacy argument is stored in Terraform plan and state. It conflicts with `secret_wo`.
+- `secret` - (Optional) The shared secret for the webhook. It conflicts with `secret_wo`.
 
-- `secret_wo` - (Optional, Write-only) The shared secret for the webhook. Requires Terraform 1.11 or later and must be paired with `secret_wo_version`. It accepts ephemeral or ordinary values and is omitted from Terraform plan and state. It conflicts with `secret`.
+- `secret_wo` - (Optional, Write-only) The shared secret for the webhook (write-only variant). Requires Terraform 1.11 or later and must be paired with `secret_wo_version`. It accepts ephemeral or ordinary values and is omitted from Terraform plan and state. It conflicts with `secret`.
 
 - `secret_wo_version` - (Optional) Version of `secret_wo`. It must be at least `1` and must be paired with `secret_wo`. Change this value whenever the secret is rotated; changing the secret value alone does not trigger an update.
 

--- a/templates/resources/repository_webhook.md.tmpl
+++ b/templates/resources/repository_webhook.md.tmpl
@@ -32,7 +32,11 @@ The following arguments are supported:
 
 - `content_type` - (Required) The content type for the payload. Valid values are either `form` or `json`.
 
-- `secret` - (Optional) The shared secret for the webhook. [See API documentation](https://developer.github.com/v3/repos/hooks/#create-a-hook).
+- `secret` - (Optional) The shared secret for the webhook. Although sensitive, this legacy argument is stored in Terraform plan and state. It conflicts with `secret_wo`. [See API documentation](https://developer.github.com/v3/repos/hooks/#create-a-hook).
+
+- `secret_wo` - (Optional, Write-only) The shared secret for the webhook. Requires Terraform 1.11 or later and must be paired with `secret_wo_version`. It accepts ephemeral or ordinary values and is omitted from Terraform plan and state. It conflicts with `secret`.
+
+- `secret_wo_version` - (Optional) Version of `secret_wo`. It must be at least `1` and must be paired with `secret_wo`. Change this value whenever the secret is rotated; changing the secret value alone does not trigger an update.
 
 - `insecure_ssl` - (Optional) Insecure SSL boolean toggle. Defaults to `false`.
 
@@ -52,4 +56,4 @@ Importing uses the name of the repository, as well as the ID of the webhook, e.g
 terraform import github_repository_webhook.terraform terraform/11235813
 ```
 
-If secret is populated in the webhook's configuration, the value will be imported as "********".
+Webhook secrets cannot be recovered during import, so neither `secret` nor `secret_wo` is populated in imported state. To establish a write-only secret after import, configure `secret_wo` and `secret_wo_version`; Terraform updates the existing webhook in place.

--- a/templates/resources/repository_webhook.md.tmpl
+++ b/templates/resources/repository_webhook.md.tmpl
@@ -32,9 +32,9 @@ The following arguments are supported:
 
 - `content_type` - (Required) The content type for the payload. Valid values are either `form` or `json`.
 
-- `secret` - (Optional) The shared secret for the webhook. Although sensitive, this legacy argument is stored in Terraform plan and state. It conflicts with `secret_wo`. [See API documentation](https://developer.github.com/v3/repos/hooks/#create-a-hook).
+- `secret` - (Optional) The shared secret for the webhook. It conflicts with `secret_wo`. [See API documentation](https://developer.github.com/v3/repos/hooks/#create-a-hook).
 
-- `secret_wo` - (Optional, Write-only) The shared secret for the webhook. Requires Terraform 1.11 or later and must be paired with `secret_wo_version`. It accepts ephemeral or ordinary values and is omitted from Terraform plan and state. It conflicts with `secret`.
+- `secret_wo` - (Optional, Write-only) The shared secret for the webhook (write-only variant). Requires Terraform 1.11 or later and must be paired with `secret_wo_version`. It accepts ephemeral or ordinary values and is omitted from Terraform plan and state. It conflicts with `secret`.
 
 - `secret_wo_version` - (Optional) Version of `secret_wo`. It must be at least `1` and must be paired with `secret_wo`. Change this value whenever the secret is rotated; changing the secret value alone does not trigger an update.
 


### PR DESCRIPTION
Resolves #3628

----

### Before the change?

- The `github_repository_webhook` and `github_organization_webhook` resources currenrly only support a `secret` attribute to set the webhook's secret. This secret is persisted in Terraform state which is suboptimal from a security perspective.

### After the change?

- In addition to a `secret` attribute, `github_repository_webhook` and `github_organization_webhook` now support a write-only `secret_wo` attribute (and related `secret_wo_version` attribute for triggering updates) as per conventions used in other Terraform providers. Terraform's [ephemeral resources support](https://developer.hashicorp.com/terraform/language/manage-sensitive-data/ephemeral) can now be used together with the write-only `secret_wo` attribute to ensure webhook secrets are never persisted in Terraform state.

### Pull request checklist

- [x] Schema migrations have been created if needed ([example](https://github.com/F-Secure-web/terraform-provider-github/blob/main/github/migrate_github_actions_organization_secret.go))
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

No. The new `secret_wo` and `secret_wo_version` fields were added and the `secret` field remains in place and available for use by users. The two schemes are marked as conflicting in the schema so Terraform and logic in this PR should prevent users from trying to use both schemes.

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----
